### PR TITLE
[codex] add per-task git worktrees

### DIFF
--- a/apps/backend/lib/config.ml
+++ b/apps/backend/lib/config.ml
@@ -16,6 +16,14 @@ type tracker = {
 
 type polling = { interval_ms : int }
 type workspace = { root : string }
+type git_cleanup = { remove_worktree_after_merge : bool; keep_task_branch : bool }
+type git = {
+  task_branch_prefix : string;
+  protected_trunk_branches : string list;
+  auto_merge : bool;
+  merge_attention_status : string;
+  cleanup : git_cleanup;
+}
 type agent = { max_concurrent_agents : int; max_turns : int; max_retry_backoff_ms : int }
 type codex = {
   command : string;
@@ -26,7 +34,7 @@ type codex = {
   stall_timeout_ms : int;
 }
 type server = { port : int option }
-type stage_commit = { enabled : bool; commit_type : string; message : string }
+type stage_commit = { enabled : bool; commit_type : string; message : string; push : bool }
 type stage_agent = {
   states : string list;
   agent : string;
@@ -44,6 +52,7 @@ type t = {
   tracker : tracker;
   polling : polling;
   workspace : workspace;
+  git : git;
   agent : agent;
   codex : codex;
   server : server;
@@ -59,10 +68,20 @@ let default_terminal_states = [ "Done"; "Closed"; "Cancelled"; "Canceled"; "Dupl
 let default_dispatch_status = "In progress"
 let default_review_status = "In review"
 let default_retry_status = "To-Do"
+let default_merge_attention_status = "Human attention"
 let default_commit_message = "<type>: <generated_message_max_90char>"
 let default_model = "gpt-5.5"
 let default_reasoning_effort = "medium"
 let default_codex_command = "codex exec"
+
+let default_git =
+  {
+    task_branch_prefix = "symphony/task-";
+    protected_trunk_branches = [ "main"; "master" ];
+    auto_merge = true;
+    merge_attention_status = default_merge_attention_status;
+    cleanup = { remove_worktree_after_merge = true; keep_task_branch = true };
+  }
 
 let normalize_codex_command command =
   if Util.trim command = "codex app-server" then default_codex_command else command
@@ -75,7 +94,7 @@ let default_stage_agents =
       start_status = None;
       success_status = Some "To-Do";
       retry_status = Some "Backlog";
-      commit = Some { enabled = false; commit_type = "feature"; message = default_commit_message };
+      commit = Some { enabled = false; commit_type = "feature"; message = default_commit_message; push = false };
     };
     {
       states = [ "Todo"; "To-Do"; "In progress"; "In Progress" ];
@@ -83,7 +102,7 @@ let default_stage_agents =
       start_status = Some "In progress";
       success_status = Some "In review";
       retry_status = Some "To-Do";
-      commit = Some { enabled = true; commit_type = "feature"; message = default_commit_message };
+      commit = Some { enabled = true; commit_type = "feature"; message = default_commit_message; push = false };
     };
     {
       states = [ "In review"; "In Review" ];
@@ -91,7 +110,7 @@ let default_stage_agents =
       start_status = None;
       success_status = Some "Done";
       retry_status = Some "In progress";
-      commit = Some { enabled = false; commit_type = "refactor"; message = default_commit_message };
+      commit = Some { enabled = false; commit_type = "refactor"; message = default_commit_message; push = false };
     };
   ]
 
@@ -188,6 +207,7 @@ let from_workflow workflow =
       };
     polling = { interval_ms = positive "polling.interval_ms" (Option.value (Simple_yaml.get_int "interval_ms" polling_raw) ~default:30000) };
     workspace = { root = workspace_root };
+    git = default_git;
     agent =
       {
         max_concurrent_agents =
@@ -247,6 +267,7 @@ let json_stage_agent json =
             enabled = json_bool "enabled" commit_raw ~default:false;
             commit_type = json_string "type" commit_raw ~default:"feature";
             message = json_string "message" commit_raw ~default:default_commit_message;
+            push = json_bool "push" commit_raw ~default:false;
           }
     | _ -> None
   in
@@ -268,6 +289,7 @@ let from_settings_file ~workspace_root path =
   let project_raw = member "project" root in
   let polling_raw = member "polling" root in
   let workspace_raw = member "workspace" root in
+  let git_raw = member "git" root in
   let agent_raw = member "agent" root in
   let codex_raw = member "codex" root in
   let server_raw = member "server" root in
@@ -302,6 +324,23 @@ let from_settings_file ~workspace_root path =
       };
     polling = { interval_ms = positive "polling.intervalMs" (json_int "intervalMs" polling_raw ~default:30000) };
     workspace = { root = workspace_root_value };
+    git =
+      {
+        task_branch_prefix = json_string "taskBranchPrefix" git_raw ~default:default_git.task_branch_prefix;
+        protected_trunk_branches =
+          json_string_list "protectedTrunkBranches" git_raw ~default:default_git.protected_trunk_branches;
+        auto_merge = json_bool "autoMerge" git_raw ~default:default_git.auto_merge;
+        merge_attention_status =
+          json_string "mergeAttentionStatus" git_raw ~default:default_git.merge_attention_status;
+        cleanup =
+          {
+            remove_worktree_after_merge =
+              json_bool "removeWorktreeAfterMerge" (member "cleanup" git_raw)
+                ~default:default_git.cleanup.remove_worktree_after_merge;
+            keep_task_branch =
+              json_bool "keepTaskBranch" (member "cleanup" git_raw) ~default:default_git.cleanup.keep_task_branch;
+          };
+      };
     agent =
       {
         max_concurrent_agents =

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -232,6 +232,13 @@ let git_ref_exists root refname =
   | Ok _ -> true
   | Error _ -> false
 
+let worktree_branch path =
+  if Sys.file_exists path && Sys.is_directory path then
+    match (run_shell_capture ~cwd:path "git rev-parse --show-toplevel", run_shell_capture ~cwd:path "git branch --show-current") with
+    | Ok top_level, Ok branch when Unix.realpath top_level = Unix.realpath path && Util.trim branch <> "" -> Some (Util.trim branch)
+    | _ -> None
+  else None
+
 let issue_branch_key issue =
   let digits =
     issue.Issue.identifier |> String.to_seq
@@ -255,9 +262,11 @@ let shell_prepare_workspace config ~loop_start_branch issue =
   else
     let workspace_key = Workspace.sanitize issue.Issue.identifier in
     let workspace_path = Filename.concat config.Config.workspace.root workspace_key in
-    if Sys.file_exists workspace_path then
-      Ok (Workspace.create_for_issue ~root:config.Config.workspace.root issue.Issue.identifier)
-    else
+    match worktree_branch workspace_path with
+    | Some existing when existing = branch -> Ok (Workspace.create_for_issue ~root:config.Config.workspace.root issue.Issue.identifier)
+    | Some existing -> Error (Printf.sprintf "agent worktree uses %s but expected %s" existing branch)
+    | None when Sys.file_exists workspace_path -> Error (workspace_path ^ " exists but is not an Agent Worktree")
+    | None ->
       match require_clean_loop_start config.repository_root with
       | Error _ as error -> error
       | Ok () ->

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -11,7 +11,7 @@ type launch =
 
 type fetch = Github_tracker.t -> Issue.t list
 type set_status = Github_tracker.t -> Issue.t -> string -> (unit, string) result
-type commit_stage = Config.t -> Issue.t -> Config.stage_agent option -> string option -> (unit, string) result
+type commit_stage = Config.t -> Workspace.t -> Issue.t -> Config.stage_agent option -> string option -> (unit, string) result
 type notify_state = Runtime_state.t -> unit
 
 type t = {
@@ -28,6 +28,7 @@ type t = {
   set_status : set_status;
   commit_stage : commit_stage;
   notify_state : notify_state;
+  loop_start_branch : string;
 }
 
 and child = {
@@ -36,6 +37,7 @@ and child = {
   issue_id : string;
   issue_identifier : string;
   issue_title : string;
+  workspace : Workspace.t;
   mutable started_at : float;
   mutable last_output_at : float;
   stdout_path : string option;
@@ -214,12 +216,84 @@ let run_shell_capture ~cwd command =
   | Unix.WSIGNALED signal -> Error (Printf.sprintf "signal %d: %s" signal output)
   | Unix.WSTOPPED signal -> Error (Printf.sprintf "stopped %d: %s" signal output)
 
+let current_branch root =
+  match run_shell_capture ~cwd:root "git branch --show-current" with
+  | Ok branch when Util.trim branch <> "" -> Util.trim branch
+  | _ -> (
+      match run_shell_capture ~cwd:root "git rev-parse --short HEAD" with Ok sha -> sha | Error _ -> "HEAD")
+
+let is_git_repository root =
+  match run_shell_capture ~cwd:root "git rev-parse --is-inside-work-tree" with
+  | Ok "true" -> true
+  | _ -> false
+
+let git_ref_exists root refname =
+  match run_shell_capture ~cwd:root (Printf.sprintf "git show-ref --verify --quiet refs/heads/%s" (Util.shell_quote refname)) with
+  | Ok _ -> true
+  | Error _ -> false
+
+let issue_branch_key issue =
+  let digits =
+    issue.Issue.identifier |> String.to_seq
+    |> Seq.filter (function '0' .. '9' -> true | _ -> false)
+    |> String.of_seq
+  in
+  if digits <> "" then digits else Workspace.sanitize issue.id
+
+let task_branch config issue = config.Config.git.task_branch_prefix ^ issue_branch_key issue
+
+let require_clean_loop_start root =
+  match run_shell_capture ~cwd:root "git status --porcelain" with
+  | Ok "" -> Ok ()
+  | Ok _ -> Error "loop-start worktree must be clean before creating task worktrees"
+  | Error error -> Error ("git status failed: " ^ error)
+
+let shell_prepare_workspace config ~loop_start_branch issue =
+  let branch = task_branch config issue in
+  if not (is_git_repository config.repository_root) then
+    Ok (Workspace.create_for_issue ~root:config.Config.workspace.root issue.Issue.identifier)
+  else
+    let workspace_key = Workspace.sanitize issue.Issue.identifier in
+    let workspace_path = Filename.concat config.Config.workspace.root workspace_key in
+    if Sys.file_exists workspace_path then
+      Ok (Workspace.create_for_issue ~root:config.Config.workspace.root issue.Issue.identifier)
+    else
+      match require_clean_loop_start config.repository_root with
+      | Error _ as error -> error
+      | Ok () ->
+          let workspace = Workspace.create_for_issue ~root:config.Config.workspace.root issue.Issue.identifier in
+          let create_branch =
+            if git_ref_exists config.repository_root branch then Ok ()
+            else
+              match
+                run_shell_capture ~cwd:config.repository_root
+                  (Printf.sprintf "git branch %s %s" (Util.shell_quote branch) (Util.shell_quote loop_start_branch))
+              with
+              | Ok _ -> Ok ()
+              | Error _ as error -> error
+          in
+          (match create_branch with
+          | Error error -> Error ("task branch creation failed: " ^ error)
+          | Ok _ -> (
+              match
+                run_shell_capture ~cwd:config.repository_root
+                  (Printf.sprintf "git worktree add %s %s" (Util.shell_quote workspace.path) (Util.shell_quote branch))
+              with
+              | Ok _ -> Ok workspace
+              | Error error -> Error ("agent worktree creation failed: " ^ error)))
+
 let has_worktree_changes root =
   match run_shell_capture ~cwd:root "git status --porcelain" with
   | Ok output -> Ok (output <> "")
   | Error error -> Error ("git status failed: " ^ error)
 
-let git_commit_stage_changes config issue stage next_status =
+let push_current_branch root =
+  match run_shell_capture ~cwd:root "git rev-parse --abbrev-ref --symbolic-full-name @{u}" with
+  | Ok _ -> run_shell_capture ~cwd:root "git push"
+  | Error _ ->
+      run_shell_capture ~cwd:root "git push -u origin HEAD"
+
+let git_commit_stage_changes _config workspace issue stage next_status =
   match stage with
   | None -> Ok ()
   | Some stage -> (
@@ -227,7 +301,7 @@ let git_commit_stage_changes config issue stage next_status =
       | None -> Ok ()
       | Some policy when not policy.enabled -> Ok ()
       | Some policy ->
-          let root = config.Config.repository_root in
+          let root = workspace.Workspace.path in
           match has_worktree_changes root with
           | Error error -> Error error
           | Ok false ->
@@ -247,7 +321,11 @@ let git_commit_stage_changes config issue stage next_status =
                       match run_shell_capture ~cwd:root command with
                       | Ok _ ->
                           render_commit_completed issue.Issue.identifier message;
-                          Ok ()
+                          if policy.Config.push then
+                            match push_current_branch root with
+                            | Ok _ -> Ok ()
+                            | Error error -> Error ("stage push failed: " ^ error)
+                          else Ok ()
                       | Error error -> Error error))
 
 let replace_first_word command replacement =
@@ -281,7 +359,7 @@ let shell_launch ~config ~workspace ~prompt ~issue =
   let stdout_path = Filename.concat workspace.Workspace.path "stdout.log" in
   let stderr_path = Filename.concat workspace.Workspace.path "stderr.log" in
   let command =
-    Printf.sprintf "cd %s && %s < %s > %s 2> %s" (Util.shell_quote config.Config.repository_root) (codex_command config)
+    Printf.sprintf "cd %s && %s < %s > %s 2> %s" (Util.shell_quote workspace.Workspace.path) (codex_command config)
       (Util.shell_quote prompt_path) (Util.shell_quote stdout_path) (Util.shell_quote stderr_path)
   in
   let pid = Unix.create_process "/bin/sh" [| "/bin/sh"; "-lc"; command |] Unix.stdin Unix.stdout Unix.stderr in
@@ -311,6 +389,7 @@ let make ?(launch = shell_launch) ?(fetch = Github_tracker.fetch_candidate_issue
     set_status;
     commit_stage;
     notify_state;
+    loop_start_branch = current_branch config.repository_root;
   }
 
 let get_state orchestrator = orchestrator.state
@@ -415,62 +494,68 @@ let issue_is_active orchestrator issue =
 
 let dispatch_issue orchestrator issue =
   let target_start_status = start_status orchestrator issue in
-  let can_dispatch =
-    match target_start_status with
-    | None -> true
-    | Some status -> move_issue_status orchestrator issue status
-  in
-  if can_dispatch then (
-    let issue = match target_start_status with Some state -> { issue with Issue.state } | None -> issue in
-    let workspace = Workspace.create_for_issue ~root:orchestrator.config.workspace.root issue.Issue.identifier in
-    let attempt = Hashtbl.find_opt orchestrator.attempts issue.id in
-    let rendered = Prompt.render ~issue ~attempt orchestrator.prompt_template in
-    let prompt = compose_prompt orchestrator.config issue rendered in
-    let launched = orchestrator.launch ~config:orchestrator.config ~workspace ~prompt ~issue in
-    let now = Util.now_iso8601 () in
-    let row =
-      {
-        Runtime_state.issue;
-        session_id = launched.session_id;
-        turn_count = 0;
-        last_event = Some launched.event;
-        last_message = None;
-        started_at = now;
-        last_event_at = Some now;
-        tokens = runtime_tokens;
-      }
-    in
-    Hashtbl.remove orchestrator.retry_due issue.id;
-    update_state orchestrator (fun state ->
-      {
-        state with
-        issues = List.map (fun candidate -> if candidate.Issue.id = issue.id then issue else candidate) state.issues;
-        running = row :: state.running;
-        retrying = List.filter (fun (retry : Runtime_state.retrying) -> retry.issue_id <> issue.id) state.retrying;
-        issue_errors =
-          List.filter (fun (issue_error : Runtime_state.issue_error) -> issue_error.issue_id <> issue.id) state.issue_errors;
-        last_error = None;
-      });
-    (match launched.pid with
-    | Some pid ->
-        let now_float = Unix.time () in
-        orchestrator.children <-
+  match shell_prepare_workspace orchestrator.config ~loop_start_branch:orchestrator.loop_start_branch issue with
+  | Error error ->
+      set_error orchestrator error;
+      render_dispatch_retrying issue.identifier 0 error;
+      ignore (move_issue_status orchestrator issue orchestrator.config.git.merge_attention_status)
+  | Ok workspace ->
+      let can_dispatch =
+        match target_start_status with
+        | None -> true
+        | Some status -> move_issue_status orchestrator issue status
+      in
+      if can_dispatch then (
+        let issue = match target_start_status with Some state -> { issue with Issue.state } | None -> issue in
+        let attempt = Hashtbl.find_opt orchestrator.attempts issue.id in
+        let rendered = Prompt.render ~issue ~attempt orchestrator.prompt_template in
+        let prompt = compose_prompt orchestrator.config issue rendered in
+        let launched = orchestrator.launch ~config:orchestrator.config ~workspace ~prompt ~issue in
+        let now = Util.now_iso8601 () in
+        let row =
           {
-            pid;
-            issue;
-            issue_id = issue.id;
-            issue_identifier = issue.identifier;
-            issue_title = issue.title;
-            started_at = now_float;
-            last_output_at = now_float;
-            stdout_path = launched.stdout_path;
-            stderr_path = launched.stderr_path;
-            stdout_size = file_size launched.stdout_path;
-            stderr_size = file_size launched.stderr_path;
+            Runtime_state.issue;
+            session_id = launched.session_id;
+            turn_count = 0;
+            last_event = Some launched.event;
+            last_message = None;
+            started_at = now;
+            last_event_at = Some now;
+            tokens = runtime_tokens;
           }
-          :: orchestrator.children
-    | None -> ());
-    render_dispatch_started issue)
+        in
+        Hashtbl.remove orchestrator.retry_due issue.id;
+        update_state orchestrator (fun state ->
+          {
+            state with
+            issues = List.map (fun candidate -> if candidate.Issue.id = issue.id then issue else candidate) state.issues;
+            running = row :: state.running;
+            retrying = List.filter (fun (retry : Runtime_state.retrying) -> retry.issue_id <> issue.id) state.retrying;
+            issue_errors =
+              List.filter (fun (issue_error : Runtime_state.issue_error) -> issue_error.issue_id <> issue.id) state.issue_errors;
+            last_error = None;
+          });
+        (match launched.pid with
+        | Some pid ->
+            let now_float = Unix.time () in
+            orchestrator.children <-
+              {
+                pid;
+                issue;
+                issue_id = issue.id;
+                issue_identifier = issue.identifier;
+                issue_title = issue.title;
+                workspace;
+                started_at = now_float;
+                last_output_at = now_float;
+                stdout_path = launched.stdout_path;
+                stderr_path = launched.stderr_path;
+                stdout_size = file_size launched.stdout_path;
+                stderr_size = file_size launched.stderr_path;
+              }
+              :: orchestrator.children
+        | None -> ());
+        render_dispatch_started issue)
 
 let mark_retrying orchestrator issue_id error =
   match List.find_opt (fun (row : Runtime_state.running) -> row.issue.id = issue_id) orchestrator.state.running with
@@ -555,23 +640,72 @@ let complete_child orchestrator child =
     });
   render_dispatch_completed child.issue_identifier child.issue_title
 
+let protected_loop_start orchestrator =
+  List.exists
+    (fun branch -> String.lowercase_ascii branch = String.lowercase_ascii orchestrator.loop_start_branch)
+    orchestrator.config.git.protected_trunk_branches
+
+let cleanup_task_worktree orchestrator child =
+  if orchestrator.config.git.cleanup.remove_worktree_after_merge then
+    ignore
+      (run_shell_capture ~cwd:orchestrator.config.repository_root
+         (Printf.sprintf "git worktree remove %s" (Util.shell_quote child.workspace.path)));
+  if not orchestrator.config.git.cleanup.keep_task_branch then
+    ignore
+      (run_shell_capture ~cwd:orchestrator.config.repository_root
+         (Printf.sprintf "git branch -d %s" (Util.shell_quote (task_branch orchestrator.config child.issue))))
+
+let auto_merge_child orchestrator child =
+  if (not (is_git_repository orchestrator.config.repository_root)) || (not orchestrator.config.git.auto_merge) || protected_loop_start orchestrator then Ok ()
+  else
+    let branch = task_branch orchestrator.config child.issue in
+    match
+      run_shell_capture ~cwd:orchestrator.config.repository_root
+        (Printf.sprintf "git merge --ff-only %s" (Util.shell_quote branch))
+    with
+    | Ok _ ->
+        cleanup_task_worktree orchestrator child;
+        Ok ()
+    | Error error -> Error ("auto-merge failed: " ^ error)
+
+let mark_merge_attention orchestrator child error =
+  set_error orchestrator error;
+  ignore (move_issue_status orchestrator child.issue orchestrator.config.git.merge_attention_status);
+  update_state orchestrator (fun state ->
+    {
+      state with
+      running = List.filter (fun (row : Runtime_state.running) -> row.issue.id <> child.issue_id) state.running;
+      retrying = List.filter (fun (retry : Runtime_state.retrying) -> retry.issue_id <> child.issue_id) state.retrying;
+      issue_errors =
+        {
+          Runtime_state.issue_id = child.issue_id;
+          issue_identifier = child.issue_identifier;
+          error;
+        }
+        :: List.filter (fun (issue_error : Runtime_state.issue_error) -> issue_error.issue_id <> child.issue_id) state.issue_errors;
+      last_error = Some error;
+    })
+
 let mark_completed orchestrator child =
   let issue_id = child.issue_id in
   let stage = stage_for_issue orchestrator.config child.issue in
   let next_status = success_status orchestrator child.issue in
-  match orchestrator.commit_stage orchestrator.config child.issue stage next_status with
+  match orchestrator.commit_stage orchestrator.config child.workspace child.issue stage next_status with
   | Error error ->
       set_error orchestrator error;
       render_commit_failed child.issue_identifier error;
       if non_retryable_completion_error error then mark_blocked orchestrator issue_id error
       else mark_retrying orchestrator issue_id error
   | Ok () ->
-      (match next_status with
-      | None -> complete_child orchestrator child
-      | Some status ->
-          if not (move_issue_status orchestrator child.issue status) then
-            mark_retrying orchestrator issue_id (Printf.sprintf "could not move issue to %s" status)
-          else complete_child orchestrator child)
+      (match auto_merge_child orchestrator child with
+      | Error error -> mark_merge_attention orchestrator child error
+      | Ok () -> (
+          match next_status with
+          | None -> complete_child orchestrator child
+          | Some status ->
+              if not (move_issue_status orchestrator child.issue status) then
+                mark_retrying orchestrator issue_id (Printf.sprintf "could not move issue to %s" status)
+              else complete_child orchestrator child))
 
 let kill_child child =
   try Unix.kill child.pid Sys.sigterm with Unix.Unix_error _ -> ()

--- a/apps/backend/lib/runtime_home.ml
+++ b/apps/backend/lib/runtime_home.ml
@@ -39,6 +39,16 @@ let settings_json =
   "workspace": {
     "root": ".symphony/workspaces"
   },
+  "git": {
+    "taskBranchPrefix": "symphony/task-",
+    "protectedTrunkBranches": ["main", "master"],
+    "autoMerge": true,
+    "mergeAttentionStatus": "Human attention",
+    "cleanup": {
+      "removeWorktreeAfterMerge": true,
+      "keepTaskBranch": true
+    }
+  },
   "stageAgents": {
     "enabled": true,
     "root": ".symphony/agents",
@@ -52,7 +62,8 @@ let settings_json =
         "commit": {
           "enabled": false,
           "type": "feature",
-          "message": "<type>: <generated_message_max_90char>"
+          "message": "<type>: <generated_message_max_90char>",
+          "push": false
         }
       },
       {
@@ -64,7 +75,8 @@ let settings_json =
         "commit": {
           "enabled": true,
           "type": "feature",
-          "message": "<type>: <generated_message_max_90char>"
+          "message": "<type>: <generated_message_max_90char>",
+          "push": false
         }
       },
       {
@@ -75,7 +87,8 @@ let settings_json =
         "commit": {
           "enabled": false,
           "type": "refactor",
-          "message": "<type>: <generated_message_max_90char>"
+          "message": "<type>: <generated_message_max_90char>",
+          "push": false
         }
       }
     ]

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -16,6 +16,66 @@ let with_temp_dir prefix f =
       Unix.mkdir root 0o755;
       f root)
 
+let run_ok ?(cwd = ".") label command =
+  match Orchestrator.run_shell_capture ~cwd command with
+  | Ok output -> output
+  | Error error -> Alcotest.fail (label ^ ": " ^ error)
+
+let init_repo root branch =
+  ignore (run_ok ~cwd:root "git init" (Printf.sprintf "git init -q -b %s" (Util.shell_quote branch)));
+  ignore (run_ok ~cwd:root "git user email" "git config user.email test@example.com");
+  ignore (run_ok ~cwd:root "git user name" "git config user.name Test");
+  Util.write_file (Filename.concat root "README.md") "initial\n";
+  ignore (run_ok ~cwd:root "initial commit" "git add README.md && git commit -q -m initial")
+
+let git_policy ?(auto_merge = false) ?(protected_trunk_branches = [ "main"; "master" ])
+    ?(merge_attention_status = "Human attention") ?(remove_worktree_after_merge = true) () =
+  {
+    Config.default_git with
+    auto_merge;
+    protected_trunk_branches;
+    merge_attention_status;
+    cleanup = { Config.remove_worktree_after_merge = remove_worktree_after_merge; keep_task_branch = true };
+  }
+
+let test_config_parses_git_policy_and_stage_push () =
+  with_temp_dir "symphony-settings-git-" (fun root ->
+      let settings = Filename.concat root "settings.json" in
+      Util.mkdir_p (Filename.concat root ".symphony/agents");
+      Util.write_file settings
+        {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "git": {
+    "taskBranchPrefix": "agent/",
+    "protectedTrunkBranches": ["main", "release"],
+    "autoMerge": false,
+    "mergeAttentionStatus": "Needs merge",
+    "cleanup": {"removeWorktreeAfterMerge": false, "keepTaskBranch": true}
+  },
+  "stageAgents": {
+    "enabled": true,
+    "root": ".symphony/agents",
+    "stages": [
+      {
+        "states": ["In progress"],
+        "agent": "engineer",
+        "commit": {"enabled": true, "type": "feat", "message": "<type>: work", "push": true}
+      }
+    ]
+  }
+}|};
+      Util.write_file (Filename.concat root ".symphony/agents/engineer.md") "Engineer";
+      Unix.putenv "GITHUB_TOKEN" "token";
+      let config = Config.from_settings_file ~workspace_root:root settings in
+      Alcotest.(check string) "branch prefix" "agent/" config.git.task_branch_prefix;
+      Alcotest.(check (list string)) "protected trunks" [ "main"; "release" ] config.git.protected_trunk_branches;
+      Alcotest.(check bool) "auto merge" false config.git.auto_merge;
+      Alcotest.(check string) "attention status" "Needs merge" config.git.merge_attention_status;
+      Alcotest.(check bool) "cleanup worktree" false config.git.cleanup.remove_worktree_after_merge;
+      match config.stage_agents.stages with
+      | [ { Config.commit = Some commit; _ } ] -> Alcotest.(check bool) "stage push" true commit.push
+      | _ -> Alcotest.fail "expected stage commit policy")
+
 let test_workflow_and_config () =
   let content =
     {|
@@ -65,7 +125,7 @@ let test_workspace_safety () =
       let reused = Workspace.create_for_issue ~root "ABC/42 needs work" in
       Alcotest.(check bool) "reused" false reused.created_now)
 
-let test_shell_launch_runs_agent_in_repository_root () =
+let test_shell_launch_runs_agent_in_agent_worktree () =
   with_temp_dir "symphony-launch-root-" (fun root ->
       let workspace_root = Filename.concat root "workspaces" in
       let config =
@@ -90,6 +150,7 @@ let test_shell_launch_runs_agent_in_repository_root () =
             };
           polling = { interval_ms = 1000 };
           workspace = { root = workspace_root };
+          git = Config.default_git;
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex =
             {
@@ -110,9 +171,10 @@ let test_shell_launch_runs_agent_in_repository_root () =
       (match launched.pid with
       | Some pid -> ignore (Unix.waitpid [] pid)
       | None -> Alcotest.fail "expected shell launch pid");
-      Alcotest.(check string) "agent cwd" (Unix.realpath root) (Util.read_file (Filename.concat root "launched.cwd") |> Util.trim);
-      Alcotest.(check string) "prompt piped" "Issue #1" (Util.read_file (Filename.concat root "launched.prompt") |> Util.trim);
-      Alcotest.(check bool) "workspace is only logs" false (Sys.file_exists (Filename.concat workspace.path "launched.cwd")))
+      Alcotest.(check string) "agent cwd" (Unix.realpath workspace.path)
+        (Util.read_file (Filename.concat workspace.path "launched.cwd") |> Util.trim);
+      Alcotest.(check string) "prompt piped" "Issue #1" (Util.read_file (Filename.concat workspace.path "launched.prompt") |> Util.trim);
+      Alcotest.(check bool) "loop-start unchanged" false (Sys.file_exists (Filename.concat root "launched.cwd")))
 
 let test_invalid_tracker_kind () =
   let content =
@@ -175,6 +237,7 @@ let test_project_status_order_uses_transition_flow () =
       tracker;
       polling = { interval_ms = 1000 };
       workspace = { root = "/tmp/widgets/.symphony/workspaces" };
+      git = Config.default_git;
       agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
       codex =
         {
@@ -541,6 +604,7 @@ let test_orchestrator_notifies_each_state_mutation () =
             };
           polling = { interval_ms = 1000 };
           workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "cat"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 1000; stall_timeout_ms = 1000 };
           server = { port = None };
@@ -780,6 +844,7 @@ let test_orchestrator_dispatch_limits () =
             };
           polling = { interval_ms = 1000 };
           workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
           agent = { max_concurrent_agents = 2; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "cat"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 1000; stall_timeout_ms = 1000 };
           server = { port = None };
@@ -833,6 +898,7 @@ let test_orchestrator_does_not_dispatch_terminal_issues () =
             };
           polling = { interval_ms = 1000 };
           workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
           agent = { max_concurrent_agents = 2; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "cat"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 1000; stall_timeout_ms = 1000 };
           server = { port = None };
@@ -882,6 +948,7 @@ let test_orchestrator_retries_failed_agent () =
             };
           polling = { interval_ms = 1000 };
           workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "false"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
@@ -928,6 +995,7 @@ let test_orchestrator_moves_status_to_review_on_success () =
             };
           polling = { interval_ms = 1000 };
           workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
@@ -984,6 +1052,7 @@ let test_orchestrator_uses_stage_agent_prompt_and_status () =
             };
           polling = { interval_ms = 1000 };
           workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
@@ -1034,6 +1103,7 @@ let test_orchestrator_uses_stage_agent_prompt_and_status () =
           issue_id = issue.id;
           issue_identifier = issue.identifier;
           issue_title = issue.title;
+          workspace = { Workspace.path = root; workspace_key = "test"; created_now = false };
           started_at = Unix.time ();
           last_output_at = Unix.time ();
           stdout_path = None;
@@ -1067,6 +1137,7 @@ let test_orchestrator_commits_stage_before_success_status () =
             };
           polling = { interval_ms = 1000 };
           workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
@@ -1083,7 +1154,7 @@ let test_orchestrator_commits_stage_before_success_status () =
                     start_status = None;
                     success_status = Some "In review";
                     retry_status = Some "Todo";
-                    commit = Some { enabled = true; commit_type = "fixture"; message = "<type>: <generated_message_max_90char>" };
+                    commit = Some { enabled = true; commit_type = "fixture"; message = "<type>: <generated_message_max_90char>"; push = false };
                   };
                 ];
             };
@@ -1095,7 +1166,7 @@ let test_orchestrator_commits_stage_before_success_status () =
         events := ("status:" ^ status) :: !events;
         Ok ()
       in
-      let commit_stage _ issue stage next_status =
+      let commit_stage _ _workspace issue stage next_status =
         let message =
           match stage with
           | Some { Config.commit = Some policy; _ } -> Orchestrator.render_commit_message issue stage next_status policy
@@ -1112,6 +1183,7 @@ let test_orchestrator_commits_stage_before_success_status () =
           issue_id = issue.id;
           issue_identifier = issue.identifier;
           issue_title = issue.title;
+          workspace = { Workspace.path = root; workspace_key = "test"; created_now = false };
           started_at = Unix.time ();
           last_output_at = Unix.time ();
           stdout_path = None;
@@ -1145,6 +1217,7 @@ let test_orchestrator_retries_when_success_status_move_fails () =
             };
           polling = { interval_ms = 1000 };
           workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
@@ -1166,6 +1239,7 @@ let test_orchestrator_retries_when_success_status_move_fails () =
           issue_id = issue.id;
           issue_identifier = issue.identifier;
           issue_title = issue.title;
+          workspace = { Workspace.path = root; workspace_key = "test"; created_now = false };
           started_at = Unix.time ();
           last_output_at = Unix.time ();
           stdout_path = None;
@@ -1207,6 +1281,7 @@ let test_stage_commit_requires_code_changes () =
             };
           polling = { interval_ms = 1000 };
           workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
@@ -1222,10 +1297,11 @@ let test_stage_commit_requires_code_changes () =
             start_status = None;
             success_status = Some "In review";
             retry_status = Some "Todo";
-            commit = Some { enabled = true; commit_type = "feature"; message = Config.default_commit_message };
+            commit = Some { enabled = true; commit_type = "feature"; message = Config.default_commit_message; push = false };
           }
       in
-      match Orchestrator.git_commit_stage_changes config issue stage (Some "In review") with
+      let workspace = { Workspace.path = root; workspace_key = "test"; created_now = false } in
+      match Orchestrator.git_commit_stage_changes config workspace issue stage (Some "In review") with
       | Ok () -> Alcotest.fail "empty commit-required stages must fail"
       | Error error -> Alcotest.(check string) "empty commit error" "commit required but agent produced no code changes" error)
 
@@ -1253,6 +1329,7 @@ let test_orchestrator_does_not_retry_empty_commit () =
             };
           polling = { interval_ms = 1000 };
           workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
@@ -1269,7 +1346,7 @@ let test_orchestrator_does_not_retry_empty_commit () =
                     start_status = None;
                     success_status = Some "In review";
                     retry_status = Some "Todo";
-                    commit = Some { enabled = true; commit_type = "feature"; message = Config.default_commit_message };
+                    commit = Some { enabled = true; commit_type = "feature"; message = Config.default_commit_message; push = false };
                   };
                 ];
             };
@@ -1287,7 +1364,7 @@ let test_orchestrator_does_not_retry_empty_commit () =
         statuses := status :: !statuses;
         Ok ()
       in
-      let commit_stage _ _ _ _ = Error "commit required but agent produced no code changes" in
+      let commit_stage _ _ _ _ _ = Error "commit required but agent produced no code changes" in
       let orchestrator = Orchestrator.make ~launch ~fetch ~set_status ~commit_stage ~config ~prompt_template:"Issue {{ issue.identifier }}" () in
       Orchestrator.poll_once orchestrator;
       Alcotest.(check int) "first launch" 1 !launches;
@@ -1298,6 +1375,7 @@ let test_orchestrator_does_not_retry_empty_commit () =
           issue_id = issue.id;
           issue_identifier = issue.identifier;
           issue_title = issue.title;
+          workspace = { Workspace.path = root; workspace_key = "test"; created_now = false };
           started_at = Unix.time ();
           last_output_at = Unix.time ();
           stdout_path = None;
@@ -1313,13 +1391,324 @@ let test_orchestrator_does_not_retry_empty_commit () =
       Alcotest.(check int) "issue error recorded" 1 (List.length state.issue_errors);
       Alcotest.(check (option string)) "last error" (Some "commit required but agent produced no code changes") state.last_error)
 
+let base_orchestrator_config root git =
+  {
+    Config.workflow_path = "settings.json";
+    repository_root = root;
+    tracker =
+      {
+        kind = "github";
+        owner = "acme";
+        repo = "widgets";
+        project_number = 7;
+        api_key_env = "GITHUB_TOKEN";
+        api_key = Some "token";
+        active_states = [ "Todo"; "In progress" ];
+        terminal_states = [ "Done" ];
+        project_status_field = "Status";
+        project_status_on_dispatch = Some "In progress";
+        project_status_on_success = Some "In review";
+        project_status_on_retry = Some "Todo";
+        ensure_project_statuses = true;
+      };
+    polling = { interval_ms = 1000 };
+    workspace = { root = Filename.concat root ".symphony/workspaces" };
+    git;
+    agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
+    codex =
+      {
+        command = "true";
+        model = Config.default_model;
+        reasoning_effort = Config.default_reasoning_effort;
+        turn_timeout_ms = 1000;
+        read_timeout_ms = 100;
+        stall_timeout_ms = 1000;
+      };
+    server = { port = None };
+    stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
+  }
+
+let test_orchestrator_creates_task_worktree_and_branch () =
+  with_temp_dir "symphony-task-worktree-" (fun root ->
+      init_repo root "feature/start";
+      let config = base_orchestrator_config root (git_policy ()) in
+      let issue = Issue.empty ~id:"I1" ~identifier:"#3" ~title:"Three" ~state:"Todo" in
+      let captured_workspace = ref None in
+      let launch ~config:_ ~(workspace : Workspace.t) ~prompt:_ ~issue =
+        captured_workspace := Some workspace;
+        { Orchestrator.pid = None; session_id = Some issue.Issue.id; event = "test-launch"; stdout_path = None; stderr_path = None }
+      in
+      let statuses = ref [] in
+      let set_status _ _ status =
+        statuses := status :: !statuses;
+        Ok ()
+      in
+      let orchestrator =
+        Orchestrator.make ~launch ~fetch:(fun _ -> [ issue ]) ~set_status ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      let workspace = match !captured_workspace with Some workspace -> workspace | None -> Alcotest.fail "expected launch" in
+      Alcotest.(check bool) "under runtime workspaces" true (Workspace.is_inside ~root:config.workspace.root ~path:workspace.path);
+      Alcotest.(check string) "task branch" "symphony/task-3" (run_ok ~cwd:workspace.path "branch" "git branch --show-current");
+      Alcotest.(check bool) "task branch exists" true
+        (Sys.command ("cd " ^ Util.shell_quote root ^ " && git show-ref --verify --quiet refs/heads/symphony/task-3") = 0);
+      Alcotest.(check (list string)) "start status moved" [ "In progress" ] (List.rev !statuses))
+
+let test_orchestrator_requires_clean_loop_start_for_new_worktree () =
+  with_temp_dir "symphony-dirty-loop-" (fun root ->
+      init_repo root "feature/start";
+      Util.write_file (Filename.concat root "dirty.txt") "dirty\n";
+      let config = base_orchestrator_config root (git_policy ()) in
+      let issue = Issue.empty ~id:"I2" ~identifier:"#4" ~title:"Four" ~state:"Todo" in
+      let launches = ref 0 in
+      let statuses = ref [] in
+      let launch ~config:_ ~workspace:_ ~prompt:_ ~issue =
+        incr launches;
+        { Orchestrator.pid = None; session_id = Some issue.Issue.id; event = "test-launch"; stdout_path = None; stderr_path = None }
+      in
+      let set_status _ _ status =
+        statuses := status :: !statuses;
+        Ok ()
+      in
+      let orchestrator =
+        Orchestrator.make ~launch ~fetch:(fun _ -> [ issue ]) ~set_status ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check int) "not launched" 0 !launches;
+      Alcotest.(check (list string)) "moves to attention without in-progress" [ "Human attention" ] (List.rev !statuses);
+      Alcotest.(check (option string)) "last error"
+        (Some "loop-start worktree must be clean before creating task worktrees")
+        (Orchestrator.get_state orchestrator).last_error;
+      Alcotest.(check bool) "no placeholder worktree left" false
+        (Sys.file_exists (Filename.concat config.workspace.root "_4")))
+
+let test_orchestrator_reuses_existing_task_branch_on_restart () =
+  with_temp_dir "symphony-reuse-task-branch-" (fun root ->
+      init_repo root "feature/start";
+      let config = base_orchestrator_config root (git_policy ()) in
+      let issue = Issue.empty ~id:"I6" ~identifier:"#8" ~title:"Eight" ~state:"In progress" in
+      ignore (run_ok ~cwd:root "create task branch" "git branch symphony/task-8 feature/start");
+      let workspace =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"feature/start" issue with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Alcotest.(check string) "reused branch checked out" "symphony/task-8"
+        (run_ok ~cwd:workspace.path "branch" "git branch --show-current"))
+
+let test_orchestrator_reuses_worktree_for_existing_in_progress_task_before_launch () =
+  with_temp_dir "symphony-existing-progress-" (fun root ->
+      init_repo root "feature/start";
+      let config = base_orchestrator_config root (git_policy ()) in
+      let issue = Issue.empty ~id:"I9" ~identifier:"#11" ~title:"Eleven" ~state:"In progress" in
+      ignore (run_ok ~cwd:root "create task branch" "git branch symphony/task-11 feature/start");
+      let launched_branch = ref None in
+      let launch ~config:_ ~(workspace : Workspace.t) ~prompt:_ ~issue =
+        launched_branch := Some (run_ok ~cwd:workspace.path "branch" "git branch --show-current");
+        { Orchestrator.pid = None; session_id = Some issue.Issue.id; event = "test-launch"; stdout_path = None; stderr_path = None }
+      in
+      let orchestrator =
+        Orchestrator.make ~launch ~fetch:(fun _ -> [ issue ]) ~set_status:(fun _ _ _ -> Ok ()) ~config
+          ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check (option string)) "launched from reused task branch" (Some "symphony/task-11") !launched_branch)
+
+let test_stage_commit_pushes_task_branch () =
+  with_temp_dir "symphony-stage-push-" (fun root ->
+      let remote = Filename.concat root "remote.git" in
+      let repo = Filename.concat root "repo" in
+      Unix.mkdir repo 0o755;
+      ignore (run_ok ~cwd:root "bare remote" ("git init -q --bare " ^ Util.shell_quote remote));
+      init_repo repo "feature/start";
+      ignore (run_ok ~cwd:repo "add origin" ("git remote add origin " ^ Util.shell_quote remote));
+      let config = base_orchestrator_config repo (git_policy ()) in
+      let issue = Issue.empty ~id:"I3" ~identifier:"#5" ~title:"Five" ~state:"In progress" in
+      let workspace =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"feature/start" issue with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Util.write_file (Filename.concat workspace.path "work.txt") "work\n";
+      let stage =
+        Some
+          {
+            Config.states = [ "In progress" ];
+            agent = "engineer";
+            start_status = None;
+            success_status = Some "In review";
+            retry_status = Some "Todo";
+            commit = Some { enabled = true; commit_type = "feat"; message = Config.default_commit_message; push = true };
+          }
+      in
+      (match Orchestrator.git_commit_stage_changes config workspace issue stage (Some "In review") with
+      | Ok () -> ()
+      | Error error -> Alcotest.fail error);
+      Alcotest.(check bool) "remote task branch exists" true
+        (Sys.command ("git --git-dir " ^ Util.shell_quote remote ^ " show-ref --verify --quiet refs/heads/symphony/task-5") = 0);
+      Alcotest.(check bool) "loop-start branch not pushed" false
+        (Sys.command ("git --git-dir " ^ Util.shell_quote remote ^ " show-ref --verify --quiet refs/heads/feature/start") = 0))
+
+let test_auto_merge_fast_forwards_and_removes_worktree () =
+  with_temp_dir "symphony-auto-merge-" (fun root ->
+      init_repo root "feature/start";
+      let config = base_orchestrator_config root (git_policy ~auto_merge:true ()) in
+      let issue = Issue.empty ~id:"I4" ~identifier:"#6" ~title:"Six" ~state:"In progress" in
+      let workspace =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"feature/start" issue with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Util.write_file (Filename.concat workspace.path "merged.txt") "merged\n";
+      ignore (run_ok ~cwd:workspace.path "task commit" "git add merged.txt && git commit -q -m task");
+      let statuses = ref [] in
+      let set_status _ _ status =
+        statuses := status :: !statuses;
+        Ok ()
+      in
+      let orchestrator = Orchestrator.make ~set_status ~config ~prompt_template:"Issue {{ issue.identifier }}" () in
+      Orchestrator.mark_completed orchestrator
+        {
+          Orchestrator.pid = 0;
+          issue;
+          issue_id = issue.id;
+          issue_identifier = issue.identifier;
+          issue_title = issue.title;
+          workspace;
+          started_at = Unix.time ();
+          last_output_at = Unix.time ();
+          stdout_path = None;
+          stderr_path = None;
+          stdout_size = 0;
+          stderr_size = 0;
+        };
+      Alcotest.(check bool) "merged file present" true (Sys.file_exists (Filename.concat root "merged.txt"));
+      Alcotest.(check bool) "worktree removed" false (Sys.file_exists workspace.path);
+      Alcotest.(check bool) "task branch kept" true
+        (Sys.command ("cd " ^ Util.shell_quote root ^ " && git show-ref --verify --quiet refs/heads/symphony/task-6") = 0);
+      Alcotest.(check (list string)) "success status after merge" [ "In review" ] (List.rev !statuses))
+
+let test_cleanup_can_remove_task_branch_after_merge () =
+  with_temp_dir "symphony-cleanup-branch-" (fun root ->
+      init_repo root "feature/start";
+      let git =
+        {
+          (git_policy ~auto_merge:true ()) with
+          cleanup = { Config.remove_worktree_after_merge = true; keep_task_branch = false };
+        }
+      in
+      let config = base_orchestrator_config root git in
+      let issue = Issue.empty ~id:"I7" ~identifier:"#9" ~title:"Nine" ~state:"In progress" in
+      let workspace =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"feature/start" issue with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Util.write_file (Filename.concat workspace.path "cleanup.txt") "cleanup\n";
+      ignore (run_ok ~cwd:workspace.path "task commit" "git add cleanup.txt && git commit -q -m task");
+      let orchestrator = Orchestrator.make ~set_status:(fun _ _ _ -> Ok ()) ~config ~prompt_template:"Issue {{ issue.identifier }}" () in
+      Orchestrator.mark_completed orchestrator
+        {
+          Orchestrator.pid = 0;
+          issue;
+          issue_id = issue.id;
+          issue_identifier = issue.identifier;
+          issue_title = issue.title;
+          workspace;
+          started_at = Unix.time ();
+          last_output_at = Unix.time ();
+          stdout_path = None;
+          stderr_path = None;
+          stdout_size = 0;
+          stderr_size = 0;
+        };
+      Alcotest.(check bool) "task branch removed" false
+        (Sys.command ("cd " ^ Util.shell_quote root ^ " && git show-ref --verify --quiet refs/heads/symphony/task-9") = 0))
+
+let test_auto_merge_skips_protected_trunk_branch () =
+  with_temp_dir "symphony-protected-trunk-" (fun root ->
+      init_repo root "main";
+      let config = base_orchestrator_config root (git_policy ~auto_merge:true ()) in
+      let issue = Issue.empty ~id:"I8" ~identifier:"#10" ~title:"Ten" ~state:"In progress" in
+      let workspace =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"main" issue with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Util.write_file (Filename.concat workspace.path "protected.txt") "protected\n";
+      ignore (run_ok ~cwd:workspace.path "task commit" "git add protected.txt && git commit -q -m task");
+      let statuses = ref [] in
+      let set_status _ _ status =
+        statuses := status :: !statuses;
+        Ok ()
+      in
+      let orchestrator = Orchestrator.make ~set_status ~config ~prompt_template:"Issue {{ issue.identifier }}" () in
+      Orchestrator.mark_completed orchestrator
+        {
+          Orchestrator.pid = 0;
+          issue;
+          issue_id = issue.id;
+          issue_identifier = issue.identifier;
+          issue_title = issue.title;
+          workspace;
+          started_at = Unix.time ();
+          last_output_at = Unix.time ();
+          stdout_path = None;
+          stderr_path = None;
+          stdout_size = 0;
+          stderr_size = 0;
+        };
+      Alcotest.(check bool) "not merged into main" false (Sys.file_exists (Filename.concat root "protected.txt"));
+      Alcotest.(check bool) "worktree kept" true (Sys.file_exists workspace.path);
+      Alcotest.(check (list string)) "still advances status" [ "In review" ] (List.rev !statuses))
+
+let test_auto_merge_failure_moves_human_attention () =
+  with_temp_dir "symphony-auto-merge-fail-" (fun root ->
+      init_repo root "feature/start";
+      let config = base_orchestrator_config root (git_policy ~auto_merge:true ()) in
+      let issue = Issue.empty ~id:"I5" ~identifier:"#7" ~title:"Seven" ~state:"In progress" in
+      let workspace =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"feature/start" issue with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Util.write_file (Filename.concat workspace.path "task.txt") "task\n";
+      ignore (run_ok ~cwd:workspace.path "task commit" "git add task.txt && git commit -q -m task");
+      Util.write_file (Filename.concat root "loop.txt") "loop\n";
+      ignore (run_ok ~cwd:root "loop commit" "git add loop.txt && git commit -q -m loop");
+      let statuses = ref [] in
+      let set_status _ _ status =
+        statuses := status :: !statuses;
+        Ok ()
+      in
+      let orchestrator = Orchestrator.make ~set_status ~config ~prompt_template:"Issue {{ issue.identifier }}" () in
+      Orchestrator.mark_completed orchestrator
+        {
+          Orchestrator.pid = 0;
+          issue;
+          issue_id = issue.id;
+          issue_identifier = issue.identifier;
+          issue_title = issue.title;
+          workspace;
+          started_at = Unix.time ();
+          last_output_at = Unix.time ();
+          stdout_path = None;
+          stderr_path = None;
+          stdout_size = 0;
+          stderr_size = 0;
+        };
+      Alcotest.(check (list string)) "attention status only" [ "Human attention" ] (List.rev !statuses);
+      let state = Orchestrator.get_state orchestrator in
+      Alcotest.(check int) "issue error" 1 (List.length state.issue_errors);
+      Alcotest.(check bool) "worktree kept for inspection" true (Sys.file_exists workspace.path))
+
 let () =
   Alcotest.run "symphony-backend"
     [
       ("workflow", [ Alcotest.test_case "parse config" `Quick test_workflow_and_config ]);
       ("prompt", [ Alcotest.test_case "strict render" `Quick test_prompt_strict_rendering ]);
       ("workspace", [ Alcotest.test_case "sanitize and reuse" `Quick test_workspace_safety ]);
-      ("launch", [ Alcotest.test_case "runs agent in repository root" `Quick test_shell_launch_runs_agent_in_repository_root ]);
+      ("launch", [ Alcotest.test_case "runs agent in agent worktree" `Quick test_shell_launch_runs_agent_in_agent_worktree ]);
       ( "runtime-home",
         [
           Alcotest.test_case "bootstrap is idempotent" `Quick test_bootstrap_idempotency_preserves_user_files;
@@ -1334,6 +1723,7 @@ let () =
           Alcotest.test_case "reject non-github tracker" `Quick test_invalid_tracker_kind;
           Alcotest.test_case "normalizes legacy codex app-server command" `Quick test_legacy_codex_app_server_command_normalizes_to_exec;
           Alcotest.test_case "derives kanban status order from transitions" `Quick test_project_status_order_uses_transition_flow;
+          Alcotest.test_case "parses git policy and stage push" `Quick test_config_parses_git_policy_and_stage_push;
         ] );
       ("runtime-state", [ Alcotest.test_case "exposes running issue details" `Quick test_runtime_state_exposes_running_issue_details ]);
       ( "server",
@@ -1366,5 +1756,15 @@ let () =
           Alcotest.test_case "stage commit requires code changes" `Quick test_stage_commit_requires_code_changes;
           Alcotest.test_case "does not retry empty required commits" `Quick test_orchestrator_does_not_retry_empty_commit;
           Alcotest.test_case "notifies repeated state mutations" `Quick test_orchestrator_notifies_each_state_mutation;
+          Alcotest.test_case "creates task worktree and branch" `Quick test_orchestrator_creates_task_worktree_and_branch;
+          Alcotest.test_case "requires clean loop-start worktree" `Quick test_orchestrator_requires_clean_loop_start_for_new_worktree;
+          Alcotest.test_case "reuses existing task branch on restart" `Quick test_orchestrator_reuses_existing_task_branch_on_restart;
+          Alcotest.test_case "reuses worktree for existing in-progress task"
+            `Quick test_orchestrator_reuses_worktree_for_existing_in_progress_task_before_launch;
+          Alcotest.test_case "pushes task branch after stage commit" `Quick test_stage_commit_pushes_task_branch;
+          Alcotest.test_case "fast-forwards task branch and removes worktree" `Quick test_auto_merge_fast_forwards_and_removes_worktree;
+          Alcotest.test_case "can remove task branch after merge" `Quick test_cleanup_can_remove_task_branch_after_merge;
+          Alcotest.test_case "skips auto-merge on protected trunk" `Quick test_auto_merge_skips_protected_trunk_branch;
+          Alcotest.test_case "moves merge failures to human attention" `Quick test_auto_merge_failure_moves_human_attention;
         ] );
     ]

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -1514,6 +1514,34 @@ let test_orchestrator_reuses_worktree_for_existing_in_progress_task_before_launc
       Orchestrator.poll_once orchestrator;
       Alcotest.(check (option string)) "launched from reused task branch" (Some "symphony/task-11") !launched_branch)
 
+let test_orchestrator_rejects_existing_non_worktree_workspace () =
+  with_temp_dir "symphony-existing-non-worktree-" (fun root ->
+      init_repo root "feature/start";
+      let config = base_orchestrator_config root (git_policy ()) in
+      let issue = Issue.empty ~id:"I10" ~identifier:"#12" ~title:"Twelve" ~state:"In progress" in
+      Util.mkdir_p config.workspace.root;
+      let stale_workspace = Filename.concat config.workspace.root "_12" in
+      Unix.mkdir stale_workspace 0o755;
+      let launches = ref 0 in
+      let launch ~config:_ ~workspace:_ ~prompt:_ ~issue =
+        incr launches;
+        { Orchestrator.pid = None; session_id = Some issue.Issue.id; event = "test-launch"; stdout_path = None; stderr_path = None }
+      in
+      let statuses = ref [] in
+      let set_status _ _ status =
+        statuses := status :: !statuses;
+        Ok ()
+      in
+      let orchestrator =
+        Orchestrator.make ~launch ~fetch:(fun _ -> [ issue ]) ~set_status ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check int) "not launched" 0 !launches;
+      Alcotest.(check (list string)) "attention status" [ "Human attention" ] (List.rev !statuses);
+      Alcotest.(check (option string)) "last error"
+        (Some (stale_workspace ^ " exists but is not an Agent Worktree"))
+        (Orchestrator.get_state orchestrator).last_error)
+
 let test_stage_commit_pushes_task_branch () =
   with_temp_dir "symphony-stage-push-" (fun root ->
       let remote = Filename.concat root "remote.git" in
@@ -1761,6 +1789,7 @@ let () =
           Alcotest.test_case "reuses existing task branch on restart" `Quick test_orchestrator_reuses_existing_task_branch_on_restart;
           Alcotest.test_case "reuses worktree for existing in-progress task"
             `Quick test_orchestrator_reuses_worktree_for_existing_in_progress_task_before_launch;
+          Alcotest.test_case "rejects existing non-worktree workspace" `Quick test_orchestrator_rejects_existing_non_worktree_workspace;
           Alcotest.test_case "pushes task branch after stage commit" `Quick test_stage_commit_pushes_task_branch;
           Alcotest.test_case "fast-forwards task branch and removes worktree" `Quick test_auto_merge_fast_forwards_and_removes_worktree;
           Alcotest.test_case "can remove task branch after merge" `Quick test_cleanup_can_remove_task_branch_after_merge;

--- a/docs/adr/0005-per-task-git-worktrees.md
+++ b/docs/adr/0005-per-task-git-worktrees.md
@@ -1,3 +1,35 @@
 # Use per-task Git worktrees and task branches
 
-Personal Symphony will run each dispatched task in an Agent Worktree under `.symphony/workspaces/`, backed by a Task Branch created from the Loop-Start Branch. This isolates concurrent task changes and makes integration explicit: completed Task Branches may fast-forward merge back into the Loop-Start Branch only when it is not a configured Protected Trunk Branch such as `main` or `master`; merge failures move the task to the paused `Human attention` status instead of retrying agent work automatically.
+## Status
+
+Accepted
+
+## Context
+
+Personal Symphony can dispatch multiple tasks from one Loop-Start Branch. Running every agent in the Loop-Start Worktree makes task changes hard to isolate, makes concurrent work unsafe, and leaves the operator without a clear boundary for deciding which task changes should come back to the branch where orchestration started.
+
+## Decision
+
+Personal Symphony runs each dispatched task in an Agent Worktree under `.symphony/workspaces/`. Each Agent Worktree checks out a per-task Task Branch whose name starts with the configured Task Branch Prefix and is created from the Loop-Start Branch. Existing Task Branches are reused on restart, including tasks that already start in an in-progress project state.
+
+The Loop-Start Worktree must be clean before Symphony creates a new Agent Worktree. Symphony creates or reuses the Agent Worktree before moving the task into the in-progress project state or launching agent work.
+
+Runtime Settings include a Git Policy for:
+
+- Task Branch Prefix.
+- Protected Trunk Branches.
+- fast-forward-only auto-merge.
+- Merge Attention Status.
+- Task Cleanup Policy.
+
+Stage Commit still happens before a task moves to its success status. When a stage commit policy enables Stage Push, Symphony pushes the current Task Branch after the Stage Commit and before any auto-merge attempt.
+
+Completed Task Branches may auto-merge into the Loop-Start Branch only when the Loop-Start Branch is not a configured Protected Trunk Branch. Auto-merge is fast-forward only. Symphony does not push the Loop-Start Branch after auto-merge.
+
+The default cleanup policy removes the Agent Worktree after a successful merge and keeps the Task Branch. If configured not to keep the Task Branch, Symphony deletes it after the worktree is removed.
+
+## Consequences
+
+Concurrent task work is isolated by Git instead of by convention. Operators can inspect, push, merge, or discard each Task Branch independently.
+
+Merge conflicts and non-fast-forward integration failures are treated as human attention events. Symphony moves the task to the configured Merge Attention Status, which defaults to `Human attention`, instead of retrying agent work against an integration problem.


### PR DESCRIPTION
## What changed

- Added Runtime Settings for Git policy, including task branch prefix, protected trunk branches, auto-merge, merge attention status, cleanup, and stage push.
- Runs dispatched agents inside per-task Git worktrees under `.symphony/workspaces/`.
- Creates or reuses task branches from the Loop-Start Branch and supports restart of existing in-progress tasks.
- Adds fast-forward-only auto-merge, protected trunk handling, task branch/worktree cleanup, and Human attention handling for merge failures.
- Expands ADR 0005 with the accepted worktree policy.

Closes #3.

## Validation

- `pnpm backend:test`
- `pnpm frontend:test`