### PR TITLE
feat: add batch pull request handoff

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -237,6 +237,7 @@ _Avoid_: reinitialize, reset
 - A **Batch Branch Push** pushes the **Loop-Start Branch** to its remote head branch.
 - A failed **Batch Branch Push** prevents the **Batch Pull Request** from being opened.
 - A failed **Batch Branch Push** is retryable.
+- Runtime State records Batch Pull Request handoff attempts, completions, and retryable failures.
 - The **Runtime Contract** is version-controlled with the Workspace Repository.
 - A **Readiness Gap** prevents dispatch but does not prevent the TUI from starting.
 - Personal Symphony starts the **Terminal Console** by default.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,32 @@ template supports `<type>`, `<generated_message_max_90char>`, `<issue_identifier
 branch after a successful stage commit and before the status transition; omitted values default to
 `false`.
 
+## Batch Pull Requests
+
+Symphony can optionally open one Batch Pull Request after Orchestration Idle, using the Loop-Start
+Branch as the PR head. Automatic PR creation is disabled by default:
+
+```json
+{
+  "pullRequest": {
+    "enabled": false,
+    "baseBranch": "main",
+    "title": "Symphony batch from <head_branch>",
+    "body": "Opened automatically by Symphony after orchestration became idle."
+  }
+}
+```
+
+When `pullRequest.enabled` is `true`, `pullRequest.baseBranch` must be set explicitly. On an idle
+poll, Symphony first performs a non-force Batch Branch Push of the Loop-Start Branch to `origin`,
+then checks for an existing open PR with the same head/base pair before creating one with `gh`.
+Failed pushes or PR creation attempts are recorded in Runtime State as retryable handoff failures and
+are retried on later idle polls. Symphony does not attempt a Batch Pull Request while any issue is in
+the configured Merge Attention Status or has unresolved orchestration attention.
+
+The `title` and `body` fields are deterministic templates. They support `<head_branch>` and
+`<base_branch>`; Symphony does not generate PR prose with an agent.
+
 ## GitHub Token Permissions
 
 Personal Symphony reads GitHub Issues and GitHub Projects. Use a **personal access token (classic)**

--- a/apps/backend/lib/config.ml
+++ b/apps/backend/lib/config.ml
@@ -34,6 +34,7 @@ type codex = {
   stall_timeout_ms : int;
 }
 type server = { port : int option }
+type pull_request = { enabled : bool; base_branch : string; title : string; body : string }
 type stage_commit = { enabled : bool; commit_type : string; message : string; push : bool }
 type stage_agent = {
   states : string list;
@@ -56,6 +57,7 @@ type t = {
   agent : agent;
   codex : codex;
   server : server;
+  pull_request : pull_request;
   stage_agents : stage_agents;
 }
 
@@ -73,6 +75,9 @@ let default_commit_message = "<type>: <generated_message_max_90char>"
 let default_model = "gpt-5.5"
 let default_reasoning_effort = "medium"
 let default_codex_command = "codex exec"
+let default_pull_request_title = "Symphony batch from <head_branch>"
+let default_pull_request_body = "Opened automatically by Symphony after orchestration became idle."
+let default_pull_request = { enabled = false; base_branch = "main"; title = default_pull_request_title; body = default_pull_request_body }
 
 let default_git =
   {
@@ -113,6 +118,10 @@ let default_stage_agents =
       commit = Some { enabled = false; commit_type = "refactor"; message = default_commit_message; push = false };
     };
   ]
+
+let add_string_ci value values =
+  if List.exists (fun existing -> String.lowercase_ascii existing = String.lowercase_ascii value) values then values
+  else values @ [ value ]
 
 let resolve_secret = function
   | None -> None
@@ -176,7 +185,8 @@ let from_workflow workflow =
     match Simple_yaml.get_list "active_states" tracker_raw with [] -> default_active_states | states -> states
   in
   let terminal_states =
-    match Simple_yaml.get_list "terminal_states" tracker_raw with [] -> default_terminal_states | states -> states
+    (match Simple_yaml.get_list "terminal_states" tracker_raw with [] -> default_terminal_states | states -> states)
+    |> add_string_ci default_git.merge_attention_status
   in
   let workspace_root =
     Simple_yaml.get_string "root" workspace_raw
@@ -228,6 +238,7 @@ let from_workflow workflow =
         stall_timeout_ms = Option.value (Simple_yaml.get_int "stall_timeout_ms" codex_raw) ~default:300000;
       };
     server = { port = Simple_yaml.get_int "port" server_raw };
+    pull_request = default_pull_request;
     stage_agents = { enabled = false; root = Filename.concat workflow.dir ".symphony/agents"; default_agent = None; stages = [] };
   }
 
@@ -293,10 +304,18 @@ let from_settings_file ~workspace_root path =
   let agent_raw = member "agent" root in
   let codex_raw = member "codex" root in
   let server_raw = member "server" root in
+  let pull_request_raw = member "pullRequest" root in
   let stage_agents_raw = member "stageAgents" root in
   let kind = json_string "kind" tracker_raw ~default:"github" in
   if kind <> "github" then raise (Invalid_config "tracker.kind must be github for this implementation");
   let api_key_env = json_string "apiKeyEnv" tracker_raw ~default:"GITHUB_TOKEN" in
+  let merge_attention_status =
+    json_string "mergeAttentionStatus" git_raw ~default:default_git.merge_attention_status
+  in
+  let terminal_states =
+    json_string_list "terminalStates" project_raw ~default:default_terminal_states
+    |> add_string_ci merge_attention_status
+  in
   let workspace_root_value =
     json_string "root" workspace_raw ~default:".symphony/workspaces" |> expand_path ~base_dir:workspace_root
   in
@@ -312,7 +331,7 @@ let from_settings_file ~workspace_root path =
         api_key_env;
         api_key = resolve_env_secret api_key_env;
         active_states = json_string_list "activeStates" project_raw ~default:default_active_states;
-        terminal_states = json_string_list "terminalStates" project_raw ~default:default_terminal_states;
+        terminal_states;
         project_status_field = json_string "statusField" project_raw ~default:"Status";
         project_status_on_dispatch =
           Some (Option.value (json_optional_string "startStatus" project_raw) ~default:default_dispatch_status);
@@ -330,8 +349,7 @@ let from_settings_file ~workspace_root path =
         protected_trunk_branches =
           json_string_list "protectedTrunkBranches" git_raw ~default:default_git.protected_trunk_branches;
         auto_merge = json_bool "autoMerge" git_raw ~default:default_git.auto_merge;
-        merge_attention_status =
-          json_string "mergeAttentionStatus" git_raw ~default:default_git.merge_attention_status;
+        merge_attention_status;
         cleanup =
           {
             remove_worktree_after_merge =
@@ -359,6 +377,13 @@ let from_settings_file ~workspace_root path =
         stall_timeout_ms = json_int "stallTimeoutMs" codex_raw ~default:300000;
       };
     server = { port = (match member "port" server_raw with `Null -> None | _ -> Some (json_int "port" server_raw ~default:8080)) };
+    pull_request =
+      {
+        enabled = json_bool "enabled" pull_request_raw ~default:default_pull_request.enabled;
+        base_branch = json_string "baseBranch" pull_request_raw ~default:default_pull_request.base_branch;
+        title = json_string "title" pull_request_raw ~default:default_pull_request.title;
+        body = json_string "body" pull_request_raw ~default:default_pull_request.body;
+      };
     stage_agents =
       {
         enabled = json_bool "enabled" stage_agents_raw ~default:true;
@@ -397,6 +422,8 @@ let readiness_gaps config =
     add "project.activeStates" "Add at least one active project state in .symphony/settings.json.";
   if config.tracker.terminal_states = [] then
     add "project.terminalStates" "Add at least one terminal project state in .symphony/settings.json.";
+  if config.pull_request.enabled && Util.trim config.pull_request.base_branch = "" then
+    add "pullRequest.baseBranch" "Set pullRequest.baseBranch in .symphony/settings.json when pullRequest.enabled is true.";
   if config.stage_agents.enabled then (
     if not (Sys.file_exists config.stage_agents.root && Sys.is_directory config.stage_agents.root) then
       add "stageAgents.root" "Create .symphony/agents or set stageAgents.enabled to false.";

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -12,6 +12,7 @@ type launch =
 type fetch = Github_tracker.t -> Issue.t list
 type set_status = Github_tracker.t -> Issue.t -> string -> (unit, string) result
 type commit_stage = Config.t -> Workspace.t -> Issue.t -> Config.stage_agent option -> string option -> (unit, string) result
+type batch_pull_request_handoff = Config.t -> head_branch:string -> (string option, string) result
 type notify_state = Runtime_state.t -> unit
 
 type t = {
@@ -27,8 +28,10 @@ type t = {
   fetch : fetch;
   set_status : set_status;
   commit_stage : commit_stage;
+  batch_pull_request_handoff : batch_pull_request_handoff;
   notify_state : notify_state;
   loop_start_branch : string;
+  mutable batch_pull_request_completed : bool;
 }
 
 and child = {
@@ -112,6 +115,14 @@ let render_commit_skipped issue_identifier =
 let render_commit_failed issue_identifier error =
   Printf.eprintf "%s%s %s %s %s %s\n%!" clear_line (dim (clock_time ())) (cyan "commit") (red "failed")
     issue_identifier error
+
+let render_pull_request_completed head base =
+  Printf.eprintf "%s%s %s %s %s %s %s\n%!" clear_line (dim (clock_time ())) (cyan "pull-request") (green "ready")
+    head (dim "base") base
+
+let render_pull_request_failed head base error =
+  Printf.eprintf "%s%s %s %s %s %s %s %s\n%!" clear_line (dim (clock_time ())) (cyan "pull-request") (red "failed")
+    head (dim "base") base error
 
 let running_ids state = List.map (fun (row : Runtime_state.running) -> row.issue.id) state.Runtime_state.running
 let is_running state issue = List.exists (( = ) issue.Issue.id) (running_ids state)
@@ -302,6 +313,65 @@ let push_current_branch root =
   | Error _ ->
       run_shell_capture ~cwd:root "git push -u origin HEAD"
 
+let render_pull_request_template config ~head_branch text =
+  text
+  |> replace_token ~token:"head_branch" ~value:head_branch
+  |> replace_token ~token:"base_branch" ~value:config.Config.pull_request.base_branch
+  |> Util.trim
+
+let batch_branch_push config ~head_branch =
+  if not (is_git_repository config.Config.repository_root) then Error "batch pull request requires a Git repository"
+  else
+    let command =
+      Printf.sprintf "git push -u origin refs/heads/%s:refs/heads/%s" (Util.shell_quote head_branch)
+        (Util.shell_quote head_branch)
+    in
+    match run_shell_capture ~cwd:config.repository_root command with
+    | Ok _ -> Ok ()
+    | Error error -> Error ("batch branch push failed: " ^ error)
+
+let existing_batch_pull_request config ~head_branch =
+  let repo_full_name = config.Config.tracker.owner ^ "/" ^ config.tracker.repo in
+  let head_filter = config.tracker.owner ^ ":" ^ head_branch in
+  let command =
+    Printf.sprintf "gh pr list --repo %s --state open --head %s --base %s --limit 1 --json url"
+      (Util.shell_quote repo_full_name) (Util.shell_quote head_filter)
+      (Util.shell_quote config.pull_request.base_branch)
+  in
+  match run_shell_capture ~cwd:config.repository_root command with
+  | Error error -> Error ("batch pull request lookup failed: " ^ error)
+  | Ok output -> (
+      try
+        match Yojson.Safe.from_string output with
+        | `List (`Assoc fields :: _) -> (
+            match List.assoc_opt "url" fields with Some (`String url) -> Ok (Some url) | _ -> Ok (Some ""))
+        | `List [] -> Ok None
+        | _ -> Ok None
+      with Yojson.Json_error msg -> Error ("batch pull request lookup returned invalid JSON: " ^ msg))
+
+let create_batch_pull_request config ~head_branch =
+  let repo_full_name = config.Config.tracker.owner ^ "/" ^ config.tracker.repo in
+  let title = render_pull_request_template config ~head_branch config.pull_request.title in
+  let body = render_pull_request_template config ~head_branch config.pull_request.body in
+  let command =
+    Printf.sprintf "gh pr create --repo %s --head %s --base %s --title %s --body %s" (Util.shell_quote repo_full_name)
+      (Util.shell_quote head_branch)
+      (Util.shell_quote config.pull_request.base_branch)
+      (Util.shell_quote title) (Util.shell_quote body)
+  in
+  match run_shell_capture ~cwd:config.repository_root command with
+  | Ok output -> Ok (Some (Util.trim output))
+  | Error error -> Error ("batch pull request creation failed: " ^ error)
+
+let gh_batch_pull_request_handoff config ~head_branch =
+  match batch_branch_push config ~head_branch with
+  | Error _ as error -> error
+  | Ok () -> (
+      match existing_batch_pull_request config ~head_branch with
+      | Error _ as error -> error
+      | Ok (Some url) -> Ok (if Util.trim url = "" then None else Some url)
+      | Ok None -> create_batch_pull_request config ~head_branch)
+
 let git_commit_stage_changes _config workspace issue stage next_status =
   match stage with
   | None -> Ok ()
@@ -383,7 +453,8 @@ let shell_launch ~config ~workspace ~prompt ~issue =
   }
 
 let make ?(launch = shell_launch) ?(fetch = Github_tracker.fetch_candidate_issues) ?(set_status = Github_tracker.update_issue_status)
-    ?(commit_stage = git_commit_stage_changes) ?(notify_state = fun _ -> ()) ~config ~prompt_template () =
+    ?(commit_stage = git_commit_stage_changes) ?(batch_pull_request_handoff = gh_batch_pull_request_handoff)
+    ?(notify_state = fun _ -> ()) ~config ~prompt_template () =
   {
     config;
     prompt_template;
@@ -397,8 +468,10 @@ let make ?(launch = shell_launch) ?(fetch = Github_tracker.fetch_candidate_issue
     fetch;
     set_status;
     commit_stage;
+    batch_pull_request_handoff;
     notify_state;
     loop_start_branch = current_branch config.repository_root;
+    batch_pull_request_completed = false;
   }
 
 let get_state orchestrator = orchestrator.state
@@ -500,6 +573,50 @@ let retry_status orchestrator issue =
 
 let issue_is_active orchestrator issue =
   Github_tracker.status_is_active ~active_states:orchestrator.config.tracker.active_states issue.Issue.state
+
+let issue_needs_attention orchestrator issue =
+  string_equal_ci issue.Issue.state orchestrator.config.git.merge_attention_status || is_blocked orchestrator issue
+
+let set_pull_request_handoff orchestrator status ?url ?error () =
+  let policy = orchestrator.config.Config.pull_request in
+  update_state orchestrator (fun state ->
+    {
+      state with
+      pull_request =
+        Some
+          {
+            Runtime_state.enabled = policy.enabled;
+            head_branch = Some orchestrator.loop_start_branch;
+            base_branch = Some policy.base_branch;
+            status;
+            url;
+            error;
+          };
+      last_error = (match error with Some error -> Some error | None -> state.last_error);
+    })
+
+let maybe_open_batch_pull_request orchestrator ~candidates ~dispatchable_count =
+  let policy = orchestrator.config.Config.pull_request in
+  if policy.enabled && not orchestrator.batch_pull_request_completed then
+    let has_attention = List.exists (issue_needs_attention orchestrator) candidates || orchestrator.state.issue_errors <> [] in
+    let idle =
+      dispatchable_count = 0
+      && orchestrator.state.running = []
+      && orchestrator.state.retrying = []
+      && Hashtbl.length orchestrator.retry_due = 0
+      && orchestrator.children = []
+      && not has_attention
+    in
+    if idle then (
+      set_pull_request_handoff orchestrator "attempting" ();
+      match orchestrator.batch_pull_request_handoff orchestrator.config ~head_branch:orchestrator.loop_start_branch with
+      | Ok url ->
+          orchestrator.batch_pull_request_completed <- true;
+          set_pull_request_handoff orchestrator "completed" ?url ();
+          render_pull_request_completed orchestrator.loop_start_branch policy.base_branch
+      | Error error ->
+          set_pull_request_handoff orchestrator "retryable_failure" ~error ();
+          render_pull_request_failed orchestrator.loop_start_branch policy.base_branch error)
 
 let dispatch_issue orchestrator issue =
   let target_start_status = start_status orchestrator issue in
@@ -791,6 +908,7 @@ let poll_once orchestrator =
              && retrying_due orchestrator issue)
     in
     if available > 0 then dispatchable |> take available |> List.iter (dispatch_issue orchestrator);
+    maybe_open_batch_pull_request orchestrator ~candidates ~dispatchable_count:(List.length dispatchable);
     render_poll_completed orchestrator (List.length dispatchable)
   with exn ->
     let msg = Printexc.to_string exn in

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -332,10 +332,9 @@ let batch_branch_push config ~head_branch =
 
 let existing_batch_pull_request config ~head_branch =
   let repo_full_name = config.Config.tracker.owner ^ "/" ^ config.tracker.repo in
-  let head_filter = config.tracker.owner ^ ":" ^ head_branch in
   let command =
     Printf.sprintf "gh pr list --repo %s --state open --head %s --base %s --limit 1 --json url"
-      (Util.shell_quote repo_full_name) (Util.shell_quote head_filter)
+      (Util.shell_quote repo_full_name) (Util.shell_quote head_branch)
       (Util.shell_quote config.pull_request.base_branch)
   in
   match run_shell_capture ~cwd:config.repository_root command with

--- a/apps/backend/lib/runtime_home.ml
+++ b/apps/backend/lib/runtime_home.ml
@@ -49,6 +49,12 @@ let settings_json =
       "keepTaskBranch": true
     }
   },
+  "pullRequest": {
+    "enabled": false,
+    "baseBranch": "main",
+    "title": "Symphony batch from <head_branch>",
+    "body": "Opened automatically by Symphony after orchestration became idle."
+  },
   "stageAgents": {
     "enabled": true,
     "root": ".symphony/agents",

--- a/apps/backend/lib/runtime_state.ml
+++ b/apps/backend/lib/runtime_state.ml
@@ -14,6 +14,14 @@ type running = {
 type retrying = { issue_id : string; issue_identifier : string; attempt : int; due_at : string; error : string option }
 type issue_error = { issue_id : string; issue_identifier : string; error : string }
 type readiness_gap = { requirement : string; remediation : string }
+type pull_request_handoff = {
+  enabled : bool;
+  head_branch : string option;
+  base_branch : string option;
+  status : string;
+  url : string option;
+  error : string option;
+}
 
 type t = {
   issues : Issue.t list;
@@ -25,6 +33,7 @@ type t = {
   codex_totals : tokens;
   seconds_running : float;
   rate_limits : Yojson.Safe.t option;
+  pull_request : pull_request_handoff option;
   last_error : string option;
 }
 
@@ -39,6 +48,7 @@ let empty ?(readiness_gaps = []) ?(status_order = []) ?last_error () =
     codex_totals = { input_tokens = 0; output_tokens = 0; total_tokens = 0 };
     seconds_running = 0.;
     rate_limits = None;
+    pull_request = None;
     last_error;
   }
 
@@ -102,6 +112,17 @@ let issue_error_to_yojson (row : issue_error) =
 let readiness_gap_to_yojson row =
   `Assoc [ ("requirement", `String row.requirement); ("remediation", `String row.remediation) ]
 
+let pull_request_handoff_to_yojson row =
+  `Assoc
+    [
+      ("enabled", `Bool row.enabled);
+      ("head_branch", (match row.head_branch with Some s -> `String s | None -> `Null));
+      ("base_branch", (match row.base_branch with Some s -> `String s | None -> `Null));
+      ("status", `String row.status);
+      ("url", (match row.url with Some s -> `String s | None -> `Null));
+      ("error", (match row.error with Some s -> `String s | None -> `Null));
+    ]
+
 let to_yojson state =
   `Assoc
     [
@@ -122,5 +143,6 @@ let to_yojson state =
             ("seconds_running", `Float state.seconds_running);
           ] );
       ("rate_limits", Option.value state.rate_limits ~default:`Null);
+      ("pull_request", (match state.pull_request with Some row -> pull_request_handoff_to_yojson row | None -> `Null));
       ("last_error", (match state.last_error with Some s -> `String s | None -> `Null));
     ]

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -52,6 +52,12 @@ let test_config_parses_git_policy_and_stage_push () =
     "mergeAttentionStatus": "Needs merge",
     "cleanup": {"removeWorktreeAfterMerge": false, "keepTaskBranch": true}
   },
+  "pullRequest": {
+    "enabled": true,
+    "baseBranch": "main",
+    "title": "Symphony batch from <head_branch> into <base_branch>",
+    "body": "Batch handoff for <head_branch>."
+  },
   "stageAgents": {
     "enabled": true,
     "root": ".symphony/agents",
@@ -76,12 +82,33 @@ let test_config_parses_git_policy_and_stage_push () =
       Alcotest.(check (list string)) "protected trunks" [ "main"; "release" ] config.git.protected_trunk_branches;
       Alcotest.(check bool) "auto merge" false config.git.auto_merge;
       Alcotest.(check string) "attention status" "Needs merge" config.git.merge_attention_status;
+      Alcotest.(check bool) "attention status visible" true
+        (List.exists (( = ) "Needs merge") config.tracker.terminal_states);
       Alcotest.(check bool) "cleanup worktree" false config.git.cleanup.remove_worktree_after_merge;
+      Alcotest.(check bool) "pull request enabled" true config.pull_request.enabled;
+      Alcotest.(check string) "pull request base" "main" config.pull_request.base_branch;
+      Alcotest.(check string) "pull request title" "Symphony batch from <head_branch> into <base_branch>" config.pull_request.title;
       match config.stage_agents.stages with
       | [ { Config.commit = Some engineer_commit; _ }; { Config.commit = Some reviewer_commit; _ } ] ->
           Alcotest.(check bool) "stage push" true engineer_commit.push;
           Alcotest.(check bool) "stage push default" false reviewer_commit.push
       | _ -> Alcotest.fail "expected stage commit policy")
+
+let test_pull_request_base_branch_readiness_gap () =
+  with_temp_dir "symphony-settings-pr-gap-" (fun root ->
+      let settings = Filename.concat root "settings.json" in
+      Util.mkdir_p (Filename.concat root ".symphony");
+      Unix.putenv "GITHUB_TOKEN" "token";
+      Util.write_file settings
+        {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "pullRequest": {"enabled": true, "baseBranch": ""},
+  "stageAgents": {"enabled": false}
+}|};
+      let config = Config.from_settings_file ~workspace_root:root settings in
+      let gaps = Config.readiness_gaps config in
+      Alcotest.(check bool) "base branch gap" true
+        (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "pullRequest.baseBranch") gaps))
 
 let test_workflow_and_config () =
   let content =
@@ -169,6 +196,7 @@ let test_shell_launch_runs_agent_in_agent_worktree () =
               stall_timeout_ms = 1000;
             };
           server = { port = None };
+          pull_request = Config.default_pull_request;
           stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
         }
       in
@@ -254,9 +282,10 @@ let test_project_status_order_uses_transition_flow () =
           turn_timeout_ms = 1000;
           read_timeout_ms = 100;
           stall_timeout_ms = 1000;
-        };
-      server = { port = None };
-      stage_agents = { enabled = false; root = "/tmp/widgets/.symphony/agents"; default_agent = None; stages = [] };
+      };
+    server = { port = None };
+    pull_request = Config.default_pull_request;
+    stage_agents = { enabled = false; root = "/tmp/widgets/.symphony/agents"; default_agent = None; stages = [] };
     }
   in
   Alcotest.(check (list string)) "kanban status order" [ "To-Do"; "In progress"; "In review"; "Done" ]
@@ -615,6 +644,7 @@ let test_orchestrator_notifies_each_state_mutation () =
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "cat"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 1000; stall_timeout_ms = 1000 };
           server = { port = None };
+          pull_request = Config.default_pull_request;
           stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
         }
       in
@@ -855,6 +885,7 @@ let test_orchestrator_dispatch_limits () =
           agent = { max_concurrent_agents = 2; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "cat"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 1000; stall_timeout_ms = 1000 };
           server = { port = None };
+          pull_request = Config.default_pull_request;
           stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
         }
       in
@@ -909,6 +940,7 @@ let test_orchestrator_does_not_dispatch_terminal_issues () =
           agent = { max_concurrent_agents = 2; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "cat"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 1000; stall_timeout_ms = 1000 };
           server = { port = None };
+          pull_request = Config.default_pull_request;
           stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
         }
       in
@@ -959,6 +991,7 @@ let test_orchestrator_retries_failed_agent () =
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "false"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
+          pull_request = Config.default_pull_request;
           stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
         }
       in
@@ -1006,6 +1039,7 @@ let test_orchestrator_moves_status_to_review_on_success () =
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
+          pull_request = Config.default_pull_request;
           stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
         }
       in
@@ -1063,6 +1097,7 @@ let test_orchestrator_uses_stage_agent_prompt_and_status () =
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
+          pull_request = Config.default_pull_request;
           stage_agents =
             {
               enabled = true;
@@ -1148,6 +1183,7 @@ let test_orchestrator_commits_stage_before_success_status () =
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
+          pull_request = Config.default_pull_request;
           stage_agents =
             {
               enabled = true;
@@ -1228,6 +1264,7 @@ let test_orchestrator_retries_when_success_status_move_fails () =
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
+          pull_request = Config.default_pull_request;
           stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
         }
       in
@@ -1291,6 +1328,7 @@ let test_orchestrator_retries_push_failure_before_success_status () =
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
+          pull_request = Config.default_pull_request;
           stage_agents =
             {
               enabled = true;
@@ -1375,6 +1413,7 @@ let test_stage_commit_requires_code_changes () =
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
+          pull_request = Config.default_pull_request;
           stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
         }
       in
@@ -1423,6 +1462,7 @@ let test_orchestrator_does_not_retry_empty_commit () =
           agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
           codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
           server = { port = None };
+          pull_request = Config.default_pull_request;
           stage_agents =
             {
               enabled = true;
@@ -1513,8 +1553,9 @@ let base_orchestrator_config root git =
         turn_timeout_ms = 1000;
         read_timeout_ms = 100;
         stall_timeout_ms = 1000;
-      };
+    };
     server = { port = None };
+    pull_request = Config.default_pull_request;
     stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
   }
 
@@ -1543,6 +1584,127 @@ let test_orchestrator_creates_task_worktree_and_branch () =
       Alcotest.(check bool) "task branch exists" true
         (Sys.command ("cd " ^ Util.shell_quote root ^ " && git show-ref --verify --quiet refs/heads/symphony/task-3") = 0);
       Alcotest.(check (list string)) "start status moved" [ "In progress" ] (List.rev !statuses))
+
+let pull_request_config config =
+  {
+    config with
+    Config.pull_request =
+      {
+        enabled = true;
+        base_branch = "main";
+        title = "Symphony batch from <head_branch>";
+        body = "Opened automatically by Symphony after orchestration became idle.";
+      };
+  }
+
+let test_orchestrator_opens_batch_pull_request_once_when_idle () =
+  with_temp_dir "symphony-batch-pr-idle-" (fun root ->
+      init_repo root "feature/start";
+      let config = base_orchestrator_config root (git_policy ()) |> pull_request_config in
+      let attempts = ref [] in
+      let batch_pull_request_handoff _config ~head_branch =
+        attempts := head_branch :: !attempts;
+        Ok (Some "https://github.example/acme/widgets/pull/1")
+      in
+      let orchestrator =
+        Orchestrator.make ~fetch:(fun _ -> []) ~batch_pull_request_handoff ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check (list string)) "handoff attempted once" [ "feature/start" ] (List.rev !attempts);
+      match (Orchestrator.get_state orchestrator).Runtime_state.pull_request with
+      | Some handoff ->
+          Alcotest.(check string) "status" "completed" handoff.status;
+          Alcotest.(check (option string)) "url" (Some "https://github.example/acme/widgets/pull/1") handoff.url
+      | None -> Alcotest.fail "expected pull request handoff state")
+
+let test_orchestrator_retries_batch_pull_request_handoff_failure () =
+  with_temp_dir "symphony-batch-pr-retry-" (fun root ->
+      init_repo root "feature/start";
+      let config = base_orchestrator_config root (git_policy ()) |> pull_request_config in
+      let attempts = ref 0 in
+      let batch_pull_request_handoff _config ~head_branch:_ =
+        incr attempts;
+        if !attempts = 1 then Error "batch branch push failed: exit 1: rejected" else Ok None
+      in
+      let orchestrator =
+        Orchestrator.make ~fetch:(fun _ -> []) ~batch_pull_request_handoff ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      (match (Orchestrator.get_state orchestrator).Runtime_state.pull_request with
+      | Some handoff ->
+          Alcotest.(check string) "failure status" "retryable_failure" handoff.status;
+          Alcotest.(check (option string)) "failure error" (Some "batch branch push failed: exit 1: rejected") handoff.error
+      | None -> Alcotest.fail "expected failed handoff state");
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check int) "retried on later idle poll" 2 !attempts;
+      match (Orchestrator.get_state orchestrator).Runtime_state.pull_request with
+      | Some handoff -> Alcotest.(check string) "eventual status" "completed" handoff.status
+      | None -> Alcotest.fail "expected completed handoff state")
+
+let test_orchestrator_blocks_batch_pull_request_on_attention () =
+  with_temp_dir "symphony-batch-pr-attention-" (fun root ->
+      init_repo root "feature/start";
+      let config = base_orchestrator_config root (git_policy ()) |> pull_request_config in
+      let attempts = ref 0 in
+      let batch_pull_request_handoff _config ~head_branch:_ =
+        incr attempts;
+        Ok None
+      in
+      let issue = Issue.empty ~id:"I-attn" ~identifier:"#99" ~title:"Needs merge" ~state:"Human attention" in
+      let orchestrator =
+        Orchestrator.make ~fetch:(fun _ -> [ issue ]) ~batch_pull_request_handoff ~config
+          ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check int) "no handoff while attention remains" 0 !attempts;
+      Alcotest.(check bool) "no handoff state" true
+        (Option.is_none (Orchestrator.get_state orchestrator).Runtime_state.pull_request))
+
+let test_batch_pull_request_handoff_reuses_existing_pr () =
+  with_temp_dir "symphony-batch-pr-existing-" (fun root ->
+      let remote = Filename.concat root "remote.git" in
+      let repo = Filename.concat root "repo" in
+      let bin = Filename.concat root "bin" in
+      Unix.mkdir repo 0o755;
+      Unix.mkdir bin 0o755;
+      ignore (run_ok ~cwd:root "bare remote" ("git init -q --bare " ^ Util.shell_quote remote));
+      init_repo repo "feature/start";
+      ignore (run_ok ~cwd:repo "add origin" ("git remote add origin " ^ Util.shell_quote remote));
+      let gh_log = Filename.concat root "gh.log" in
+      let gh_path = Filename.concat bin "gh" in
+      Util.write_file gh_path
+        (Printf.sprintf
+           {|#!/bin/sh
+printf '%%s\n' "$*" >> %s
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  printf '[{"url":"https://github.example/acme/widgets/pull/9"}]\n'
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  exit 42
+fi
+exit 1
+|}
+           (Util.shell_quote gh_log));
+      Unix.chmod gh_path 0o755;
+      let original_path = Sys.getenv_opt "PATH" in
+      Fun.protect
+        ~finally:(fun () -> match original_path with Some path -> Unix.putenv "PATH" path | None -> Unix.putenv "PATH" "")
+        (fun () ->
+          Unix.putenv "PATH" (bin ^ ":" ^ Option.value original_path ~default:"");
+          let config = base_orchestrator_config repo (git_policy ()) |> pull_request_config in
+          match Orchestrator.gh_batch_pull_request_handoff config ~head_branch:"feature/start" with
+          | Error error -> Alcotest.fail error
+          | Ok url ->
+              Alcotest.(check (option string)) "existing PR URL" (Some "https://github.example/acme/widgets/pull/9") url;
+              Alcotest.(check bool) "remote loop-start branch pushed" true
+                (Sys.command ("git --git-dir " ^ Util.shell_quote remote ^ " show-ref --verify --quiet refs/heads/feature/start") = 0);
+              let lines = Util.read_file gh_log |> Util.split_lines in
+              Alcotest.(check bool) "looked for existing PR" true
+                (List.exists (Util.starts_with ~prefix:"pr list") lines);
+              Alcotest.(check bool) "did not create duplicate" false
+                (List.exists (Util.starts_with ~prefix:"pr create") lines)))
 
 let test_orchestrator_requires_clean_loop_start_for_new_worktree () =
   with_temp_dir "symphony-dirty-loop-" (fun root ->
@@ -1842,6 +2004,7 @@ let () =
           Alcotest.test_case "normalizes legacy codex app-server command" `Quick test_legacy_codex_app_server_command_normalizes_to_exec;
           Alcotest.test_case "derives kanban status order from transitions" `Quick test_project_status_order_uses_transition_flow;
           Alcotest.test_case "parses git policy and stage push" `Quick test_config_parses_git_policy_and_stage_push;
+          Alcotest.test_case "requires pull request base branch when enabled" `Quick test_pull_request_base_branch_readiness_gap;
         ] );
       ("runtime-state", [ Alcotest.test_case "exposes running issue details" `Quick test_runtime_state_exposes_running_issue_details ]);
       ( "server",
@@ -1877,6 +2040,10 @@ let () =
           Alcotest.test_case "does not retry empty required commits" `Quick test_orchestrator_does_not_retry_empty_commit;
           Alcotest.test_case "notifies repeated state mutations" `Quick test_orchestrator_notifies_each_state_mutation;
           Alcotest.test_case "creates task worktree and branch" `Quick test_orchestrator_creates_task_worktree_and_branch;
+          Alcotest.test_case "opens batch pull request once when idle" `Quick test_orchestrator_opens_batch_pull_request_once_when_idle;
+          Alcotest.test_case "retries failed batch pull request handoff" `Quick test_orchestrator_retries_batch_pull_request_handoff_failure;
+          Alcotest.test_case "blocks batch pull request on attention" `Quick test_orchestrator_blocks_batch_pull_request_on_attention;
+          Alcotest.test_case "reuses existing batch pull request" `Quick test_batch_pull_request_handoff_reuses_existing_pr;
           Alcotest.test_case "requires clean loop-start worktree" `Quick test_orchestrator_requires_clean_loop_start_for_new_worktree;
           Alcotest.test_case "reuses existing task branch on restart" `Quick test_orchestrator_reuses_existing_task_branch_on_restart;
           Alcotest.test_case "reuses worktree for existing in-progress task"


### PR DESCRIPTION
## Summary
- add `pullRequest` runtime settings with defaults and readiness validation
- open one Batch Pull Request after Orchestration Idle, with branch push, duplicate PR detection, and retryable Runtime State failures
- document the new policy and add backend coverage for idle, retry, attention blocking, and duplicate avoidance

## Validation
- pnpm backend:test
- pnpm test
- pnpm build
- pnpm frontend:test

Closes #5
