### PR TITLE
feat: add Codex stage goal handoff

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -251,6 +251,7 @@ _Avoid_: reinitialize, reset
 - Symphony does not invent **Goal Usage** when Codex output does not report it.
 - **Goal Usage** may include goal status, time used, and token usage when Codex reports those fields.
 - **Goal Usage** belongs in **Runtime State**.
+- **Goal Usage** remains in **Runtime State** when a task moves from running to retrying or attention-needed state.
 - The **Web Dashboard** shows **Goal Usage** in task execution details when available.
 - **Goal Usage** is not a primary **Web Dashboard** metric.
 - **Stage Goal Handoff** does not change retry, completion, status transition, commit, push, auto-merge, or Batch Pull Request behavior.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ Configure or disable this in `.symphony/settings.json`:
         "agent": "planner",
         "successStatus": "To-Do",
         "retryStatus": "Backlog",
+        "goal": {
+          "enabled": false
+        },
         "commit": {
           "enabled": false,
           "type": "feature",
@@ -170,6 +173,9 @@ Configure or disable this in `.symphony/settings.json`:
         "startStatus": "In progress",
         "successStatus": "In review",
         "retryStatus": "To-Do",
+        "goal": {
+          "enabled": false
+        },
         "commit": {
           "enabled": true,
           "type": "feature",
@@ -182,6 +188,9 @@ Configure or disable this in `.symphony/settings.json`:
         "agent": "reviewer",
         "successStatus": "Done",
         "retryStatus": "In progress",
+        "goal": {
+          "enabled": false
+        },
         "commit": {
           "enabled": false,
           "type": "refactor",
@@ -195,6 +204,23 @@ Configure or disable this in `.symphony/settings.json`:
 ```
 
 Set `"enabled": false` to use the single base `.symphony/prompt.md` for every issue.
+
+Set `goal.enabled` to `true` on a specific stage to enable Stage Goal Handoff for that stage only.
+When enabled, Symphony sends `/goal` with deterministic Stage Goal Context before the normal Agent
+Prompt. Stage Goal Context includes issue identifier, title, description, URL, current project
+status, labels, priority when present, blocker references when present, attempt, and stage agent
+name. It omits issue creation and update timestamps.
+
+Stage Goal Handoff requires Codex goals in `~/.codex/config.toml`:
+
+```toml
+[features]
+goals = true
+```
+
+If a stage enables goal handoff but Codex goals are not enabled, Symphony reports a Readiness Gap.
+Goal Usage reported by Codex is stored in Runtime State for running, retrying, and attention-needed
+task details when available; missing or unparseable Goal Usage does not fail a task.
 
 Stage commits run after an agent exits successfully and before Symphony moves the issue to the
 stage's `successStatus`. Set `commit.enabled` per stage to control which transitions create commits;

--- a/apps/backend/lib/config.ml
+++ b/apps/backend/lib/config.ml
@@ -36,12 +36,14 @@ type codex = {
 type server = { port : int option }
 type pull_request = { enabled : bool; base_branch : string; title : string; body : string }
 type stage_commit = { enabled : bool; commit_type : string; message : string; push : bool }
+type stage_goal = { enabled : bool }
 type stage_agent = {
   states : string list;
   agent : string;
   start_status : string option;
   success_status : string option;
   retry_status : string option;
+  goal : stage_goal option;
   commit : stage_commit option;
 }
 
@@ -99,6 +101,7 @@ let default_stage_agents =
       start_status = None;
       success_status = Some "To-Do";
       retry_status = Some "Backlog";
+      goal = Some { enabled = false };
       commit = Some { enabled = false; commit_type = "feature"; message = default_commit_message; push = false };
     };
     {
@@ -107,6 +110,7 @@ let default_stage_agents =
       start_status = Some "In progress";
       success_status = Some "In review";
       retry_status = Some "To-Do";
+      goal = Some { enabled = false };
       commit = Some { enabled = true; commit_type = "feature"; message = default_commit_message; push = false };
     };
     {
@@ -115,6 +119,7 @@ let default_stage_agents =
       start_status = None;
       success_status = Some "Done";
       retry_status = Some "In progress";
+      goal = Some { enabled = false };
       commit = Some { enabled = false; commit_type = "refactor"; message = default_commit_message; push = false };
     };
   ]
@@ -269,6 +274,8 @@ let json_object_list name json =
   match member name json with `List values -> values | _ -> []
 
 let json_stage_agent json =
+  let goal_raw = member "goal" json in
+  let goal = match goal_raw with `Assoc _ -> Some { enabled = json_bool "enabled" goal_raw ~default:false } | _ -> None in
   let commit_raw = member "commit" json in
   let commit =
     match commit_raw with
@@ -288,8 +295,97 @@ let json_stage_agent json =
     start_status = json_optional_string "startStatus" json;
     success_status = json_optional_string "successStatus" json;
     retry_status = json_optional_string "retryStatus" json;
+    goal;
     commit;
   }
+
+let stage_goal_enabled (stage : stage_agent) = match stage.goal with Some goal -> goal.enabled | None -> false
+
+let stage_goal_handoff_enabled config =
+  config.stage_agents.enabled && List.exists stage_goal_enabled config.stage_agents.stages
+
+let codex_config_path () =
+  match Sys.getenv_opt "HOME" with
+  | Some home when Util.trim home <> "" -> Filename.concat (Filename.concat home ".codex") "config.toml"
+  | _ -> Filename.concat (Filename.concat (Unix.getcwd ()) ".codex") "config.toml"
+
+let line_without_comment line =
+  match String.index_opt line '#' with
+  | Some index -> String.sub line 0 index
+  | None -> line
+  |> Util.trim
+
+let codex_goals_feature_enabled path =
+  if not (Sys.file_exists path) then false
+  else
+    let lines = Util.read_file path |> String.split_on_char '\n' in
+    let in_features = ref false in
+    List.exists
+      (fun line ->
+        let line = line_without_comment line in
+        if String.length line >= 2 && line.[0] = '[' && line.[String.length line - 1] = ']' then (
+          let section = String.sub line 1 (String.length line - 2) |> Util.trim in
+          in_features := section = "features";
+          false)
+        else
+          !in_features
+          &&
+          match String.split_on_char '=' line with
+          | [ key; value ] -> Util.trim key = "goals" && Util.trim value = "true"
+          | _ -> false)
+      lines
+
+let codex_goal_stdin_probe_enabled () =
+  match Sys.getenv_opt "SYMPHONY_CODEX_GOAL_STDIN_PROBE" with Some "1" | Some "true" -> true | _ -> false
+
+let replace_angle_token ~token ~value text =
+  String.split_on_char '<' text
+  |> List.mapi (fun index part ->
+         if index = 0 then part
+         else
+           match String.split_on_char '>' part with
+           | key :: rest when key = token -> value ^ String.concat ">" rest
+           | _ -> "<" ^ part)
+  |> String.concat ""
+
+let codex_probe_command config =
+  config.codex.command
+  |> replace_angle_token ~token:"model" ~value:(Util.shell_quote config.codex.model)
+  |> replace_angle_token ~token:"reasoning" ~value:(Util.shell_quote config.codex.reasoning_effort)
+
+let is_env_assignment word =
+  match String.index_opt word '=' with
+  | None -> false
+  | Some index -> index > 0
+
+let rec drop_env_assignments = function
+  | word :: rest when is_env_assignment word -> drop_env_assignments rest
+  | words -> words
+
+let static_codex_exec_command command =
+  let words = String.split_on_char ' ' command |> List.filter (fun word -> Util.trim word <> "") in
+  let words =
+    match words with
+    | "env" :: rest -> rest
+    | _ -> words
+    |> drop_env_assignments
+  in
+  match words with
+  | executable :: rest when Filename.basename executable = "codex" -> List.exists (( = ) "exec") rest
+  | _ -> false
+
+let codex_goal_stdin_supported config =
+  let command = Util.trim config.codex.command in
+  if command = "" then false
+  else if not (codex_goal_stdin_probe_enabled ()) then
+    static_codex_exec_command command
+  else
+    let probe = "/goal Verify Codex goal stdin support.\n\nReturn ok.\n" in
+    let command = codex_probe_command config in
+    let shell_command =
+      Printf.sprintf "printf %%s %s | timeout 20s %s >/dev/null 2>&1" (Util.shell_quote probe) command
+    in
+    match Unix.system shell_command with Unix.WEXITED 0 -> true | _ -> false
 
 let from_settings_file ~workspace_root path =
   let root =
@@ -424,6 +520,14 @@ let readiness_gaps config =
     add "project.terminalStates" "Add at least one terminal project state in .symphony/settings.json.";
   if config.pull_request.enabled && Util.trim config.pull_request.base_branch = "" then
     add "pullRequest.baseBranch" "Set pullRequest.baseBranch in .symphony/settings.json when pullRequest.enabled is true.";
+  if stage_goal_handoff_enabled config then (
+    let codex_config = codex_config_path () in
+    if not (codex_goals_feature_enabled codex_config) then
+      add "codex.goals"
+        "Add the following to ~/.codex/config.toml to enable Stage Goal Handoff:\n\n[features]\ngoals = true";
+    if not (codex_goal_stdin_supported config) then
+      add "codex.goalStdin"
+        "Use a Codex command that accepts /goal from standard input before enabling Stage Goal Handoff.");
   if config.stage_agents.enabled then (
     if not (Sys.file_exists config.stage_agents.root && Sys.is_directory config.stage_agents.root) then
       add "stageAgents.root" "Create .symphony/agents or set stageAgents.enabled to false.";

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -172,11 +172,50 @@ let agent_prompt config issue =
         let path = agent_file config agent in
         if Sys.file_exists path then Some (agent, Util.read_file path |> Util.trim) else None
 
-let compose_prompt config issue base_prompt =
+let normal_prompt config issue base_prompt =
   match agent_prompt config issue with
   | None -> base_prompt
   | Some (agent, prompt) ->
       Printf.sprintf "%s\n\n---\n\nStage agent: %s\n\n%s\n" prompt agent base_prompt
+
+let stage_goal_handoff_stage config issue =
+  match stage_for_issue config issue with
+  | Some stage when Config.stage_goal_enabled stage -> Some stage
+  | _ -> None
+
+let json_option_string = function Some value when Util.trim value <> "" -> `String value | _ -> `Null
+let json_option_int = function Some value -> `Int value | None -> `Null
+
+let blocker_to_goal_json (blocker : Issue.blocker) =
+  `Assoc
+    [
+      ("id", json_option_string blocker.id);
+      ("identifier", json_option_string blocker.identifier);
+      ("state", json_option_string blocker.state);
+    ]
+
+let stage_goal_context issue attempt (stage : Config.stage_agent) =
+  `Assoc
+    [
+      ("kind", `String "Stage Goal Context");
+      ("issue_identifier", `String issue.Issue.identifier);
+      ("title", `String issue.title);
+      ("description", json_option_string issue.description);
+      ("url", json_option_string issue.url);
+      ("current_project_status", `String issue.state);
+      ("labels", `List (List.map (fun label -> `String label) issue.labels));
+      ("priority", json_option_int issue.priority);
+      ("blocker_references", `List (List.map blocker_to_goal_json issue.blocked_by));
+      ("attempt", `Int (Option.value attempt ~default:0));
+      ("stage_agent_name", `String stage.agent);
+    ]
+  |> Yojson.Safe.to_string
+
+let compose_prompt config issue attempt base_prompt =
+  let prompt = normal_prompt config issue base_prompt in
+  match stage_goal_handoff_stage config issue with
+  | None -> prompt
+  | Some stage -> Printf.sprintf "/goal %s\n\n---\n\n%s" (stage_goal_context issue attempt stage) prompt
 
 let replace_token ~token ~value text =
   String.split_on_char '<' text
@@ -529,6 +568,99 @@ let parse_tokens stdout_path stderr_path =
     total_tokens = find_int_key "total_tokens" content;
   }
 
+let json_member name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+
+let json_string_member name json =
+  match json_member name json with Some (`String value) when Util.trim value <> "" -> Some value | _ -> None
+
+let json_int_member name json =
+  match json_member name json with
+  | Some (`Int value) -> Some value
+  | Some (`Float value) -> Some (int_of_float value)
+  | Some (`String value) -> int_of_string_opt (Util.trim value)
+  | _ -> None
+
+let json_float_member name json =
+  match json_member name json with
+  | Some (`Float value) -> Some value
+  | Some (`Int value) -> Some (float_of_int value)
+  | Some (`String value) -> (try Some (float_of_string (Util.trim value)) with Failure _ -> None)
+  | _ -> None
+
+let first_some values = List.find_map Fun.id values
+
+let nested_json_member names json =
+  names
+  |> List.find_map (fun name ->
+         match json_member name json with Some (`Assoc _ as value) -> Some value | _ -> None)
+
+let nested_int_member containers keys json =
+  containers
+  |> List.find_map (fun container ->
+         match nested_json_member [ container ] json with
+         | Some nested -> first_some (List.map (fun key -> json_int_member key nested) keys)
+         | None -> None)
+
+let goal_usage_from_json ?(allow_top_level = false) json =
+  let source =
+    match json_member "goal_usage" json with
+    | Some (`Assoc _ as usage) -> Some usage
+    | _ -> (
+        match json_member "goalUsage" json with
+        | Some (`Assoc _ as usage) -> Some usage
+        | _ -> (
+            match json_member "goal" json with
+            | Some (`Assoc _ as goal) -> (
+                match json_member "usage" goal with Some (`Assoc _ as usage) -> Some usage | _ -> Some goal)
+            | _ -> if allow_top_level then Some json else None))
+  in
+  match source with
+  | None -> None
+  | Some usage ->
+      let result =
+        {
+          Runtime_state.status = first_some [ json_string_member "status" usage; json_string_member "goal_status" usage; json_string_member "goalStatus" usage ];
+          time_used_seconds =
+            first_some
+              [
+                json_float_member "time_used_seconds" usage;
+                json_float_member "timeUsedSeconds" usage;
+                json_float_member "duration_seconds" usage;
+                json_float_member "durationSeconds" usage;
+              ];
+          tokens_used =
+            first_some
+              [
+                json_int_member "tokens_used" usage;
+                json_int_member "tokensUsed" usage;
+                nested_int_member [ "tokens"; "token_usage"; "tokenUsage" ]
+                  [ "total_tokens"; "totalTokens"; "tokens_used"; "tokensUsed" ]
+                  usage;
+              ];
+        }
+      in
+      if result.status = None && result.time_used_seconds = None && result.tokens_used = None then None else Some result
+
+let parse_goal_usage_from_line line =
+  let line = Util.trim line in
+  let lower_line = String.lowercase_ascii line in
+  let json_text =
+    if String.starts_with ~prefix:"goal usage:" lower_line then
+      Some (true, String.sub line 11 (String.length line - 11) |> Util.trim)
+    else if String.length line > 0 && line.[0] = '{' then Some (false, line)
+    else None
+  in
+  match json_text with
+  | None -> None
+  | Some (allow_top_level, text) -> (
+      try Yojson.Safe.from_string text |> goal_usage_from_json ~allow_top_level with Yojson.Json_error _ -> None)
+
+let parse_goal_usage stdout_path stderr_path =
+  let content = file_contents stdout_path ^ "\n" ^ file_contents stderr_path in
+  content |> String.split_on_char '\n' |> List.filter_map parse_goal_usage_from_line |> List.rev |> List.find_opt (fun _ -> true)
+
 let max_tokens a b =
   {
     Runtime_state.input_tokens = max a.Runtime_state.input_tokens b.Runtime_state.input_tokens;
@@ -634,7 +766,7 @@ let dispatch_issue orchestrator issue =
         let issue = match target_start_status with Some state -> { issue with Issue.state } | None -> issue in
         let attempt = Hashtbl.find_opt orchestrator.attempts issue.id in
         let rendered = Prompt.render ~issue ~attempt orchestrator.prompt_template in
-        let prompt = compose_prompt orchestrator.config issue rendered in
+        let prompt = compose_prompt orchestrator.config issue attempt rendered in
         let launched = orchestrator.launch ~config:orchestrator.config ~workspace ~prompt ~issue in
         let now = Util.now_iso8601 () in
         let row =
@@ -647,6 +779,7 @@ let dispatch_issue orchestrator issue =
             started_at = now;
             last_event_at = Some now;
             tokens = runtime_tokens;
+            goal_usage = None;
           }
         in
         Hashtbl.remove orchestrator.retry_due issue.id;
@@ -709,6 +842,7 @@ let mark_retrying orchestrator issue_id error =
               attempt = next_attempt;
               due_at;
               error = Some error;
+              goal_usage = row.goal_usage;
             }
             :: List.filter (fun (retry : Runtime_state.retrying) -> retry.issue_id <> issue_id) state.retrying;
           issue_errors =
@@ -746,6 +880,7 @@ let mark_blocked orchestrator issue_id error =
               Runtime_state.issue_id;
               issue_identifier = row.issue.identifier;
               error;
+              goal_usage = row.goal_usage;
             }
             :: List.filter (fun (issue_error : Runtime_state.issue_error) -> issue_error.issue_id <> issue_id) state.issue_errors;
           last_error = Some error;
@@ -796,6 +931,11 @@ let auto_merge_child orchestrator child =
 let mark_merge_attention orchestrator child error =
   set_error orchestrator error;
   ignore (move_issue_status orchestrator child.issue orchestrator.config.git.merge_attention_status);
+  let goal_usage =
+    match List.find_opt (fun (row : Runtime_state.running) -> row.issue.id = child.issue_id) orchestrator.state.running with
+    | Some row -> row.goal_usage
+    | None -> None
+  in
   update_state orchestrator (fun state ->
     {
       state with
@@ -806,6 +946,7 @@ let mark_merge_attention orchestrator child error =
           Runtime_state.issue_id = child.issue_id;
           issue_identifier = child.issue_identifier;
           error;
+          goal_usage;
         }
         :: List.filter (fun (issue_error : Runtime_state.issue_error) -> issue_error.issue_id <> child.issue_id) state.issue_errors;
       last_error = Some error;
@@ -835,15 +976,16 @@ let mark_completed orchestrator child =
 let kill_child child =
   try Unix.kill child.pid Sys.sigterm with Unix.Unix_error _ -> ()
 
-let refresh_child_output orchestrator child =
+let refresh_child_output ?(force = false) orchestrator child =
   let stdout_size = file_size child.stdout_path in
   let stderr_size = file_size child.stderr_path in
-  if stdout_size <> child.stdout_size || stderr_size <> child.stderr_size then (
+  if force || stdout_size <> child.stdout_size || stderr_size <> child.stderr_size then (
     child.stdout_size <- stdout_size;
     child.stderr_size <- stderr_size;
     child.last_output_at <- Unix.time ();
     let now = Util.now_iso8601 () in
     let tokens = parse_tokens child.stdout_path child.stderr_path in
+    let goal_usage = parse_goal_usage child.stdout_path child.stderr_path in
     update_state orchestrator (fun state -> { state with codex_totals = max_tokens state.codex_totals tokens });
     update_running orchestrator child.issue_id (fun row ->
         {
@@ -852,6 +994,7 @@ let refresh_child_output orchestrator child =
           last_message = Some "stdout/stderr updated";
           last_event_at = Some now;
           tokens = max_tokens row.tokens tokens;
+          goal_usage = (match goal_usage with Some _ -> goal_usage | None -> row.goal_usage);
         }))
 
 let reap_children orchestrator =
@@ -864,6 +1007,7 @@ let reap_children orchestrator =
           now -. child.started_at > float_of_int orchestrator.config.codex.turn_timeout_ms /. 1000.
           || now -. child.last_output_at > float_of_int orchestrator.config.codex.stall_timeout_ms /. 1000.
         then (
+          refresh_child_output ~force:true orchestrator child;
           kill_child child;
           mark_retrying orchestrator child.issue_id "agent timed out";
           (child.issue_id :: finished, running))
@@ -871,12 +1015,15 @@ let reap_children orchestrator =
           match Unix.waitpid [ Unix.WNOHANG ] child.pid with
           | 0, _ -> (finished, child :: running)
           | _, Unix.WEXITED 0 ->
+              refresh_child_output ~force:true orchestrator child;
               mark_completed orchestrator child;
               (child.issue_id :: finished, running)
           | _, Unix.WEXITED code ->
+              refresh_child_output ~force:true orchestrator child;
               mark_retrying orchestrator child.issue_id (Printf.sprintf "agent exited with code %d" code);
               (child.issue_id :: finished, running)
           | _, Unix.WSIGNALED signal ->
+              refresh_child_output ~force:true orchestrator child;
               mark_retrying orchestrator child.issue_id (Printf.sprintf "agent signaled %d" signal);
               (child.issue_id :: finished, running)
           | _, Unix.WSTOPPED signal ->

--- a/apps/backend/lib/runtime_home.ml
+++ b/apps/backend/lib/runtime_home.ml
@@ -65,6 +65,9 @@ let settings_json =
         "agent": "planner",
         "successStatus": "To-Do",
         "retryStatus": "Backlog",
+        "goal": {
+          "enabled": false
+        },
         "commit": {
           "enabled": false,
           "type": "feature",
@@ -78,6 +81,9 @@ let settings_json =
         "startStatus": "In progress",
         "successStatus": "In review",
         "retryStatus": "To-Do",
+        "goal": {
+          "enabled": false
+        },
         "commit": {
           "enabled": true,
           "type": "feature",
@@ -90,6 +96,9 @@ let settings_json =
         "agent": "reviewer",
         "successStatus": "Done",
         "retryStatus": "In progress",
+        "goal": {
+          "enabled": false
+        },
         "commit": {
           "enabled": false,
           "type": "refactor",

--- a/apps/backend/lib/runtime_state.ml
+++ b/apps/backend/lib/runtime_state.ml
@@ -1,4 +1,5 @@
 type tokens = { input_tokens : int; output_tokens : int; total_tokens : int }
+type goal_usage = { status : string option; time_used_seconds : float option; tokens_used : int option }
 
 type running = {
   issue : Issue.t;
@@ -9,10 +10,18 @@ type running = {
   started_at : string;
   last_event_at : string option;
   tokens : tokens;
+  goal_usage : goal_usage option;
 }
 
-type retrying = { issue_id : string; issue_identifier : string; attempt : int; due_at : string; error : string option }
-type issue_error = { issue_id : string; issue_identifier : string; error : string }
+type retrying = {
+  issue_id : string;
+  issue_identifier : string;
+  attempt : int;
+  due_at : string;
+  error : string option;
+  goal_usage : goal_usage option;
+}
+type issue_error = { issue_id : string; issue_identifier : string; error : string; goal_usage : goal_usage option }
 type readiness_gap = { requirement : string; remediation : string }
 type pull_request_handoff = {
   enabled : bool;
@@ -60,6 +69,14 @@ let tokens_to_yojson tokens =
       ("total_tokens", `Int tokens.total_tokens);
     ]
 
+let goal_usage_to_yojson (usage : goal_usage) =
+  `Assoc
+    [
+      ("status", (match usage.status with Some value -> `String value | None -> `Null));
+      ("time_used_seconds", (match usage.time_used_seconds with Some value -> `Float value | None -> `Null));
+      ("tokens_used", (match usage.tokens_used with Some value -> `Int value | None -> `Null));
+    ]
+
 let issue_to_yojson issue =
   `Assoc
     [
@@ -89,6 +106,7 @@ let running_to_yojson row =
       ("started_at", `String row.started_at);
       ("last_event_at", (match row.last_event_at with Some s -> `String s | None -> `Null));
       ("tokens", tokens_to_yojson row.tokens);
+      ("goal_usage", (match row.goal_usage with Some usage -> goal_usage_to_yojson usage | None -> `Null));
     ]
 
 let retrying_to_yojson (row : retrying) =
@@ -99,6 +117,7 @@ let retrying_to_yojson (row : retrying) =
       ("attempt", `Int row.attempt);
       ("due_at", `String row.due_at);
       ("error", (match row.error with Some s -> `String s | None -> `Null));
+      ("goal_usage", (match row.goal_usage with Some usage -> goal_usage_to_yojson usage | None -> `Null));
     ]
 
 let issue_error_to_yojson (row : issue_error) =
@@ -107,6 +126,7 @@ let issue_error_to_yojson (row : issue_error) =
       ("issue_id", `String row.issue_id);
       ("issue_identifier", `String row.issue_identifier);
       ("error", `String row.error);
+      ("goal_usage", (match row.goal_usage with Some usage -> goal_usage_to_yojson usage | None -> `Null));
     ]
 
 let readiness_gap_to_yojson row =

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -94,6 +94,198 @@ let test_config_parses_git_policy_and_stage_push () =
           Alcotest.(check bool) "stage push default" false reviewer_commit.push
       | _ -> Alcotest.fail "expected stage commit policy")
 
+let test_config_parses_stage_goal_and_readiness () =
+  let original_home = Sys.getenv_opt "HOME" in
+  let original_probe = Sys.getenv_opt "SYMPHONY_CODEX_GOAL_STDIN_PROBE" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match original_home with Some value -> Unix.putenv "HOME" value | None -> Unix.putenv "HOME" "");
+      match original_probe with
+      | Some value -> Unix.putenv "SYMPHONY_CODEX_GOAL_STDIN_PROBE" value
+      | None -> Unix.putenv "SYMPHONY_CODEX_GOAL_STDIN_PROBE" "")
+    (fun () ->
+      with_temp_dir "symphony-stage-goal-" (fun root ->
+          Unix.putenv "HOME" root;
+          Unix.putenv "SYMPHONY_CODEX_GOAL_STDIN_PROBE" "";
+          Unix.putenv "GITHUB_TOKEN" "token";
+          let agents_root = Filename.concat root ".symphony/agents" in
+          Util.mkdir_p agents_root;
+          Util.write_file (Filename.concat agents_root "engineer.md") "Engineer";
+          let settings = Filename.concat root "settings.json" in
+          Util.write_file settings
+            {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "stageAgents": {
+    "enabled": true,
+    "root": ".symphony/agents",
+    "stages": [
+      {"states": ["Todo"], "agent": "engineer", "goal": {"enabled": true}}
+    ]
+  }
+}|};
+          let config = Config.from_settings_file ~workspace_root:root settings in
+          (match config.stage_agents.stages with
+          | [ stage ] -> Alcotest.(check bool) "goal enabled" true (Config.stage_goal_enabled stage)
+          | _ -> Alcotest.fail "expected one stage");
+          let gaps = Config.readiness_gaps config in
+          Alcotest.(check bool) "missing codex goals gap" true
+            (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "codex.goals") gaps);
+          Util.mkdir_p (Filename.concat root ".codex");
+          Util.write_file (Filename.concat (Filename.concat root ".codex") "config.toml") "[ features ]\ngoals = true # enable Codex goals\n";
+          let gaps = Config.readiness_gaps config in
+          Alcotest.(check bool) "codex goals gap resolved" false
+            (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "codex.goals") gaps)))
+
+let test_disabled_stage_goal_does_not_require_codex_goals () =
+  let original_home = Sys.getenv_opt "HOME" in
+  Fun.protect
+    ~finally:(fun () -> match original_home with Some value -> Unix.putenv "HOME" value | None -> Unix.putenv "HOME" "")
+    (fun () ->
+      with_temp_dir "symphony-stage-goal-disabled-" (fun root ->
+          Unix.putenv "HOME" root;
+          Unix.putenv "GITHUB_TOKEN" "token";
+          let agents_root = Filename.concat root ".symphony/agents" in
+          Util.mkdir_p agents_root;
+          Util.write_file (Filename.concat agents_root "engineer.md") "Engineer";
+          let settings = Filename.concat root "settings.json" in
+          Util.write_file settings
+            {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "stageAgents": {
+    "enabled": true,
+    "root": ".symphony/agents",
+    "stages": [
+      {"states": ["Todo"], "agent": "engineer", "goal": {"enabled": false}}
+    ]
+  }
+}|};
+          let config = Config.from_settings_file ~workspace_root:root settings in
+          let gaps = Config.readiness_gaps config in
+          Alcotest.(check bool) "no codex goals gap" false
+            (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "codex.goals") gaps);
+          Alcotest.(check bool) "no stdin gap" false
+            (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "codex.goalStdin") gaps)))
+
+let test_stage_goal_requires_codex_exec_stdin_support () =
+  let original_home = Sys.getenv_opt "HOME" in
+  Fun.protect
+    ~finally:(fun () -> match original_home with Some value -> Unix.putenv "HOME" value | None -> Unix.putenv "HOME" "")
+    (fun () ->
+      with_temp_dir "symphony-stage-goal-stdin-" (fun root ->
+          Unix.putenv "HOME" root;
+          Unix.putenv "GITHUB_TOKEN" "token";
+          Util.mkdir_p (Filename.concat root ".codex");
+          Util.write_file (Filename.concat (Filename.concat root ".codex") "config.toml") "[features]\ngoals = true\n";
+          let agents_root = Filename.concat root ".symphony/agents" in
+          Util.mkdir_p agents_root;
+          Util.write_file (Filename.concat agents_root "engineer.md") "Engineer";
+          let settings = Filename.concat root "settings.json" in
+          Util.write_file settings
+            {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "codex": {"command": "cat"},
+  "stageAgents": {
+    "enabled": true,
+    "root": ".symphony/agents",
+    "stages": [
+      {"states": ["Todo"], "agent": "engineer", "goal": {"enabled": true}}
+    ]
+  }
+}|};
+          let config = Config.from_settings_file ~workspace_root:root settings in
+          let gaps = Config.readiness_gaps config in
+          Alcotest.(check bool) "stdin gap" true
+            (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "codex.goalStdin") gaps);
+          Util.write_file settings
+            {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "codex": {"command": "env CODEX_HOME=/tmp/codex /usr/local/bin/codex -m <model> exec"},
+  "stageAgents": {
+    "enabled": true,
+    "root": ".symphony/agents",
+    "stages": [
+      {"states": ["Todo"], "agent": "engineer", "goal": {"enabled": true}}
+    ]
+  }
+}|};
+          let config = Config.from_settings_file ~workspace_root:root settings in
+          let gaps = Config.readiness_gaps config in
+          Alcotest.(check bool) "codex exec path accepted with env" false
+            (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "codex.goalStdin") gaps);
+          Util.write_file settings
+            {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "codex": {"command": "printf codex exec"},
+  "stageAgents": {
+    "enabled": true,
+    "root": ".symphony/agents",
+    "stages": [
+      {"states": ["Todo"], "agent": "engineer", "goal": {"enabled": true}}
+    ]
+  }
+}|};
+          let config = Config.from_settings_file ~workspace_root:root settings in
+          let gaps = Config.readiness_gaps config in
+          Alcotest.(check bool) "codex as argument rejected" true
+            (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "codex.goalStdin") gaps)))
+
+let test_stage_goal_live_stdin_probe () =
+  let original_home = Sys.getenv_opt "HOME" in
+  let original_probe = Sys.getenv_opt "SYMPHONY_CODEX_GOAL_STDIN_PROBE" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match original_home with Some value -> Unix.putenv "HOME" value | None -> Unix.putenv "HOME" "");
+      match original_probe with
+      | Some value -> Unix.putenv "SYMPHONY_CODEX_GOAL_STDIN_PROBE" value
+      | None -> Unix.putenv "SYMPHONY_CODEX_GOAL_STDIN_PROBE" "")
+    (fun () ->
+      with_temp_dir "symphony-stage-goal-live-probe-" (fun root ->
+          Unix.putenv "HOME" root;
+          Unix.putenv "GITHUB_TOKEN" "token";
+          Unix.putenv "SYMPHONY_CODEX_GOAL_STDIN_PROBE" "1";
+          Util.mkdir_p (Filename.concat root ".codex");
+          Util.write_file (Filename.concat (Filename.concat root ".codex") "config.toml") "[features]\ngoals = true\n";
+          let agents_root = Filename.concat root ".symphony/agents" in
+          Util.mkdir_p agents_root;
+          Util.write_file (Filename.concat agents_root "engineer.md") "Engineer";
+          let fake_codex = Filename.concat root "fake-codex.sh" in
+          Util.write_file fake_codex
+            {|#!/bin/sh
+input="$(cat)"
+case "$input" in
+  /goal*) exit 0 ;;
+  *) exit 42 ;;
+esac
+|};
+          Unix.chmod fake_codex 0o755;
+          let settings = Filename.concat root "settings.json" in
+          let write_settings command =
+            Util.write_file settings
+              (Printf.sprintf
+                 {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "codex": {"command": %S, "model": "fixture-model", "reasoningEffort": "low"},
+  "stageAgents": {
+    "enabled": true,
+    "root": ".symphony/agents",
+    "stages": [
+      {"states": ["Todo"], "agent": "engineer", "goal": {"enabled": true}}
+    ]
+  }
+}|}
+                 command)
+          in
+          write_settings (fake_codex ^ " -m <model> exec");
+          let config = Config.from_settings_file ~workspace_root:root settings in
+          let gaps = Config.readiness_gaps config in
+          Alcotest.(check bool) "live probe accepted" false
+            (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "codex.goalStdin") gaps);
+          write_settings "false";
+          let config = Config.from_settings_file ~workspace_root:root settings in
+          let gaps = Config.readiness_gaps config in
+          Alcotest.(check bool) "live probe rejected" true
+            (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "codex.goalStdin") gaps)))
+
 let test_pull_request_base_branch_readiness_gap () =
   with_temp_dir "symphony-settings-pr-gap-" (fun root ->
       let settings = Filename.concat root "settings.json" in
@@ -363,6 +555,8 @@ let test_settings_and_prompt_loading () =
       (match config.stage_agents.stages with
       | planner :: engineer :: _ ->
           Alcotest.(check (option string)) "planner success status" (Some "To-Do") planner.success_status;
+          Alcotest.(check bool) "planner goal disabled" false (Config.stage_goal_enabled planner);
+          Alcotest.(check bool) "engineer goal disabled" false (Config.stage_goal_enabled engineer);
           (match engineer.Config.commit with
           | Some commit ->
               Alcotest.(check bool) "engineer commits enabled" true commit.enabled;
@@ -467,6 +661,7 @@ let test_runtime_state_exposes_running_issue_details () =
             started_at = "2026-05-04T00:00:00Z";
             last_event_at = None;
             tokens = { input_tokens = 0; output_tokens = 0; total_tokens = 0 };
+            goal_usage = None;
           };
         ];
     }
@@ -484,6 +679,66 @@ let test_runtime_state_exposes_running_issue_details () =
   Alcotest.(check (list string)) "status order"
     [ "Todo"; "In progress"; "In review"; "Done" ]
     (Runtime_state.to_yojson ordered_state |> member "status_order" |> to_list |> List.map to_string)
+
+let test_runtime_state_exposes_goal_usage_when_available () =
+  let issue = Issue.empty ~id:"I1" ~identifier:"#1" ~title:"Add goal usage" ~state:"In progress" in
+  let state =
+    {
+      (Runtime_state.empty ()) with
+      running =
+        [
+          {
+            Runtime_state.issue;
+            session_id = Some "pid:123";
+            turn_count = 0;
+            last_event = Some "agent_output";
+            last_message = Some "stdout/stderr updated";
+            started_at = "2026-05-04T00:00:00Z";
+            last_event_at = Some "2026-05-04T00:00:05Z";
+            tokens = { input_tokens = 1; output_tokens = 2; total_tokens = 3 };
+            goal_usage = Some { Runtime_state.status = Some "complete"; time_used_seconds = Some 5.; tokens_used = Some 99 };
+          };
+        ];
+    }
+  in
+  let open Yojson.Safe.Util in
+  let usage = Runtime_state.to_yojson state |> member "running" |> to_list |> List.hd |> member "goal_usage" in
+  Alcotest.(check string) "goal status" "complete" (usage |> member "status" |> to_string);
+  Alcotest.(check (float 0.01)) "goal time" 5. (usage |> member "time_used_seconds" |> to_float);
+  Alcotest.(check int) "goal tokens" 99 (usage |> member "tokens_used" |> to_int);
+  let retrying_state =
+    {
+      (Runtime_state.empty ()) with
+      retrying =
+        [
+          {
+            Runtime_state.issue_id = "I1";
+            issue_identifier = "#1";
+            attempt = 1;
+            due_at = "2026-05-04T00:01:00Z";
+            error = Some "agent exited with code 1";
+            goal_usage = Some { Runtime_state.status = Some "active"; time_used_seconds = None; tokens_used = Some 42 };
+          };
+        ];
+      issue_errors =
+        [
+          {
+            Runtime_state.issue_id = "I2";
+            issue_identifier = "#2";
+            error = "commit required but agent produced no code changes";
+            goal_usage = Some { Runtime_state.status = Some "blocked"; time_used_seconds = Some 2.; tokens_used = None };
+          };
+        ];
+    }
+  in
+  let retry_usage = Runtime_state.to_yojson retrying_state |> member "retrying" |> to_list |> List.hd |> member "goal_usage" in
+  Alcotest.(check string) "retry goal status" "active" (retry_usage |> member "status" |> to_string);
+  Alcotest.(check int) "retry goal tokens" 42 (retry_usage |> member "tokens_used" |> to_int);
+  let error_usage =
+    Runtime_state.to_yojson retrying_state |> member "issue_errors" |> to_list |> List.hd |> member "goal_usage"
+  in
+  Alcotest.(check string) "error goal status" "blocked" (error_usage |> member "status" |> to_string);
+  Alcotest.(check (float 0.01)) "error goal time" 2. (error_usage |> member "time_used_seconds" |> to_float)
 
 let websocket_request () =
   {
@@ -591,6 +846,7 @@ let test_websocket_broadcast_after_state_change () =
                 started_at = "2026-05-04T00:00:00Z";
                 last_event_at = None;
                 tokens = { input_tokens = 0; output_tokens = 0; total_tokens = 0 };
+                goal_usage = None;
               };
             ];
         };
@@ -658,6 +914,278 @@ let test_orchestrator_notifies_each_state_mutation () =
       Orchestrator.poll_once orchestrator;
       Orchestrator.poll_once orchestrator;
       Alcotest.(check int) "notifies repeated state writes" 2 !notifications)
+
+let test_orchestrator_parses_final_output_when_size_was_already_seen () =
+  with_temp_dir "symphony-final-output-" (fun root ->
+      let config =
+        {
+          Config.workflow_path = "settings.json";
+          repository_root = root;
+          tracker =
+            {
+              kind = "github";
+              owner = "acme";
+              repo = "widgets";
+              project_number = 7;
+              api_key_env = "GITHUB_TOKEN";
+              api_key = Some "token";
+              active_states = [ "Todo" ];
+              terminal_states = [ "Done" ];
+              project_status_field = "Status";
+              project_status_on_dispatch = None;
+              project_status_on_success = None;
+              project_status_on_retry = None;
+              ensure_project_statuses = true;
+            };
+          polling = { interval_ms = 1000 };
+          workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
+          agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
+          codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 1000; stall_timeout_ms = 1000 };
+          server = { port = None };
+          pull_request = Config.default_pull_request;
+          stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
+        }
+      in
+      let issue = Issue.empty ~id:"I1" ~identifier:"#1" ~title:"Fast output" ~state:"Todo" in
+      let workspace = Workspace.create_for_issue ~root:(Filename.concat root "workspaces") issue.identifier in
+      let stdout_path = Filename.concat workspace.path "stdout.log" in
+      Util.write_file stdout_path
+        {|input_tokens: 11
+output_tokens: 13
+total_tokens: 24
+Goal Usage: {"status":"complete","time_used_seconds":1.5,"tokens_used":24}
+|};
+      let pid = Unix.create_process "/bin/sh" [| "/bin/sh"; "-lc"; "true" |] Unix.stdin Unix.stdout Unix.stderr in
+      Unix.sleepf 0.05;
+      let snapshots = ref [] in
+      let orchestrator =
+        Orchestrator.make ~fetch:(fun _ -> []) ~set_status:(fun _ _ _ -> Ok ()) ~config ~prompt_template:"Issue {{ issue.identifier }}"
+          ~notify_state:(fun state -> snapshots := state :: !snapshots)
+          ()
+      in
+      Orchestrator.set_state orchestrator
+        {
+          (Runtime_state.empty ()) with
+          running =
+            [
+              {
+                Runtime_state.issue;
+                session_id = Some "pid:test";
+                turn_count = 0;
+                last_event = Some "launched";
+                last_message = None;
+                started_at = "2026-05-04T00:00:00Z";
+                last_event_at = None;
+                tokens = { input_tokens = 0; output_tokens = 0; total_tokens = 0 };
+                goal_usage = None;
+              };
+            ];
+        };
+      orchestrator.Orchestrator.children <-
+        [
+          {
+            Orchestrator.pid;
+            issue;
+            issue_id = issue.id;
+            issue_identifier = issue.identifier;
+            issue_title = issue.title;
+            workspace;
+            started_at = Unix.time ();
+            last_output_at = Unix.time ();
+            stdout_path = Some stdout_path;
+            stderr_path = None;
+            stdout_size = (Unix.stat stdout_path).Unix.st_size;
+            stderr_size = 0;
+          };
+        ];
+      Orchestrator.reap_children orchestrator;
+      let state = Orchestrator.get_state orchestrator in
+      Alcotest.(check int) "final total tokens parsed" 24 state.codex_totals.total_tokens;
+      Alcotest.(check int) "completed row removed" 0 (List.length state.running);
+      let saw_goal_usage =
+        List.exists
+          (fun (state : Runtime_state.t) ->
+            List.exists
+              (fun (row : Runtime_state.running) ->
+                match row.goal_usage with
+                | Some usage -> usage.status = Some "complete" && usage.tokens_used = Some 24
+                | None -> false)
+              state.running)
+          !snapshots
+      in
+      Alcotest.(check bool) "goal usage was exposed before completion" true saw_goal_usage)
+
+let test_orchestrator_parses_final_output_before_timeout_retry () =
+  with_temp_dir "symphony-timeout-output-" (fun root ->
+      let config =
+        {
+          Config.workflow_path = "settings.json";
+          repository_root = root;
+          tracker =
+            {
+              kind = "github";
+              owner = "acme";
+              repo = "widgets";
+              project_number = 7;
+              api_key_env = "GITHUB_TOKEN";
+              api_key = Some "token";
+              active_states = [ "Todo" ];
+              terminal_states = [ "Done" ];
+              project_status_field = "Status";
+              project_status_on_dispatch = None;
+              project_status_on_success = None;
+              project_status_on_retry = None;
+              ensure_project_statuses = true;
+            };
+          polling = { interval_ms = 1000 };
+          workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
+          agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
+          codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1; read_timeout_ms = 1000; stall_timeout_ms = 100000 };
+          server = { port = None };
+          pull_request = Config.default_pull_request;
+          stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
+        }
+      in
+      let issue = Issue.empty ~id:"I1" ~identifier:"#1" ~title:"Timeout output" ~state:"Todo" in
+      let workspace = Workspace.create_for_issue ~root:(Filename.concat root "workspaces") issue.identifier in
+      let stdout_path = Filename.concat workspace.path "stdout.log" in
+      Util.write_file stdout_path
+        {|input_tokens: 3
+output_tokens: 5
+total_tokens: 8
+Goal Usage: {"status":"active","time_used_seconds":9,"tokens_used":8}
+|};
+      let pid = Unix.create_process "/bin/sh" [| "/bin/sh"; "-lc"; "sleep 30" |] Unix.stdin Unix.stdout Unix.stderr in
+      let snapshots = ref [] in
+      let orchestrator =
+        Orchestrator.make ~fetch:(fun _ -> []) ~set_status:(fun _ _ _ -> Ok ()) ~config ~prompt_template:"Issue {{ issue.identifier }}"
+          ~notify_state:(fun state -> snapshots := state :: !snapshots)
+          ()
+      in
+      Orchestrator.set_state orchestrator
+        {
+          (Runtime_state.empty ()) with
+          running =
+            [
+              {
+                Runtime_state.issue;
+                session_id = Some "pid:timeout";
+                turn_count = 0;
+                last_event = Some "launched";
+                last_message = None;
+                started_at = "2026-05-04T00:00:00Z";
+                last_event_at = None;
+                tokens = { input_tokens = 0; output_tokens = 0; total_tokens = 0 };
+                goal_usage = None;
+              };
+            ];
+        };
+      orchestrator.Orchestrator.children <-
+        [
+          {
+            Orchestrator.pid;
+            issue;
+            issue_id = issue.id;
+            issue_identifier = issue.identifier;
+            issue_title = issue.title;
+            workspace;
+            started_at = Unix.time () -. 10.;
+            last_output_at = Unix.time ();
+            stdout_path = Some stdout_path;
+            stderr_path = None;
+            stdout_size = (Unix.stat stdout_path).Unix.st_size;
+            stderr_size = 0;
+          };
+        ];
+      Orchestrator.reap_children orchestrator;
+      let state = Orchestrator.get_state orchestrator in
+      Alcotest.(check int) "timeout total tokens parsed" 8 state.codex_totals.total_tokens;
+      Alcotest.(check int) "running removed" 0 (List.length state.running);
+      Alcotest.(check int) "retrying added" 1 (List.length state.retrying);
+      (match state.retrying with
+      | retry :: _ -> (
+          match retry.goal_usage with
+          | Some usage ->
+              Alcotest.(check (option string)) "retry goal status preserved" (Some "active") usage.status;
+              Alcotest.(check (option int)) "retry goal tokens preserved" (Some 8) usage.tokens_used
+          | None -> Alcotest.fail "expected retry goal usage")
+      | [] -> Alcotest.fail "expected retrying row");
+      let saw_goal_usage =
+        List.exists
+          (fun (state : Runtime_state.t) ->
+            List.exists
+              (fun (row : Runtime_state.running) ->
+                match row.goal_usage with
+                | Some usage -> usage.status = Some "active" && usage.tokens_used = Some 8
+                | None -> false)
+              state.running)
+          !snapshots
+      in
+      Alcotest.(check bool) "timeout goal usage exposed before retry" true saw_goal_usage)
+
+let test_orchestrator_preserves_goal_usage_on_blocked_issue_error () =
+  with_temp_dir "symphony-blocked-goal-usage-" (fun root ->
+      let config =
+        {
+          Config.workflow_path = "settings.json";
+          repository_root = root;
+          tracker =
+            {
+              kind = "github";
+              owner = "acme";
+              repo = "widgets";
+              project_number = 7;
+              api_key_env = "GITHUB_TOKEN";
+              api_key = Some "token";
+              active_states = [ "Todo" ];
+              terminal_states = [ "Done" ];
+              project_status_field = "Status";
+              project_status_on_dispatch = None;
+              project_status_on_success = None;
+              project_status_on_retry = None;
+              ensure_project_statuses = true;
+            };
+          polling = { interval_ms = 1000 };
+          workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
+          agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
+          codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 1000; stall_timeout_ms = 1000 };
+          server = { port = None };
+          pull_request = Config.default_pull_request;
+          stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
+        }
+      in
+      let issue = Issue.empty ~id:"I1" ~identifier:"#1" ~title:"Blocked usage" ~state:"Todo" in
+      let orchestrator = Orchestrator.make ~fetch:(fun _ -> []) ~set_status:(fun _ _ _ -> Ok ()) ~config ~prompt_template:"Issue {{ issue.identifier }}" () in
+      Orchestrator.set_state orchestrator
+        {
+          (Runtime_state.empty ()) with
+          running =
+            [
+              {
+                Runtime_state.issue;
+                session_id = Some "pid:block";
+                turn_count = 0;
+                last_event = Some "agent_output";
+                last_message = Some "stdout/stderr updated";
+                started_at = "2026-05-04T00:00:00Z";
+                last_event_at = Some "2026-05-04T00:00:10Z";
+                tokens = { input_tokens = 0; output_tokens = 0; total_tokens = 0 };
+                goal_usage = Some { Runtime_state.status = Some "blocked"; time_used_seconds = Some 10.; tokens_used = Some 77 };
+              };
+            ];
+        };
+      Orchestrator.mark_blocked orchestrator issue.id "commit required but agent produced no code changes";
+      match (Orchestrator.get_state orchestrator).issue_errors with
+      | issue_error :: _ -> (
+          match issue_error.goal_usage with
+          | Some usage ->
+              Alcotest.(check (option string)) "blocked goal status" (Some "blocked") usage.status;
+              Alcotest.(check (option int)) "blocked goal tokens" (Some 77) usage.tokens_used
+          | None -> Alcotest.fail "expected blocked goal usage")
+      | [] -> Alcotest.fail "expected issue error")
 
 let test_ready_terminal_mode_runs_orchestrator () =
   Alcotest.(check bool) "ready terminal loops" true
@@ -1111,6 +1639,7 @@ let test_orchestrator_uses_stage_agent_prompt_and_status () =
                     start_status = None;
                     success_status = Some "Done";
                     retry_status = Some "In progress";
+                    goal = None;
                     commit = None;
                   };
                 ];
@@ -1155,6 +1684,212 @@ let test_orchestrator_uses_stage_agent_prompt_and_status () =
         };
       Alcotest.(check (list (pair string string))) "review moves done" [ ("#1", "Done") ] (List.rev !statuses))
 
+let test_orchestrator_prepends_stage_goal_handoff () =
+  with_temp_dir "symphony-stage-goal-prompt-" (fun root ->
+      let agents_root = Filename.concat root "agents" in
+      Unix.mkdir agents_root 0o755;
+      Util.write_file (Filename.concat agents_root "engineer.md") "Engineer stage instructions";
+      let config =
+        {
+          Config.workflow_path = "settings.json";
+          repository_root = root;
+          tracker =
+            {
+              kind = "github";
+              owner = "acme";
+              repo = "widgets";
+              project_number = 7;
+              api_key_env = "GITHUB_TOKEN";
+              api_key = Some "token";
+              active_states = [ "Todo" ];
+              terminal_states = [ "Done" ];
+              project_status_field = "Status";
+              project_status_on_dispatch = None;
+              project_status_on_success = Some "In review";
+              project_status_on_retry = Some "Todo";
+              ensure_project_statuses = true;
+            };
+          polling = { interval_ms = 1000 };
+          workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
+          agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
+          codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
+          server = { port = None };
+          pull_request = Config.default_pull_request;
+          stage_agents =
+            {
+              enabled = true;
+              root = agents_root;
+              default_agent = None;
+              stages =
+                [
+                  {
+                    Config.states = [ "Todo" ];
+                    agent = "engineer";
+                    start_status = None;
+                    success_status = Some "In review";
+                    retry_status = Some "Todo";
+                    goal = Some { enabled = true };
+                    commit = None;
+                  };
+                ];
+            };
+        }
+      in
+      let issue =
+        {
+          (Issue.empty ~id:"I1" ~identifier:"#1" ~title:"One" ~state:"Todo") with
+          description = Some "Build the feature";
+          url = Some "https://example.test/issues/1";
+          labels = [ "enhancement"; "codex" ];
+          priority = Some 2;
+          blocked_by = [ { Issue.id = Some "I0"; identifier = Some "#0"; state = Some "Done" } ];
+          created_at = Some "2026-01-01T00:00:00Z";
+        }
+      in
+      let captured_prompt = ref "" in
+      let launch ~config:_ ~workspace:_ ~prompt ~issue =
+        captured_prompt := prompt;
+        { Orchestrator.pid = None; session_id = Some issue.Issue.id; event = "test-launch"; stdout_path = None; stderr_path = None }
+      in
+      let orchestrator = Orchestrator.make ~launch ~fetch:(fun _ -> [ issue ]) ~set_status:(fun _ _ _ -> Ok ()) ~config ~prompt_template:"Normal {{ issue.identifier }}" () in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check bool) "goal command first" true (String.starts_with ~prefix:"/goal {\"kind\":\"Stage Goal Context\"" !captured_prompt);
+      Alcotest.(check bool) "stage agent included" true (String.contains !captured_prompt 'E');
+      Alcotest.(check bool) "normal prompt included" true (String.contains !captured_prompt '#');
+      let goal_line =
+        match String.split_on_char '\n' !captured_prompt with
+        | first :: _ -> first
+        | [] -> Alcotest.fail "expected prompt"
+      in
+      let goal_json = String.sub goal_line 6 (String.length goal_line - 6) |> Yojson.Safe.from_string in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "goal kind" "Stage Goal Context" (goal_json |> member "kind" |> to_string);
+      Alcotest.(check string) "goal issue" "#1" (goal_json |> member "issue_identifier" |> to_string);
+      Alcotest.(check string) "goal description" "Build the feature" (goal_json |> member "description" |> to_string);
+      Alcotest.(check (list string)) "goal labels" [ "enhancement"; "codex" ]
+        (goal_json |> member "labels" |> to_list |> List.map to_string);
+      Alcotest.(check int) "goal priority" 2 (goal_json |> member "priority" |> to_int);
+      Alcotest.(check string) "goal blocker" "#0"
+        (goal_json |> member "blocker_references" |> to_list |> List.hd |> member "identifier" |> to_string);
+      Alcotest.(check bool) "created timestamp omitted" true
+        (match goal_json |> member "created_at" with `Null -> true | _ -> false);
+      Alcotest.(check bool) "updated timestamp omitted" true
+        (match goal_json |> member "updated_at" with `Null -> true | _ -> false))
+
+let test_orchestrator_skips_stage_goal_when_disabled () =
+  with_temp_dir "symphony-stage-goal-disabled-prompt-" (fun root ->
+      let agents_root = Filename.concat root "agents" in
+      Unix.mkdir agents_root 0o755;
+      Util.write_file (Filename.concat agents_root "engineer.md") "Engineer stage instructions";
+      let config =
+        {
+          Config.workflow_path = "settings.json";
+          repository_root = root;
+          tracker =
+            {
+              kind = "github";
+              owner = "acme";
+              repo = "widgets";
+              project_number = 7;
+              api_key_env = "GITHUB_TOKEN";
+              api_key = Some "token";
+              active_states = [ "Todo" ];
+              terminal_states = [ "Done" ];
+              project_status_field = "Status";
+              project_status_on_dispatch = None;
+              project_status_on_success = Some "In review";
+              project_status_on_retry = Some "Todo";
+              ensure_project_statuses = true;
+            };
+          polling = { interval_ms = 1000 };
+          workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
+          agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
+          codex = { command = "true"; model = Config.default_model; reasoning_effort = Config.default_reasoning_effort; turn_timeout_ms = 1000; read_timeout_ms = 100; stall_timeout_ms = 1000 };
+          server = { port = None };
+          pull_request = Config.default_pull_request;
+          stage_agents =
+            {
+              enabled = true;
+              root = agents_root;
+              default_agent = None;
+              stages =
+                [
+                  {
+                    Config.states = [ "Todo" ];
+                    agent = "engineer";
+                    start_status = None;
+                    success_status = Some "In review";
+                    retry_status = Some "Todo";
+                    goal = Some { enabled = false };
+                    commit = None;
+                  };
+                ];
+            };
+        }
+      in
+      let issue = Issue.empty ~id:"I1" ~identifier:"#1" ~title:"One" ~state:"Todo" in
+      let captured_prompt = ref "" in
+      let launch ~config:_ ~workspace:_ ~prompt ~issue =
+        captured_prompt := prompt;
+        { Orchestrator.pid = None; session_id = Some issue.Issue.id; event = "test-launch"; stdout_path = None; stderr_path = None }
+      in
+      let orchestrator = Orchestrator.make ~launch ~fetch:(fun _ -> [ issue ]) ~set_status:(fun _ _ _ -> Ok ()) ~config ~prompt_template:"Normal {{ issue.identifier }}" () in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check bool) "no goal command" false (String.starts_with ~prefix:"/goal" !captured_prompt);
+      Alcotest.(check bool) "stage agent still included" true (String.contains !captured_prompt 'E');
+      Alcotest.(check bool) "normal prompt still included" true (String.contains !captured_prompt '#'))
+
+let test_parse_goal_usage_from_codex_output () =
+  with_temp_dir "symphony-goal-usage-" (fun root ->
+      let stdout_path = Filename.concat root "stdout.log" in
+      Util.write_file stdout_path
+        {|noise
+Goal Usage: {"goal_usage":{"status":"complete","time_used_seconds":12.5,"tokens_used":345}}
+|};
+      match Orchestrator.parse_goal_usage (Some stdout_path) None with
+      | None -> Alcotest.fail "expected goal usage"
+      | Some usage ->
+          Alcotest.(check (option string)) "status" (Some "complete") usage.status;
+          Alcotest.(check (option (float 0.01))) "time" (Some 12.5) usage.time_used_seconds;
+          Alcotest.(check (option int)) "tokens" (Some 345) usage.tokens_used)
+
+let test_parse_goal_usage_variants_and_ignores_invalid () =
+  with_temp_dir "symphony-goal-usage-variants-" (fun root ->
+      let stdout_path = Filename.concat root "stdout.log" in
+      let stderr_path = Filename.concat root "stderr.log" in
+      Util.write_file stdout_path "Goal Usage: not json\n";
+      Alcotest.(check bool) "invalid ignored" true (Option.is_none (Orchestrator.parse_goal_usage (Some stdout_path) None));
+      Util.write_file stdout_path {|{"status":"active","timeUsedSeconds":3,"tokensUsed":44}|};
+      Alcotest.(check bool) "bare non-goal json ignored" true
+        (Option.is_none (Orchestrator.parse_goal_usage (Some stdout_path) None));
+      Util.write_file stdout_path {|Goal Usage: {"status":"active","timeUsedSeconds":3,"tokensUsed":44}|};
+      (match Orchestrator.parse_goal_usage (Some stdout_path) None with
+      | None -> Alcotest.fail "expected prefixed top-level goal usage"
+      | Some usage ->
+          Alcotest.(check (option string)) "prefixed status" (Some "active") usage.status;
+          Alcotest.(check (option int)) "prefixed tokens" (Some 44) usage.tokens_used);
+      Util.write_file stderr_path {|goal usage: {"status":"active","timeUsedSeconds":3,"tokensUsed":44}|};
+      match Orchestrator.parse_goal_usage (Some stdout_path) (Some stderr_path) with
+      | None -> Alcotest.fail "expected camel case goal usage"
+      | Some usage ->
+          Alcotest.(check (option string)) "status" (Some "active") usage.status;
+          Alcotest.(check (option (float 0.01))) "time" (Some 3.) usage.time_used_seconds;
+          Alcotest.(check (option int)) "tokens" (Some 44) usage.tokens_used)
+
+let test_parse_goal_usage_nested_usage_fields () =
+  with_temp_dir "symphony-goal-usage-nested-" (fun root ->
+      let stdout_path = Filename.concat root "stdout.log" in
+      Util.write_file stdout_path
+        {|{"goalUsage":{"goalStatus":"complete","durationSeconds":7.25,"tokenUsage":{"totalTokens":88}}}|};
+      match Orchestrator.parse_goal_usage (Some stdout_path) None with
+      | None -> Alcotest.fail "expected nested goal usage"
+      | Some usage ->
+          Alcotest.(check (option string)) "nested status" (Some "complete") usage.status;
+          Alcotest.(check (option (float 0.01))) "nested time" (Some 7.25) usage.time_used_seconds;
+          Alcotest.(check (option int)) "nested tokens" (Some 88) usage.tokens_used)
+
 let test_orchestrator_commits_stage_before_success_status () =
   with_temp_dir "symphony-stage-commit-" (fun root ->
       let config =
@@ -1197,6 +1932,7 @@ let test_orchestrator_commits_stage_before_success_status () =
                     start_status = None;
                     success_status = Some "In review";
                     retry_status = Some "Todo";
+                    goal = None;
                     commit = Some { enabled = true; commit_type = "fixture"; message = "<type>: <generated_message_max_90char>"; push = false };
                   };
                 ];
@@ -1342,6 +2078,7 @@ let test_orchestrator_retries_push_failure_before_success_status () =
                     start_status = None;
                     success_status = Some "In review";
                     retry_status = Some "Todo";
+                    goal = None;
                     commit = Some { enabled = true; commit_type = "feature"; message = Config.default_commit_message; push = true };
                   };
                 ];
@@ -1426,6 +2163,7 @@ let test_stage_commit_requires_code_changes () =
             start_status = None;
             success_status = Some "In review";
             retry_status = Some "Todo";
+            goal = None;
             commit = Some { enabled = true; commit_type = "feature"; message = Config.default_commit_message; push = false };
           }
       in
@@ -1476,6 +2214,7 @@ let test_orchestrator_does_not_retry_empty_commit () =
                     start_status = None;
                     success_status = Some "In review";
                     retry_status = Some "Todo";
+                    goal = None;
                     commit = Some { enabled = true; commit_type = "feature"; message = Config.default_commit_message; push = false };
                   };
                 ];
@@ -1818,6 +2557,7 @@ let test_stage_commit_pushes_task_branch () =
             start_status = None;
             success_status = Some "In review";
             retry_status = Some "Todo";
+            goal = None;
             commit = Some { enabled = true; commit_type = "feat"; message = Config.default_commit_message; push = true };
           }
       in
@@ -2004,9 +2744,17 @@ let () =
           Alcotest.test_case "normalizes legacy codex app-server command" `Quick test_legacy_codex_app_server_command_normalizes_to_exec;
           Alcotest.test_case "derives kanban status order from transitions" `Quick test_project_status_order_uses_transition_flow;
           Alcotest.test_case "parses git policy and stage push" `Quick test_config_parses_git_policy_and_stage_push;
+          Alcotest.test_case "parses stage goal and readiness" `Quick test_config_parses_stage_goal_and_readiness;
+          Alcotest.test_case "disabled stage goal does not require codex goals" `Quick test_disabled_stage_goal_does_not_require_codex_goals;
+          Alcotest.test_case "stage goal requires codex exec stdin support" `Quick test_stage_goal_requires_codex_exec_stdin_support;
+          Alcotest.test_case "stage goal live stdin probe" `Quick test_stage_goal_live_stdin_probe;
           Alcotest.test_case "requires pull request base branch when enabled" `Quick test_pull_request_base_branch_readiness_gap;
         ] );
-      ("runtime-state", [ Alcotest.test_case "exposes running issue details" `Quick test_runtime_state_exposes_running_issue_details ]);
+      ( "runtime-state",
+        [
+          Alcotest.test_case "exposes running issue details" `Quick test_runtime_state_exposes_running_issue_details;
+          Alcotest.test_case "exposes goal usage when available" `Quick test_runtime_state_exposes_goal_usage_when_available;
+        ] );
       ( "server",
         [
           Alcotest.test_case "handles websocket upgrade and initial snapshot" `Quick test_websocket_accept_and_initial_snapshot;
@@ -2032,6 +2780,11 @@ let () =
           Alcotest.test_case "retries failed agents" `Quick test_orchestrator_retries_failed_agent;
           Alcotest.test_case "moves status to review on success" `Quick test_orchestrator_moves_status_to_review_on_success;
           Alcotest.test_case "uses stage agent prompt and status" `Quick test_orchestrator_uses_stage_agent_prompt_and_status;
+          Alcotest.test_case "prepends stage goal handoff" `Quick test_orchestrator_prepends_stage_goal_handoff;
+          Alcotest.test_case "skips stage goal handoff when disabled" `Quick test_orchestrator_skips_stage_goal_when_disabled;
+          Alcotest.test_case "parses goal usage output" `Quick test_parse_goal_usage_from_codex_output;
+          Alcotest.test_case "parses goal usage variants" `Quick test_parse_goal_usage_variants_and_ignores_invalid;
+          Alcotest.test_case "parses nested goal usage fields" `Quick test_parse_goal_usage_nested_usage_fields;
           Alcotest.test_case "commits stage before success status" `Quick test_orchestrator_commits_stage_before_success_status;
           Alcotest.test_case "retries when success status move fails" `Quick test_orchestrator_retries_when_success_status_move_fails;
           Alcotest.test_case "retries push failure before success status"
@@ -2039,6 +2792,12 @@ let () =
           Alcotest.test_case "stage commit requires code changes" `Quick test_stage_commit_requires_code_changes;
           Alcotest.test_case "does not retry empty required commits" `Quick test_orchestrator_does_not_retry_empty_commit;
           Alcotest.test_case "notifies repeated state mutations" `Quick test_orchestrator_notifies_each_state_mutation;
+          Alcotest.test_case "parses final output when size was already seen"
+            `Quick test_orchestrator_parses_final_output_when_size_was_already_seen;
+          Alcotest.test_case "parses final output before timeout retry"
+            `Quick test_orchestrator_parses_final_output_before_timeout_retry;
+          Alcotest.test_case "preserves goal usage on blocked issue error"
+            `Quick test_orchestrator_preserves_goal_usage_on_blocked_issue_error;
           Alcotest.test_case "creates task worktree and branch" `Quick test_orchestrator_creates_task_worktree_and_branch;
           Alcotest.test_case "opens batch pull request once when idle" `Quick test_orchestrator_opens_batch_pull_request_once_when_idle;
           Alcotest.test_case "retries failed batch pull request handoff" `Quick test_orchestrator_retries_batch_pull_request_handoff_failure;

--- a/apps/frontend/src/Main.res
+++ b/apps/frontend/src/Main.res
@@ -9,6 +9,18 @@ function shortDescription(value) {
 function arrayOrEmpty(value) {
   return Array.isArray(value) ? value : [];
 }
+function goalUsageText(value) {
+  if (!value) return "";
+  const parts = [];
+  if (value.status) parts.push("status " + value.status);
+  if (value.time_used_seconds !== null && value.time_used_seconds !== undefined) {
+    parts.push("time " + value.time_used_seconds + "s");
+  }
+  if (value.tokens_used !== null && value.tokens_used !== undefined) {
+    parts.push("tokens " + value.tokens_used);
+  }
+  return parts.join(" | ");
+}
 `)
 
 type domElement
@@ -26,16 +38,24 @@ type readinessGap = {
   remediation: string,
 }
 
+type goalUsage = {
+  status: option<string>,
+  time_used_seconds: option<float>,
+  tokens_used: option<int>,
+}
+
 type taskError = {
   issue_id: string,
   issue_identifier: string,
   error: option<string>,
+  goal_usage: option<goalUsage>,
 }
 
 type blockedTaskError = {
   issue_id: string,
   issue_identifier: string,
   error: string,
+  goal_usage: option<goalUsage>,
 }
 
 type runningIssue = {
@@ -45,6 +65,7 @@ type runningIssue = {
   state: string,
   url: option<string>,
   description: option<string>,
+  goal_usage: option<goalUsage>,
 }
 
 type runtimeState = {
@@ -66,6 +87,7 @@ type runtimeState = {
 
 @val external shortDescription: string => string = "shortDescription"
 @val external arrayOrEmpty: array<'value> => array<'value> = "arrayOrEmpty"
+@val external goalUsageText: option<goalUsage> => string = "goalUsageText"
 external audioNotificationState: runtimeState => AudioNotifications.runtimeState = "%identity"
 
 let readinessText = state =>
@@ -93,10 +115,129 @@ let taskErrorForIssue = (state, issueId) => {
   }
 }
 
+let goalUsageForIssue = (state, issueId) => {
+  switch arrayOrEmpty(state.running)->Array.find(issue => issue.issue_id == issueId) {
+  | Some(issue) => goalUsageText(issue.goal_usage)
+  | None =>
+    switch arrayOrEmpty(state.issue_errors)->Array.find(error => error.issue_id == issueId) {
+    | Some(error) => goalUsageText(error.goal_usage)
+    | None =>
+      switch arrayOrEmpty(state.retrying)->Array.find(error => error.issue_id == issueId) {
+      | Some(error) => goalUsageText(error.goal_usage)
+      | None => ""
+      }
+    }
+  }
+}
+
+let navItem = (href, label, isActive) =>
+  <a
+    href=href
+    className={
+      "block rounded px-3 py-2 text-sm transition-colors " ++
+      if isActive {
+        "bg-teal-950/80 text-teal-100"
+      } else {
+        "text-neutral-400 hover:bg-neutral-900 hover:text-neutral-100"
+      }
+    }>
+    {React.string(label)}
+  </a>
+
+module App = {
+  @react.component
+  let make = (
+    ~snapshot: option<Dashboard.snapshot>,
+    ~error: option<string>,
+    ~audioEnabled: bool,
+    ~onAudioToggle: bool => unit,
+  ) => {
+    let location = ReactRouter.useLocation()
+    let isConfiguration = location.pathname == "/configuration"
+
+    <section className="min-h-screen bg-[#0b0b0b] text-neutral-100">
+      <div className="grid min-h-screen lg:grid-cols-[240px_minmax(0,1fr)]">
+        <aside className="border-b border-neutral-800 bg-neutral-950 px-4 py-4 lg:border-b-0 lg:border-r">
+          <div className="flex items-center justify-between gap-4 lg:block">
+            <div>
+              <div className="text-lg font-semibold tracking-normal text-neutral-50">
+                {React.string("Symphony")}
+              </div>
+              <div className="mt-1 text-xs text-neutral-500">
+                {React.string("Workspace Repository control")}
+              </div>
+            </div>
+            <HeroUI.Chip
+              size="sm"
+              variant="flat"
+              className="rounded border border-emerald-800 bg-emerald-950/70 px-3 text-emerald-100 lg:mt-4">
+              {React.string("Live OCaml API")}
+            </HeroUI.Chip>
+          </div>
+          <nav className="mt-5 grid grid-cols-2 gap-2 lg:grid-cols-1">
+            {navItem("#/", "Orchestrator", !isConfiguration)}
+            {navItem("#/configuration", "Configuration", isConfiguration)}
+          </nav>
+        </aside>
+        <main className="min-w-0">
+          <header className="border-b border-neutral-800 bg-neutral-950/95 px-5 py-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="text-xs text-neutral-500">
+                <span className="uppercase"> {React.string("Generated")} </span>
+                <span className="ml-2 text-neutral-200">
+                  {React.string(switch snapshot {
+                  | Some(data) => data.generatedAt
+                  | None => "-"
+                  })}
+                </span>
+              </div>
+              <div className="flex flex-wrap items-center gap-3 text-xs text-neutral-500">
+                <span>
+                  {React.string("Live state: ")}
+                  <code className="text-teal-200"> {React.string("/api/v1/state/live")} </code>
+                </span>
+                <HeroUI.Button
+                  type_="button"
+                  variant="bordered"
+                  size="sm"
+                  onClick={_ => onAudioToggle(!audioEnabled)}
+                  className={
+                    "rounded border px-3 py-1 text-xs font-medium " ++
+                    if audioEnabled {
+                      "border-teal-700 bg-teal-950/60 text-teal-100"
+                    } else {
+                      "border-neutral-700 bg-neutral-900 text-neutral-300"
+                    }
+                  }>
+                  {React.string(if audioEnabled {
+                    "Audio on"
+                  } else {
+                    "Audio off"
+                  })}
+                </HeroUI.Button>
+              </div>
+            </div>
+          </header>
+          <div className="px-5 py-6">
+            <ReactRouter.Routes>
+              <ReactRouter.Route path="/" element={<Dashboard snapshot error />} />
+              <ReactRouter.Route
+                path="/configuration"
+                element={<Configuration audioEnabled onAudioToggle />}
+              />
+              <ReactRouter.Route path="*" element={<ReactRouter.Navigate to="/" replace=true />} />
+            </ReactRouter.Routes>
+          </div>
+        </main>
+      </div>
+    </section>
+  }
+}
+
 let renderDashboard = (root, ~snapshot, ~error, ~audioEnabled, ~onAudioToggle) =>
   root->render(
     <ReactRouter.HashRouter>
-      <Dashboard snapshot error audioEnabled onAudioToggle />
+      <App snapshot error audioEnabled onAudioToggle />
     </ReactRouter.HashRouter>,
   )
 
@@ -126,6 +267,7 @@ let snapshotFromState = state => {
       },
       description: description->shortDescription,
       error: taskErrorForIssue(state, issue.issue_id),
+      goalUsage: goalUsageForIssue(state, issue.issue_id),
     }
   }),
 }

--- a/apps/frontend/src/Pages/Configuration.res
+++ b/apps/frontend/src/Pages/Configuration.res
@@ -1,0 +1,43 @@
+@react.component
+let make = (~audioEnabled: bool, ~onAudioToggle: bool => unit) =>
+  <div className="space-y-5">
+    <div>
+      <h1 className="text-2xl font-semibold tracking-normal text-neutral-50">
+        {React.string("Configuration")}
+      </h1>
+      <p className="mt-1 text-sm text-neutral-500">
+        {React.string("Browser-local Audio Notification Configuration.")}
+      </p>
+    </div>
+    <HeroUI.Card className="rounded border border-neutral-800 bg-neutral-950">
+      <HeroUI.CardHeader className="border-b border-neutral-800 px-4 py-3">
+        <div>
+          <div className="text-sm font-semibold text-neutral-100">
+            {React.string("Audio notifications")}
+          </div>
+          <div className="mt-1 text-xs text-neutral-500">
+            {React.string("Stored in this browser only; Runtime Settings are unchanged.")}
+          </div>
+        </div>
+      </HeroUI.CardHeader>
+      <HeroUI.CardContent className="grid gap-4 p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+        <div>
+          <div className="text-sm font-medium text-neutral-100">
+            {React.string("Notify when tracked work changes")}
+          </div>
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-neutral-500">
+            {React.string("The dashboard can play a local browser sound when active work enters a notable state.")}
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <HeroUI.Switch isSelected=audioEnabled onChange={enabled => onAudioToggle(enabled)}>
+            {React.string(if audioEnabled {
+              "Audio on"
+            } else {
+              "Audio off"
+            })}
+          </HeroUI.Switch>
+        </div>
+      </HeroUI.CardContent>
+    </HeroUI.Card>
+  </div>

--- a/apps/frontend/src/Pages/Dashboard.res
+++ b/apps/frontend/src/Pages/Dashboard.res
@@ -5,6 +5,7 @@ type issueItem = {
   url: string,
   description: string,
   error: string,
+  goalUsage: string,
 }
 
 type snapshot = {
@@ -126,6 +127,14 @@ let issueCard = issue =>
         {React.string(message)}
       </div>
     }}
+    {switch issue.goalUsage {
+    | "" => React.null
+    | value =>
+      <div className="mt-3 rounded border border-neutral-800 bg-neutral-900 px-3 py-2 text-xs leading-5 text-neutral-300">
+        <span className="font-medium text-neutral-100"> {React.string("Goal Usage")} </span>
+        <span className="ml-2"> {React.string(value)} </span>
+      </div>
+    }}
   </article>
 
 let emptyOrchestrator = error =>
@@ -146,7 +155,8 @@ let emptyOrchestrator = error =>
     </HeroUI.Card>
   </>
 
-let orchestratorView = (snapshot, error) =>
+@react.component
+let make = (~snapshot: option<snapshot>, ~error: option<string>) =>
   <div className="space-y-5">
     <div>
       <h1 className="text-2xl font-semibold tracking-normal text-neutral-50">
@@ -221,148 +231,3 @@ let orchestratorView = (snapshot, error) =>
       </>
     }}
   </div>
-
-let configurationView = (~audioEnabled, ~onAudioToggle) =>
-  <div className="space-y-5">
-    <div>
-      <h1 className="text-2xl font-semibold tracking-normal text-neutral-50">
-        {React.string("Configuration")}
-      </h1>
-      <p className="mt-1 text-sm text-neutral-500">
-        {React.string("Browser-local Audio Notification Configuration.")}
-      </p>
-    </div>
-    <HeroUI.Card className="rounded border border-neutral-800 bg-neutral-950">
-      <HeroUI.CardHeader className="border-b border-neutral-800 px-4 py-3">
-        <div>
-          <div className="text-sm font-semibold text-neutral-100">
-            {React.string("Audio notifications")}
-          </div>
-          <div className="mt-1 text-xs text-neutral-500">
-            {React.string("Stored in this browser only; Runtime Settings are unchanged.")}
-          </div>
-        </div>
-      </HeroUI.CardHeader>
-      <HeroUI.CardContent className="grid gap-4 p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
-        <div>
-          <div className="text-sm font-medium text-neutral-100">
-            {React.string("Notify when tracked work changes")}
-          </div>
-          <p className="mt-1 max-w-2xl text-sm leading-6 text-neutral-500">
-            {React.string("The dashboard can play a local browser sound when active work enters a notable state.")}
-          </p>
-        </div>
-        <div className="flex items-center gap-3">
-          <HeroUI.Switch isSelected=audioEnabled onChange={enabled => onAudioToggle(enabled)}>
-            {React.string(if audioEnabled {
-              "Audio on"
-            } else {
-              "Audio off"
-            })}
-          </HeroUI.Switch>
-        </div>
-      </HeroUI.CardContent>
-    </HeroUI.Card>
-  </div>
-
-let navItem = (href, label, isActive) =>
-  <a
-    href=href
-    className={
-      "block rounded px-3 py-2 text-sm transition-colors " ++
-      if isActive {
-        "bg-teal-950/80 text-teal-100"
-      } else {
-        "text-neutral-400 hover:bg-neutral-900 hover:text-neutral-100"
-      }
-    }>
-    {React.string(label)}
-  </a>
-
-@react.component
-let make = (
-  ~snapshot: option<snapshot>,
-  ~error: option<string>,
-  ~audioEnabled: bool,
-  ~onAudioToggle: bool => unit,
-) => {
-  let location = ReactRouter.useLocation()
-  let isConfiguration = location.pathname == "/configuration"
-
-  <section className="min-h-screen bg-[#0b0b0b] text-neutral-100">
-    <div className="grid min-h-screen lg:grid-cols-[240px_minmax(0,1fr)]">
-      <aside className="border-b border-neutral-800 bg-neutral-950 px-4 py-4 lg:border-b-0 lg:border-r">
-        <div className="flex items-center justify-between gap-4 lg:block">
-          <div>
-            <div className="text-lg font-semibold tracking-normal text-neutral-50">
-              {React.string("Symphony")}
-            </div>
-            <div className="mt-1 text-xs text-neutral-500">
-              {React.string("Workspace Repository control")}
-            </div>
-          </div>
-          <HeroUI.Chip
-            size="sm"
-            variant="flat"
-            className="rounded border border-emerald-800 bg-emerald-950/70 px-3 text-emerald-100 lg:mt-4">
-            {React.string("Live OCaml API")}
-          </HeroUI.Chip>
-        </div>
-        <nav className="mt-5 grid grid-cols-2 gap-2 lg:grid-cols-1">
-          {navItem("#/", "Orchestrator", !isConfiguration)}
-          {navItem("#/configuration", "Configuration", isConfiguration)}
-        </nav>
-      </aside>
-      <main className="min-w-0">
-        <header className="border-b border-neutral-800 bg-neutral-950/95 px-5 py-4">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="text-xs text-neutral-500">
-              <span className="uppercase"> {React.string("Generated")} </span>
-              <span className="ml-2 text-neutral-200">
-                {React.string(switch snapshot {
-                | Some(data) => data.generatedAt
-                | None => "-"
-                })}
-              </span>
-            </div>
-            <div className="flex flex-wrap items-center gap-3 text-xs text-neutral-500">
-              <span>
-                {React.string("Live state: ")}
-                <code className="text-teal-200"> {React.string("/api/v1/state/live")} </code>
-              </span>
-              <HeroUI.Button
-                type_="button"
-                variant="bordered"
-                size="sm"
-                onClick={_ => onAudioToggle(!audioEnabled)}
-                className={
-                  "rounded border px-3 py-1 text-xs font-medium " ++
-                  if audioEnabled {
-                    "border-teal-700 bg-teal-950/60 text-teal-100"
-                  } else {
-                    "border-neutral-700 bg-neutral-900 text-neutral-300"
-                  }
-                }>
-                {React.string(if audioEnabled {
-                  "Audio on"
-                } else {
-                  "Audio off"
-                })}
-              </HeroUI.Button>
-            </div>
-          </div>
-        </header>
-        <div className="px-5 py-6">
-          <ReactRouter.Routes>
-            <ReactRouter.Route path="/" element={orchestratorView(snapshot, error)} />
-            <ReactRouter.Route
-              path="/configuration"
-              element={configurationView(~audioEnabled, ~onAudioToggle)}
-            />
-            <ReactRouter.Route path="*" element={<ReactRouter.Navigate to="/" replace=true />} />
-          </ReactRouter.Routes>
-        </div>
-      </main>
-    </div>
-  </section>
-}

--- a/docs/adr/0007-stage-goal-handoff.md
+++ b/docs/adr/0007-stage-goal-handoff.md
@@ -1,0 +1,36 @@
+# Stage Goal Handoff
+
+## Status
+
+Accepted
+
+## Context
+
+Some Stage Agents benefit from Codex goal tracking, but making `/goal` a global launch mode would change every agent run and blur the boundary between the Stage Goal Context and the normal Agent Prompt.
+
+Codex goal support also depends on local Codex configuration and stdin slash-command support. Symphony needs to surface missing support before dispatch instead of turning it into a retryable task failure.
+
+## Decision
+
+Runtime Settings configure Stage Goal Handoff per stage with `goal.enabled`. Missing `goal` means disabled, and bootstrapped Runtime Settings include `goal.enabled: false` for every example stage.
+
+When a matching stage enables Stage Goal Handoff, Symphony prepends `/goal` plus deterministic Stage Goal Context before the normal rendered Agent Prompt. Stage Goal Context includes issue identifier, title, description, URL, current project status, labels, priority when present, blocker references when present, attempt, and stage agent name. It does not include issue creation or update timestamps by default.
+
+Symphony treats missing Codex goal support as a Readiness Gap. It checks `~/.codex/config.toml` for:
+
+```toml
+[features]
+goals = true
+```
+
+Symphony also verifies that the configured Codex command supports `/goal` from standard input before treating Stage Goal Handoff as supported. A live stdin probe is available with `SYMPHONY_CODEX_GOAL_STDIN_PROBE=1`; otherwise the readiness check accepts the default `codex exec` command shape without consuming a Codex run during ordinary readiness checks.
+
+Goal Usage is parsed from Codex output only when Codex reports it in a parseable JSON form. Parsed Goal Usage is stored in Runtime State for running, retrying, and attention-needed task details, and is displayed in the Web Dashboard when available.
+
+## Consequences
+
+Stage Goal Handoff supplements the Agent Prompt and does not replace stage agent instructions.
+
+Stage Goal Handoff does not change retry behavior, completion behavior, status transitions, Stage Commit, Stage Push, auto-merge, or Batch Pull Request behavior.
+
+Missing or unparseable Goal Usage does not fail a task.


### PR DESCRIPTION
## Summary
- add per-stage Stage Goal Handoff with Codex /goal context and readiness checks
- persist Goal Usage in Runtime State and show it in dashboard task details
- split dashboard/configuration pages under Pages while keeping routing in Main

## Verification
- pnpm test
- pnpm backend:build
- pnpm frontend:test
- pnpm frontend:build
- git diff --check

Closes #14