### PR TITLE
Add symphony update command

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -176,6 +176,14 @@ _Avoid_: retrying error, global error, any error
 The npm-distributed Personal Symphony package that provides the `symphony` command and carries platform binaries for supported operating systems.
 _Avoid_: npm wrapper, global install
 
+**Update Source**:
+The npm registry package metadata that `symphony update` uses to discover the latest released CLI Package version.
+_Avoid_: latest build, GitHub release lookup
+
+**Install Prefix**:
+The npm global prefix that owns the currently running `symphony` command.
+_Avoid_: global npm, current npm prefix
+
 **Idempotent Bootstrap**:
 A Bootstrap that creates missing Runtime Home files without overwriting user-edited files.
 _Avoid_: reinitialize, reset
@@ -328,6 +336,15 @@ _Avoid_: reinitialize, reset
 - The **Product Repository** provides the **CLI Package**.
 - The **CLI Package** provides the `symphony` command.
 - The **CLI Package** contains Linux x64, macOS x64, macOS arm64, and Windows x64 binaries under `vendor/`.
+- The **Update Source** for normal CLI updates is the npm registry, not GitHub Releases.
+- `symphony update` updates the installed **CLI Package** and does not require a **Workspace Repository**.
+- `symphony update` supports npm-installed **CLI Package** instances and does not update Product Repository source checkouts.
+- `symphony update` requires interactive confirmation before changing an installed **CLI Package** unless the operator passes an explicit non-interactive confirmation flag.
+- `symphony update` installs the latest **CLI Package** into the **Install Prefix** that owns the running command.
+- `symphony update` succeeds only after the updated `symphony` command reports the target version.
+- `symphony update` reports failed update phases and manual repair guidance instead of automatically rolling back partially completed package-manager changes.
+- `symphony update` requires fresh **Update Source** discovery and shows the underlying discovery error when the latest version cannot be resolved.
+- `symphony update` does not retry package installation with elevated privileges when the **Install Prefix** is not writable.
 
 ## Example Dialogue
 

--- a/apps/backend/bin/main.ml
+++ b/apps/backend/bin/main.ml
@@ -22,6 +22,8 @@ let readiness_state config =
 let colors_enabled () =
   Sys.getenv_opt "NO_COLOR" = None
 
+let version = "0.1.1"
+
 let ansi code = if colors_enabled () then "\027[" ^ code ^ "m" else ""
 let color code text = ansi code ^ text ^ ansi "0"
 let blue text = color "34;1" text
@@ -225,9 +227,9 @@ let init () =
     Printf.eprintf "event=init outcome=failed reason=%s\n%!" msg;
     1
 
-open Cmdliner
+let update yes = Update_cli.run ~current_version:version ~yes ()
 
-let version = "0.1.1"
+open Cmdliner
 
 let workflow_arg =
   Arg.(value & pos 0 (some string) None & info [] ~docv:"WORKFLOW" ~doc:"Optional legacy WORKFLOW.md path.")
@@ -241,13 +243,20 @@ let once_arg =
 let web_arg =
   Arg.(value & flag & info [ "web" ] ~doc:"Start the backend and Web Dashboard mode instead of the Terminal Console.")
 
+let yes_arg =
+  Arg.(value & flag & info [ "yes"; "y" ] ~doc:"Update without interactive confirmation.")
+
 let cmd =
   let doc = "Run Personal Symphony from a Git Workspace Repository root." in
   let default = Term.(const run $ workflow_arg $ port_arg $ once_arg $ web_arg) in
   let init_cmd =
     Cmd.v (Cmd.info "init" ~doc:"Create missing .symphony runtime files without overwriting edits.") Term.(const init $ const ())
   in
-  Cmd.group (Cmd.info "symphony" ~doc ~version) ~default [ init_cmd ]
+  let update_cmd =
+    Cmd.v (Cmd.info "update" ~doc:"Update the npm-installed CLI Package to the latest npm release.")
+      Term.(const update $ yes_arg)
+  in
+  Cmd.group (Cmd.info "symphony" ~doc ~version) ~default [ init_cmd; update_cmd ]
 
 let normalize_help_argv argv =
   Array.map

--- a/apps/backend/lib/config.ml
+++ b/apps/backend/lib/config.ml
@@ -383,7 +383,10 @@ let codex_goal_stdin_supported config =
     let probe = "/goal Verify Codex goal stdin support.\n\nReturn ok.\n" in
     let command = codex_probe_command config in
     let shell_command =
-      Printf.sprintf "printf %%s %s | timeout 20s %s >/dev/null 2>&1" (Util.shell_quote probe) command
+      Printf.sprintf
+        "if command -v timeout >/dev/null 2>&1; then printf %%s %s | timeout 20s %s; else printf %%s %s | %s; fi \
+         >/dev/null 2>&1"
+        (Util.shell_quote probe) command (Util.shell_quote probe) command
     in
     match Unix.system shell_command with Unix.WEXITED 0 -> true | _ -> false
 

--- a/apps/backend/lib/update_cli.ml
+++ b/apps/backend/lib/update_cli.ml
@@ -43,6 +43,17 @@ let infer_prefix_from_package_root package_root =
     let lib_dir = Filename.dirname node_modules in
     if Filename.basename lib_dir = "lib" then Some (Filename.dirname lib_dir) else None
 
+let is_symlink path =
+  try (Unix.lstat path).st_kind = Unix.S_LNK with Unix.Unix_error _ -> false
+
+let infer_prefix ~raw_launcher_path ~resolved_launcher_path ~package_root =
+  if is_symlink raw_launcher_path then
+    match realpath_opt raw_launcher_path with
+    | Some raw_real when raw_real = resolved_launcher_path ->
+      infer_prefix_from_launcher raw_launcher_path
+    | _ -> infer_prefix_from_package_root package_root
+  else infer_prefix_from_package_root package_root
+
 let detect_install_shape ~launcher_path =
   let raw_launcher_path = launcher_path in
   let resolved_launcher_path =
@@ -53,11 +64,7 @@ let detect_install_shape ~launcher_path =
   | None ->
       let package_root = Filename.dirname (Filename.dirname resolved_launcher_path) in
       if read_package_name package_root = Some package_name then
-        let install_prefix =
-          match infer_prefix_from_launcher raw_launcher_path with
-          | Some prefix -> Some prefix
-          | None -> infer_prefix_from_package_root package_root
-        in
+        let install_prefix = infer_prefix ~raw_launcher_path ~resolved_launcher_path ~package_root in
         match install_prefix with
         | Some install_prefix -> Npm_package { launcher_path = resolved_launcher_path; package_root; install_prefix }
         | None -> Unsupported ("could not identify the Install Prefix that owns " ^ resolved_launcher_path)

--- a/apps/backend/lib/update_cli.ml
+++ b/apps/backend/lib/update_cli.ml
@@ -1,0 +1,188 @@
+type command_result = { code : int; output : string }
+
+type install_shape =
+  | Npm_package of { launcher_path : string; package_root : string; install_prefix : string }
+  | Source_checkout of string
+  | Unsupported of string
+
+let package_name = "symphony-orchestrator"
+
+let rec find_ancestor_with name path =
+  let candidate = Filename.concat path name in
+  if Sys.file_exists candidate then Some path
+  else
+    let parent = Filename.dirname path in
+    if parent = path then None else find_ancestor_with name parent
+
+let realpath_opt path =
+  try Some (Unix.realpath path) with Unix.Unix_error _ -> None
+
+let is_source_checkout_path path =
+  let start = if Sys.file_exists path && Sys.is_directory path then path else Filename.dirname path in
+  match find_ancestor_with "dune-project" start with Some root -> Some root | None -> None
+
+let read_package_name package_root =
+  let package_json = Filename.concat package_root "package.json" in
+  if not (Sys.file_exists package_json) then None
+  else
+    try
+      match Yojson.Basic.from_file package_json with
+      | `Assoc fields -> (
+          match List.assoc_opt "name" fields with Some (`String name) -> Some name | _ -> None)
+      | _ -> None
+    with _ -> None
+
+let infer_prefix_from_launcher launcher_path =
+  let parent = Filename.dirname launcher_path in
+  if Filename.basename parent = "bin" then Some (Filename.dirname parent) else None
+
+let infer_prefix_from_package_root package_root =
+  let node_modules = Filename.dirname package_root in
+  if Filename.basename node_modules <> "node_modules" then None
+  else
+    let lib_dir = Filename.dirname node_modules in
+    if Filename.basename lib_dir = "lib" then Some (Filename.dirname lib_dir) else None
+
+let detect_install_shape ~launcher_path =
+  let raw_launcher_path = launcher_path in
+  let resolved_launcher_path =
+    match realpath_opt launcher_path with Some real -> real | None -> launcher_path
+  in
+  match is_source_checkout_path resolved_launcher_path with
+  | Some root -> Source_checkout root
+  | None ->
+      let package_root = Filename.dirname (Filename.dirname resolved_launcher_path) in
+      if read_package_name package_root = Some package_name then
+        let install_prefix =
+          match infer_prefix_from_launcher raw_launcher_path with
+          | Some prefix -> Some prefix
+          | None -> infer_prefix_from_package_root package_root
+        in
+        match install_prefix with
+        | Some install_prefix -> Npm_package { launcher_path = resolved_launcher_path; package_root; install_prefix }
+        | None -> Unsupported ("could not identify the Install Prefix that owns " ^ resolved_launcher_path)
+      else Unsupported ("current symphony command is not an npm-installed " ^ package_name ^ " CLI Package")
+
+let shell command =
+  let ic = Unix.open_process_in (command ^ " 2>&1") in
+  let output =
+    let buffer = Buffer.create 256 in
+    (try
+       while true do
+         Buffer.add_string buffer (input_line ic);
+         Buffer.add_char buffer '\n'
+       done
+     with End_of_file -> ());
+    Buffer.contents buffer |> Util.trim
+  in
+  let code =
+    match Unix.close_process_in ic with
+    | Unix.WEXITED code -> code
+    | Unix.WSIGNALED signal -> 128 + signal
+    | Unix.WSTOPPED signal -> 128 + signal
+  in
+  { code; output }
+
+let command_success command =
+  let result = shell command in
+  if result.code = 0 then Ok result.output else Error result.output
+
+let find_callable () =
+  match Util.getenv_nonempty "SYMPHONY_LAUNCHER_PATH" with
+  | Some path -> Ok path
+  | None -> (
+      match command_success "command -v symphony" with Ok path -> Ok path | Error error -> Error error)
+
+let parse_latest_version output =
+  try
+    match Yojson.Basic.from_string output with
+    | `String version when Util.trim version <> "" -> Ok (Util.trim version)
+    | _ -> Error ("npm returned malformed version metadata: " ^ output)
+  with Yojson.Json_error _ -> (
+    let trimmed = Util.trim output in
+    if trimmed <> "" && not (String.contains trimmed '\n') then Ok trimmed
+    else Error ("npm returned malformed version metadata: " ^ output))
+
+let manual_repair ~target_version ~install_prefix =
+  Printf.sprintf "Manual repair: run npm install -g %s@%s --prefix %s, then run symphony --version."
+    package_name target_version (Util.shell_quote install_prefix)
+
+let confirm_update ~current_version ~latest_version ~install_prefix ~install_command =
+  Printf.printf "current version: %s\n" current_version;
+  Printf.printf "latest version: %s\n" latest_version;
+  Printf.printf "package: %s\n" package_name;
+  Printf.printf "Install Prefix: %s\n" install_prefix;
+  Printf.printf "command: %s\n" install_command;
+  Printf.printf "Proceed with update? [y/N] %!";
+  match read_line () |> String.lowercase_ascii |> Util.trim with "y" | "yes" -> true | _ -> false
+
+let run ?(runner = shell) ?(find_callable = find_callable) ?(is_tty = fun () -> Unix.isatty Unix.stdin)
+    ?(confirm = confirm_update) ~current_version ~yes () =
+  match find_callable () with
+  | Error error ->
+      Printf.eprintf "phase=install-shape outcome=failed reason=%s\n%!" error;
+      1
+  | Ok callable -> (
+      match detect_install_shape ~launcher_path:callable with
+      | Source_checkout root ->
+          Printf.eprintf
+            "phase=install-shape outcome=failed reason=source checkout unsupported path=%s\n\
+             Source checkouts must be updated through the normal development workflow.\n%!"
+            root;
+          1
+      | Unsupported reason ->
+          Printf.eprintf "phase=install-shape outcome=failed reason=%s\n%!" reason;
+          1
+      | Npm_package { launcher_path; install_prefix; _ } ->
+          let discovery = runner (Printf.sprintf "npm view %s version --json" package_name) in
+          if discovery.code <> 0 then (
+            Printf.eprintf "phase=discovery outcome=failed\n%s\n%!" discovery.output;
+            1)
+          else
+            match parse_latest_version discovery.output with
+            | Error error ->
+                Printf.eprintf "phase=discovery outcome=failed reason=%s\n%!" error;
+                1
+            | Ok latest_version ->
+                if latest_version = current_version then (
+                  Printf.printf "symphony is already current (%s).\n%!" current_version;
+                  0)
+                else
+                  let install_command =
+                    Printf.sprintf "npm install -g %s@%s --prefix %s" package_name latest_version
+                      (Util.shell_quote install_prefix)
+                  in
+                  if (not yes) && not (is_tty ()) then (
+                    Printf.eprintf "phase=confirmation outcome=failed reason=non-interactive update requires --yes\n%!";
+                    1)
+                  else if (not yes) && not (confirm ~current_version ~latest_version ~install_prefix ~install_command)
+                  then (
+                    Printf.eprintf "phase=confirmation outcome=failed reason=update declined\n%!";
+                    1)
+                  else
+                    let install = runner install_command in
+                    if install.code <> 0 then (
+                      Printf.eprintf "phase=install outcome=failed Install Prefix=%s\n%s\n%s\n%!" install_prefix
+                        install.output (manual_repair ~target_version:latest_version ~install_prefix);
+                      1)
+                    else
+                      let resolved = runner "command -v symphony" in
+                      let validation =
+                        runner (Printf.sprintf "%s --version" (Util.shell_quote launcher_path))
+                      in
+                      let resolved_launcher =
+                        if resolved.code = 0 then realpath_opt (Util.trim resolved.output) else None
+                      in
+                      if
+                        resolved_launcher = Some launcher_path
+                        && validation.code = 0
+                        && Util.trim validation.output = latest_version
+                      then (
+                        Printf.printf "symphony updated to %s.\n%!" latest_version;
+                        0)
+                      else (
+                        Printf.eprintf
+                          "phase=validation outcome=failed expected=%s observed=%s resolved=%s Install Prefix=%s\n%s\n%!"
+                          latest_version (Util.trim validation.output) (Util.trim resolved.output) install_prefix
+                          (manual_repair ~target_version:latest_version ~install_prefix);
+                        1))

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -638,6 +638,174 @@ let test_cli_mode_selection () =
   Alcotest.(check string) "terminal default" "terminal_console" (Cli_mode.(select ~web:false |> to_string));
   Alcotest.(check string) "web flag" "web_dashboard" (Cli_mode.(select ~web:true |> to_string))
 
+let make_fake_npm_install root =
+  let prefix = Filename.concat root "prefix" in
+  let package_root = Filename.concat prefix "lib/node_modules/symphony-orchestrator" in
+  let bin_dir = Filename.concat prefix "bin" in
+  Util.mkdir_p (Filename.concat package_root "bin");
+  Util.mkdir_p bin_dir;
+  Util.write_file (Filename.concat package_root "package.json") {|{"name":"symphony-orchestrator"}|};
+  let launcher_target = Filename.concat package_root "bin/symphony.js" in
+  Util.write_file launcher_target "#!/usr/bin/env node\n";
+  Unix.chmod launcher_target 0o755;
+  let launcher = Filename.concat bin_dir "symphony" in
+  Unix.symlink launcher_target launcher;
+  (prefix, launcher, launcher_target)
+
+let test_update_detects_npm_install_prefix () =
+  with_temp_dir "symphony-update-prefix-" (fun root ->
+      let prefix, launcher, launcher_target = make_fake_npm_install root in
+      match Update_cli.detect_install_shape ~launcher_path:launcher with
+      | Update_cli.Npm_package shape ->
+          Alcotest.(check string) "launcher realpath" (Unix.realpath launcher_target) shape.launcher_path;
+          Alcotest.(check string) "install prefix" (Unix.realpath prefix) (Unix.realpath shape.install_prefix)
+      | Update_cli.Source_checkout path -> Alcotest.fail ("unexpected source checkout: " ^ path)
+      | Update_cli.Unsupported reason -> Alcotest.fail reason)
+
+let test_update_rejects_source_checkout_launcher () =
+  with_temp_dir "symphony-update-source-" (fun root ->
+      Util.write_file (Filename.concat root "dune-project") "(lang dune 3.0)\n";
+      Util.mkdir_p (Filename.concat root "bin");
+      let launcher = Filename.concat root "bin/symphony.js" in
+      Util.write_file launcher "#!/usr/bin/env node\n";
+      Unix.chmod launcher 0o755;
+      match Update_cli.detect_install_shape ~launcher_path:launcher with
+      | Update_cli.Source_checkout source_root -> Alcotest.(check string) "source root" (Unix.realpath root) source_root
+      | Update_cli.Npm_package _ -> Alcotest.fail "source checkout must not be treated as npm install"
+      | Update_cli.Unsupported reason -> Alcotest.fail reason)
+
+let test_update_prefers_launcher_env () =
+  let original = Sys.getenv_opt "SYMPHONY_LAUNCHER_PATH" in
+  Fun.protect
+    ~finally:(fun () ->
+      match original with
+      | Some value -> Unix.putenv "SYMPHONY_LAUNCHER_PATH" value
+      | None -> Unix.putenv "SYMPHONY_LAUNCHER_PATH" "")
+    (fun () ->
+      Unix.putenv "SYMPHONY_LAUNCHER_PATH" "/tmp/current-symphony";
+      match Update_cli.find_callable () with
+      | Ok path -> Alcotest.(check string) "launcher env" "/tmp/current-symphony" path
+      | Error error -> Alcotest.fail error)
+
+let test_update_noninteractive_requires_yes_before_install () =
+  with_temp_dir "symphony-update-noninteractive-" (fun root ->
+      let _, launcher, _ = make_fake_npm_install root in
+      let commands = ref [] in
+      let runner command =
+        commands := command :: !commands;
+        if command = "npm view symphony-orchestrator version --json" then { Update_cli.code = 0; output = {|"0.2.0"|} }
+        else Alcotest.fail ("unexpected command: " ^ command)
+      in
+      let code =
+        Update_cli.run ~runner ~find_callable:(fun () -> Ok launcher) ~is_tty:(fun () -> false) ~current_version:"0.1.1"
+          ~yes:false ()
+      in
+      Alcotest.(check int) "exit code" 1 code;
+      Alcotest.(check (list string)) "only discovers latest"
+        [ "npm view symphony-orchestrator version --json" ]
+        (List.rev !commands))
+
+let test_update_already_current_does_not_require_yes () =
+  with_temp_dir "symphony-update-current-" (fun root ->
+      let _, launcher, _ = make_fake_npm_install root in
+      let commands = ref [] in
+      let runner command =
+        commands := command :: !commands;
+        if command = "npm view symphony-orchestrator version --json" then { Update_cli.code = 0; output = {|"0.1.1"|} }
+        else Alcotest.fail ("unexpected command: " ^ command)
+      in
+      let code =
+        Update_cli.run ~runner ~find_callable:(fun () -> Ok launcher) ~is_tty:(fun () -> false) ~current_version:"0.1.1"
+          ~yes:false ()
+      in
+      Alcotest.(check int) "exit code" 0 code;
+      Alcotest.(check (list string)) "only discovers latest"
+        [ "npm view symphony-orchestrator version --json" ]
+        (List.rev !commands))
+
+let test_update_discovery_failure_does_not_install () =
+  with_temp_dir "symphony-update-discovery-" (fun root ->
+      let _, launcher, _ = make_fake_npm_install root in
+      let commands = ref [] in
+      let runner command =
+        commands := command :: !commands;
+        if command = "npm view symphony-orchestrator version --json" then { Update_cli.code = 1; output = "offline" }
+        else Alcotest.fail ("unexpected command: " ^ command)
+      in
+      let code =
+        Update_cli.run ~runner ~find_callable:(fun () -> Ok launcher) ~is_tty:(fun () -> false) ~current_version:"0.1.1"
+          ~yes:true ()
+      in
+      Alcotest.(check int) "exit code" 1 code;
+      Alcotest.(check (list string)) "only discovers latest"
+        [ "npm view symphony-orchestrator version --json" ]
+        (List.rev !commands))
+
+let test_update_installs_and_validates_with_yes () =
+  with_temp_dir "symphony-update-yes-" (fun root ->
+      let prefix, launcher, launcher_target = make_fake_npm_install root in
+      let launcher_real = Unix.realpath launcher_target in
+      let commands = ref [] in
+      let runner command =
+        commands := command :: !commands;
+        if command = "npm view symphony-orchestrator version --json" then { Update_cli.code = 0; output = {|"0.2.0"|} }
+        else if
+          command
+          = Printf.sprintf "npm install -g symphony-orchestrator@0.2.0 --prefix %s" (Util.shell_quote prefix)
+        then { Update_cli.code = 0; output = "installed" }
+        else if command = "command -v symphony" then { Update_cli.code = 0; output = launcher }
+        else if command = Printf.sprintf "%s --version" (Util.shell_quote launcher_real) then
+          { Update_cli.code = 0; output = "0.2.0" }
+        else Alcotest.fail ("unexpected command: " ^ command)
+      in
+      let code =
+        Update_cli.run ~runner ~find_callable:(fun () -> Ok launcher) ~is_tty:(fun () -> false) ~current_version:"0.1.1"
+          ~yes:true ()
+      in
+      Alcotest.(check int) "exit code" 0 code;
+      Alcotest.(check int) "command count" 4 (List.length !commands))
+
+let test_update_install_failure_does_not_validate () =
+  with_temp_dir "symphony-update-install-failure-" (fun root ->
+      let prefix, launcher, _ = make_fake_npm_install root in
+      let commands = ref [] in
+      let runner command =
+        commands := command :: !commands;
+        if command = "npm view symphony-orchestrator version --json" then { Update_cli.code = 0; output = {|"0.2.0"|} }
+        else if
+          command
+          = Printf.sprintf "npm install -g symphony-orchestrator@0.2.0 --prefix %s" (Util.shell_quote prefix)
+        then { Update_cli.code = 1; output = "EACCES" }
+        else Alcotest.fail ("unexpected command: " ^ command)
+      in
+      let code =
+        Update_cli.run ~runner ~find_callable:(fun () -> Ok launcher) ~is_tty:(fun () -> false) ~current_version:"0.1.1"
+          ~yes:true ()
+      in
+      Alcotest.(check int) "exit code" 1 code;
+      Alcotest.(check int) "discovery and install only" 2 (List.length !commands))
+
+let test_update_validation_failure_is_not_success () =
+  with_temp_dir "symphony-update-validation-" (fun root ->
+      let prefix, launcher, launcher_target = make_fake_npm_install root in
+      let launcher_real = Unix.realpath launcher_target in
+      let runner command =
+        if command = "npm view symphony-orchestrator version --json" then { Update_cli.code = 0; output = {|"0.2.0"|} }
+        else if
+          command
+          = Printf.sprintf "npm install -g symphony-orchestrator@0.2.0 --prefix %s" (Util.shell_quote prefix)
+        then { Update_cli.code = 0; output = "installed" }
+        else if command = "command -v symphony" then { Update_cli.code = 0; output = launcher }
+        else if command = Printf.sprintf "%s --version" (Util.shell_quote launcher_real) then
+          { Update_cli.code = 0; output = "0.1.1" }
+        else Alcotest.fail ("unexpected command: " ^ command)
+      in
+      let code =
+        Update_cli.run ~runner ~find_callable:(fun () -> Ok launcher) ~is_tty:(fun () -> false) ~current_version:"0.1.1"
+          ~yes:true ()
+      in
+      Alcotest.(check int) "exit code" 1 code)
+
 let test_runtime_state_exposes_running_issue_details () =
   let issue =
     {
@@ -2840,6 +3008,15 @@ let () =
       ( "cli",
         [
           Alcotest.test_case "selects terminal or web mode" `Quick test_cli_mode_selection;
+          Alcotest.test_case "detects update Install Prefix" `Quick test_update_detects_npm_install_prefix;
+          Alcotest.test_case "rejects source checkout updates" `Quick test_update_rejects_source_checkout_launcher;
+          Alcotest.test_case "prefers launcher environment" `Quick test_update_prefers_launcher_env;
+          Alcotest.test_case "requires --yes when non-interactive" `Quick test_update_noninteractive_requires_yes_before_install;
+          Alcotest.test_case "already current skips confirmation" `Quick test_update_already_current_does_not_require_yes;
+          Alcotest.test_case "discovery failure does not install" `Quick test_update_discovery_failure_does_not_install;
+          Alcotest.test_case "installs and validates update" `Quick test_update_installs_and_validates_with_yes;
+          Alcotest.test_case "install failure does not validate" `Quick test_update_install_failure_does_not_validate;
+          Alcotest.test_case "fails validation mismatch" `Quick test_update_validation_failure_is_not_success;
           Alcotest.test_case "ready terminal mode runs orchestrator" `Quick test_ready_terminal_mode_runs_orchestrator;
         ] );
       ( "github-tracker",

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -662,6 +662,16 @@ let test_update_detects_npm_install_prefix () =
       | Update_cli.Source_checkout path -> Alcotest.fail ("unexpected source checkout: " ^ path)
       | Update_cli.Unsupported reason -> Alcotest.fail reason)
 
+let test_update_detects_prefix_from_package_launcher () =
+  with_temp_dir "symphony-update-package-launcher-" (fun root ->
+      let prefix, _, launcher_target = make_fake_npm_install root in
+      match Update_cli.detect_install_shape ~launcher_path:launcher_target with
+      | Update_cli.Npm_package shape ->
+          Alcotest.(check string) "launcher realpath" (Unix.realpath launcher_target) shape.launcher_path;
+          Alcotest.(check string) "install prefix" (Unix.realpath prefix) (Unix.realpath shape.install_prefix)
+      | Update_cli.Source_checkout path -> Alcotest.fail ("unexpected source checkout: " ^ path)
+      | Update_cli.Unsupported reason -> Alcotest.fail reason)
+
 let test_update_rejects_source_checkout_launcher () =
   with_temp_dir "symphony-update-source-" (fun root ->
       Util.write_file (Filename.concat root "dune-project") "(lang dune 3.0)\n";
@@ -3009,6 +3019,8 @@ let () =
         [
           Alcotest.test_case "selects terminal or web mode" `Quick test_cli_mode_selection;
           Alcotest.test_case "detects update Install Prefix" `Quick test_update_detects_npm_install_prefix;
+          Alcotest.test_case "detects prefix from package launcher" `Quick
+            test_update_detects_prefix_from_package_launcher;
           Alcotest.test_case "rejects source checkout updates" `Quick test_update_rejects_source_checkout_launcher;
           Alcotest.test_case "prefers launcher environment" `Quick test_update_prefers_launcher_env;
           Alcotest.test_case "requires --yes when non-interactive" `Quick test_update_noninteractive_requires_yes_before_install;

--- a/bin/symphony.js
+++ b/bin/symphony.js
@@ -18,7 +18,11 @@ function executableCandidate() {
 }
 
 function run(command, args, options = {}) {
-  const child = spawn(command, args, { stdio: "inherit", ...options });
+  const child = spawn(command, args, {
+    stdio: "inherit",
+    env: { ...process.env, SYMPHONY_LAUNCHER_PATH: process.argv[1] },
+    ...options
+  });
   child.on("exit", (code, signal) => {
     if (signal) {
       process.kill(process.pid, signal);

--- a/docs/adr/0011-update-cli-package-through-npm-owner-prefix.md
+++ b/docs/adr/0011-update-cli-package-through-npm-owner-prefix.md
@@ -1,0 +1,3 @@
+# Update CLI Package through npm owner prefix
+
+Personal Symphony will treat npm registry package metadata as the canonical Update Source for `symphony update`, even though release builds may also publish GitHub Release assets. The command updates only npm-installed CLI Package instances by installing the latest package into the Install Prefix that owns the running `symphony` command, then validates that the callable command reports the target version. This avoids mixing package-manager updates with source checkout workflows or ad hoc binary replacement, and keeps permission, cache, and rollback behavior inside npm's normal ownership model.


### PR DESCRIPTION
## Summary
- add a backend update command for npm-installed CLI Packages
- detect the owning Install Prefix and reject source/unsupported installs
- validate updated callable versions and document the update semantics

## Verification
- pnpm backend:build
- pnpm test
- node --check bin/symphony.js
- SYMPHONY_LAUNCHER_PATH=/Users/matheusbbarni/projects/symphony-orchestrator/bin/symphony.js /Users/matheusbbarni/projects/symphony-orchestrator/_build/default/apps/backend/bin/main.exe update --yes

Closes #22