### PR TITLE
Add stage skill load support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Configure or disable this in `.symphony/settings.json`:
       {
         "states": ["Backlog"],
         "agent": "planner",
+        "skills": [],
         "successStatus": "To-Do",
         "retryStatus": "Backlog",
         "goal": {
@@ -189,6 +190,7 @@ Configure or disable this in `.symphony/settings.json`:
       {
         "states": ["Todo", "To-Do", "In progress", "In Progress"],
         "agent": "engineer",
+        "skills": [],
         "startStatus": "In progress",
         "successStatus": "In review",
         "retryStatus": "To-Do",
@@ -205,6 +207,7 @@ Configure or disable this in `.symphony/settings.json`:
       {
         "states": ["In review", "In Review"],
         "agent": "reviewer",
+        "skills": [],
         "successStatus": "Done",
         "retryStatus": "In progress",
         "goal": {
@@ -223,6 +226,14 @@ Configure or disable this in `.symphony/settings.json`:
 ```
 
 Set `"enabled": false` to use the single base `.symphony/prompt.md` for every issue.
+
+Set `skills` to an ordered list of skill identifiers when a stage requires reusable Codex workflows.
+Runtime Settings store identifiers without `$`, for example `"to-prd"` or `"github:gh-fix-ci"`.
+When a matching Stage Agent runs, Symphony renders those as `$to-prd` style references in the normal
+Agent Prompt after the Stage Agent instructions and before the base Agent Prompt. It does not expand
+skill files and does not include Stage Skill Load in Stage Goal Context. Missing, malformed, or
+duplicate skill identifiers are Readiness Gaps; Symphony checks all configured stages before
+dispatch, resolving Workspace Repository skills before Codex Home skills.
 
 Set `goal.enabled` to `true` on a specific stage to enable Stage Goal Handoff for that stage only.
 When enabled, Symphony sends `/goal` with deterministic Stage Goal Context before the normal Agent

--- a/apps/backend/lib/config.ml
+++ b/apps/backend/lib/config.ml
@@ -40,6 +40,7 @@ type stage_goal = { enabled : bool }
 type stage_agent = {
   states : string list;
   agent : string;
+  skills : string list;
   start_status : string option;
   success_status : string option;
   retry_status : string option;
@@ -98,6 +99,7 @@ let default_stage_agents =
     {
       states = [ "Backlog" ];
       agent = "planner";
+      skills = [];
       start_status = None;
       success_status = Some "To-Do";
       retry_status = Some "Backlog";
@@ -107,6 +109,7 @@ let default_stage_agents =
     {
       states = [ "Todo"; "To-Do"; "In progress"; "In Progress" ];
       agent = "engineer";
+      skills = [];
       start_status = Some "In progress";
       success_status = Some "In review";
       retry_status = Some "To-Do";
@@ -116,6 +119,7 @@ let default_stage_agents =
     {
       states = [ "In review"; "In Review" ];
       agent = "reviewer";
+      skills = [];
       start_status = None;
       success_status = Some "Done";
       retry_status = Some "In progress";
@@ -292,6 +296,7 @@ let json_stage_agent json =
   {
     states = json_string_list "states" json ~default:[];
     agent = json_string "agent" json ~default:"";
+    skills = json_string_list "skills" json ~default:[];
     start_status = json_optional_string "startStatus" json;
     success_status = json_optional_string "successStatus" json;
     retry_status = json_optional_string "retryStatus" json;
@@ -498,6 +503,136 @@ let from_settings_file ~workspace_root path =
 let is_placeholder = function "" | "your-org" | "your-repo" -> true | _ -> false
 let is_repository_name value = not (String.contains value '/')
 
+let codex_home () =
+  match Sys.getenv_opt "CODEX_HOME" with
+  | Some home when Util.trim home <> "" -> home
+  | _ -> (
+      match Sys.getenv_opt "HOME" with
+      | Some home when Util.trim home <> "" -> Filename.concat home ".codex"
+      | _ -> Filename.concat (Unix.getcwd ()) ".codex")
+
+let contains_whitespace value =
+  String.exists
+    (function ' ' | '\t' | '\n' | '\r' | '\012' -> true | _ -> false)
+    value
+
+let contains_dot_segment value =
+  String.contains value '.'
+  &&
+  let parts = String.split_on_char ':' value |> List.concat_map (String.split_on_char '.') in
+  List.exists (( = ) "") parts || List.exists (( = ) "..") (String.split_on_char '/' value)
+
+let valid_skill_identifier identifier =
+  let identifier = Util.trim identifier in
+  let valid_colons =
+    match String.split_on_char ':' identifier with
+    | [ value ] -> value <> ""
+    | [ prefix; name ] -> prefix <> "" && name <> ""
+    | _ -> false
+  in
+  identifier <> ""
+  && valid_colons
+  && not (String.contains identifier '$')
+  && not (contains_whitespace identifier)
+  && not (String.contains identifier '/')
+  && not (String.contains identifier '\\')
+  && not (contains_dot_segment identifier)
+
+let skill_candidates roots identifier =
+  let prefixed_candidates root =
+    match String.split_on_char ':' identifier with
+    | [ prefix; name ] when prefix <> "" && name <> "" ->
+        [
+          Filename.concat (Filename.concat root prefix) name;
+          Filename.concat
+            (Filename.concat
+               (Filename.concat (Filename.concat (Filename.concat root "plugins") "cache") "openai-curated")
+               prefix)
+            name;
+        ]
+    | _ -> []
+  in
+  roots
+  |> List.concat_map (fun root ->
+         [
+           Filename.concat (Filename.concat root identifier) "SKILL.md";
+           Filename.concat (Filename.concat (Filename.concat root "skills") identifier) "SKILL.md";
+           Filename.concat (Filename.concat (Filename.concat (Filename.concat root "skills") ".system") identifier) "SKILL.md";
+         ]
+         @ (prefixed_candidates root |> List.map (fun dir -> Filename.concat dir "SKILL.md")))
+
+let path_exists path = Sys.file_exists path && not (Sys.is_directory path)
+
+let path_has_dir path dir =
+  String.split_on_char '/' path |> List.exists (( = ) dir)
+
+let rec find_skill_by_scan ?plugin_prefix ~root identifier =
+  if not (Sys.file_exists root && Sys.is_directory root) then None
+  else
+    let entries = Sys.readdir root |> Array.to_list in
+    List.find_map
+      (fun name ->
+        let path = Filename.concat root name in
+        if Sys.is_directory path then
+          let skill_md = Filename.concat path "SKILL.md" in
+          if
+            path_exists skill_md
+            &&
+            match plugin_prefix with
+            | Some prefix -> name = identifier && path_has_dir path prefix
+            | None -> name = identifier
+          then Some skill_md
+          else find_skill_by_scan ?plugin_prefix ~root:path identifier
+        else None)
+      entries
+
+let resolve_stage_skill_path config identifier =
+  let workspace_skills = Filename.concat config.repository_root ".agents/skills" in
+  let home = codex_home () in
+  let home_skills = Filename.concat home "skills" in
+  let home_plugins = Filename.concat (Filename.concat home "plugins") "cache" in
+  let plugin_prefix, unqualified_identifier =
+    match String.split_on_char ':' identifier with
+    | [ prefix; name ] when prefix <> "" && name <> "" -> (Some prefix, name)
+    | _ -> (None, identifier)
+  in
+  match List.find_opt path_exists (skill_candidates [ workspace_skills ] identifier) with
+  | Some path -> Some path
+  | None -> (
+      match find_skill_by_scan ~root:workspace_skills identifier with
+      | Some _ as path -> path
+      | None -> (
+          match List.find_opt path_exists (skill_candidates [ home ] identifier) with
+          | Some _ as path -> path
+          | None -> (
+              match find_skill_by_scan ~root:home_skills identifier with
+              | Some _ as path -> path
+              | None -> find_skill_by_scan ?plugin_prefix ~root:home_plugins unqualified_identifier)))
+
+let skill_exists config identifier = Option.is_some (resolve_stage_skill_path config identifier)
+
+let validate_stage_skill_load config add =
+  if config.stage_agents.enabled then
+    List.iter
+      (fun (stage : stage_agent) ->
+        let seen = Hashtbl.create 8 in
+        List.iter
+          (fun skill ->
+            let skill = Util.trim skill in
+            let requirement = "stageAgents." ^ stage.agent ^ ".skills." ^ skill in
+            if not (valid_skill_identifier skill) then
+              add requirement
+                "Use skill identifiers without $, whitespace, path separators, dot segments, or empty values."
+            else if Hashtbl.mem seen skill then
+              add requirement "Remove duplicate skill identifiers from the Stage Skill Load."
+            else (
+              Hashtbl.add seen skill ();
+              if not (skill_exists config skill) then
+                add requirement
+                  "Install the skill in the Workspace Repository .agents/skills directory or in the Codex Home."))
+          stage.skills)
+      config.stage_agents.stages
+
 let readiness_gaps config =
   let gaps = ref [] in
   let add requirement remediation = gaps := { requirement; remediation } :: !gaps in
@@ -540,6 +675,7 @@ let readiness_gaps config =
         if not (Sys.file_exists path) then
           add ("stageAgents." ^ stage.agent) (Printf.sprintf "Create the stage agent prompt file: %s" path))
       config.stage_agents.stages);
+  validate_stage_skill_load config add;
   List.rev !gaps
 
 let validate_for_dispatch config =

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -276,11 +276,19 @@ let stage_for_issue config issue =
 let agent_file config agent =
   Filename.concat config.Config.stage_agents.root (agent ^ ".md")
 
+let stage_skill_load_prompt (stage : Config.stage_agent option) =
+  match stage with
+  | Some stage when stage.skills <> [] ->
+      let skills = stage.skills |> List.map (fun skill -> "$" ^ Util.trim skill) |> String.concat "\n" in
+      Some (Printf.sprintf "Stage Skill Load:\n%s" skills)
+  | _ -> None
+
 let agent_prompt config issue =
   if not config.Config.stage_agents.enabled then None
   else
+    let stage = stage_for_issue config issue in
     let agent =
-      match stage_for_issue config issue with
+      match stage with
       | Some stage -> Some stage.agent
       | None -> config.stage_agents.default_agent
     in
@@ -288,13 +296,16 @@ let agent_prompt config issue =
     | None -> None
     | Some agent ->
         let path = agent_file config agent in
-        if Sys.file_exists path then Some (agent, Util.read_file path |> Util.trim) else None
+        if Sys.file_exists path then Some (agent, stage, Util.read_file path |> Util.trim) else None
 
 let normal_prompt config issue base_prompt =
   match agent_prompt config issue with
   | None -> base_prompt
-  | Some (agent, prompt) ->
-      Printf.sprintf "%s\n\n---\n\nStage agent: %s\n\n%s\n" prompt agent base_prompt
+  | Some (agent, stage, prompt) ->
+      let stage_skill_load =
+        match stage_skill_load_prompt stage with Some prompt -> "\n\n" ^ prompt | None -> ""
+      in
+      Printf.sprintf "%s%s\n\n---\n\nStage agent: %s\n\n%s\n" prompt stage_skill_load agent base_prompt
 
 let stage_goal_handoff_stage config issue =
   match stage_for_issue config issue with

--- a/apps/backend/lib/runtime_home.ml
+++ b/apps/backend/lib/runtime_home.ml
@@ -63,6 +63,7 @@ let settings_json =
       {
         "states": ["Backlog"],
         "agent": "planner",
+        "skills": [],
         "successStatus": "To-Do",
         "retryStatus": "Backlog",
         "goal": {
@@ -78,6 +79,7 @@ let settings_json =
       {
         "states": ["Todo", "To-Do", "In progress", "In Progress"],
         "agent": "engineer",
+        "skills": [],
         "startStatus": "In progress",
         "successStatus": "In review",
         "retryStatus": "To-Do",
@@ -94,6 +96,7 @@ let settings_json =
       {
         "states": ["In review", "In Review"],
         "agent": "reviewer",
+        "skills": [],
         "successStatus": "Done",
         "retryStatus": "In progress",
         "goal": {

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -21,6 +21,17 @@ let run_ok ?(cwd = ".") label command =
   | Ok output -> output
   | Error error -> Alcotest.fail (label ^ ": " ^ error)
 
+let contains_substring text substring =
+  let text_len = String.length text in
+  let substring_len = String.length substring in
+  let rec loop index =
+    if substring_len = 0 then true
+    else if index + substring_len > text_len then false
+    else if String.sub text index substring_len = substring then true
+    else loop (index + 1)
+  in
+  loop 0
+
 let init_repo root branch =
   ignore (run_ok ~cwd:root "git init" (Printf.sprintf "git init -q -b %s" (Util.shell_quote branch)));
   ignore (run_ok ~cwd:root "git user email" "git config user.email test@example.com");
@@ -165,6 +176,69 @@ let test_disabled_stage_goal_does_not_require_codex_goals () =
             (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "codex.goals") gaps);
           Alcotest.(check bool) "no stdin gap" false
             (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "codex.goalStdin") gaps)))
+
+let test_config_parses_stage_skill_load_and_readiness () =
+  let original_codex_home = Sys.getenv_opt "CODEX_HOME" in
+  Fun.protect
+    ~finally:(fun () ->
+      match original_codex_home with
+      | Some value -> Unix.putenv "CODEX_HOME" value
+      | None -> Unix.putenv "CODEX_HOME" "")
+    (fun () ->
+      with_temp_dir "symphony-stage-skills-" (fun root ->
+          Unix.putenv "GITHUB_TOKEN" "token";
+          let codex_home = Filename.concat root "codex-home" in
+          Unix.putenv "CODEX_HOME" codex_home;
+          let agents_root = Filename.concat root ".symphony/agents" in
+          let workspace_skills = Filename.concat root ".agents/skills" in
+          let codex_skills = Filename.concat codex_home "skills" in
+          Util.mkdir_p agents_root;
+          Util.mkdir_p (Filename.concat workspace_skills "to-prd");
+          Util.mkdir_p (Filename.concat workspace_skills "shared-skill");
+          Util.mkdir_p (Filename.concat codex_skills "imagegen");
+          Util.mkdir_p (Filename.concat codex_skills "shared-skill");
+          Util.write_file (Filename.concat agents_root "planner.md") "Planner";
+          Util.write_file (Filename.concat (Filename.concat workspace_skills "to-prd") "SKILL.md") "workspace skill";
+          Util.write_file (Filename.concat (Filename.concat workspace_skills "shared-skill") "SKILL.md") "workspace shared";
+          Util.write_file (Filename.concat (Filename.concat codex_skills "imagegen") "SKILL.md") "home skill";
+          Util.write_file (Filename.concat (Filename.concat codex_skills "shared-skill") "SKILL.md") "home shared";
+          let settings = Filename.concat root "settings.json" in
+          Util.write_file settings
+            {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "stageAgents": {
+    "enabled": true,
+    "root": ".symphony/agents",
+    "stages": [
+      {"states": ["Backlog"], "agent": "planner", "skills": ["to-prd", "imagegen", "shared-skill"]}
+    ]
+  }
+}|};
+          let config = Config.from_settings_file ~workspace_root:root settings in
+          (match config.stage_agents.stages with
+          | [ stage ] -> Alcotest.(check (list string)) "ordered skills" [ "to-prd"; "imagegen"; "shared-skill" ] stage.skills
+          | _ -> Alcotest.fail "expected one stage");
+          Alcotest.(check int) "no readiness gaps" 0 (List.length (Config.readiness_gaps config));
+          Alcotest.(check string) "workspace wins"
+            (Filename.concat (Filename.concat workspace_skills "shared-skill") "SKILL.md")
+            (Option.value (Config.resolve_stage_skill_path config "shared-skill") ~default:"missing");
+          Util.write_file settings
+            {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "stageAgents": {
+    "enabled": true,
+    "root": ".symphony/agents",
+    "stages": [
+      {"states": ["Backlog"], "agent": "planner", "skills": ["to-prd", "to-prd", "$bad", "missing-skill"]}
+    ]
+  }
+}|};
+          let config = Config.from_settings_file ~workspace_root:root settings in
+          let requirements = Config.readiness_gaps config |> List.map (fun (gap : Config.readiness_gap) -> gap.requirement) in
+          Alcotest.(check bool) "duplicate gap" true (List.exists (( = ) "stageAgents.planner.skills.to-prd") requirements);
+          Alcotest.(check bool) "malformed gap" true (List.exists (( = ) "stageAgents.planner.skills.$bad") requirements);
+          Alcotest.(check bool) "missing gap" true
+            (List.exists (( = ) "stageAgents.planner.skills.missing-skill") requirements)))
 
 let test_stage_goal_requires_codex_exec_stdin_support () =
   let original_home = Sys.getenv_opt "HOME" in
@@ -554,6 +628,8 @@ let test_settings_and_prompt_loading () =
       Alcotest.(check int) "stage mappings" 3 (List.length config.stage_agents.stages);
       (match config.stage_agents.stages with
       | planner :: engineer :: _ ->
+          Alcotest.(check (list string)) "planner skills default empty" [] planner.skills;
+          Alcotest.(check (list string)) "engineer skills default empty" [] engineer.skills;
           Alcotest.(check (option string)) "planner success status" (Some "To-Do") planner.success_status;
           Alcotest.(check bool) "planner goal disabled" false (Config.stage_goal_enabled planner);
           Alcotest.(check bool) "engineer goal disabled" false (Config.stage_goal_enabled engineer);
@@ -2059,6 +2135,7 @@ let test_orchestrator_uses_stage_agent_prompt_and_status () =
                   {
                     Config.states = [ "In review" ];
                     agent = "reviewer";
+                    skills = [];
                     start_status = None;
                     success_status = Some "Done";
                     retry_status = Some "In progress";
@@ -2149,6 +2226,7 @@ let test_orchestrator_prepends_stage_goal_handoff () =
                   {
                     Config.states = [ "Todo" ];
                     agent = "engineer";
+                    skills = [ "to-prd"; "github:gh-fix-ci" ];
                     start_status = None;
                     success_status = Some "In review";
                     retry_status = Some "Todo";
@@ -2180,6 +2258,8 @@ let test_orchestrator_prepends_stage_goal_handoff () =
       Alcotest.(check bool) "goal command first" true (String.starts_with ~prefix:"/goal {\"kind\":\"Stage Goal Context\"" !captured_prompt);
       Alcotest.(check bool) "stage agent included" true (String.contains !captured_prompt 'E');
       Alcotest.(check bool) "normal prompt included" true (String.contains !captured_prompt '#');
+      Alcotest.(check bool) "skill load preserves order" true
+        (contains_substring !captured_prompt "Stage Skill Load:\n$to-prd\n$github:gh-fix-ci");
       let goal_line =
         match String.split_on_char '\n' !captured_prompt with
         | first :: _ -> first
@@ -2198,7 +2278,9 @@ let test_orchestrator_prepends_stage_goal_handoff () =
       Alcotest.(check bool) "created timestamp omitted" true
         (match goal_json |> member "created_at" with `Null -> true | _ -> false);
       Alcotest.(check bool) "updated timestamp omitted" true
-        (match goal_json |> member "updated_at" with `Null -> true | _ -> false))
+        (match goal_json |> member "updated_at" with `Null -> true | _ -> false);
+      Alcotest.(check bool) "skill load omitted from goal context" true
+        (match goal_json |> member "skills" with `Null -> true | _ -> false))
 
 let test_orchestrator_skips_stage_goal_when_disabled () =
   with_temp_dir "symphony-stage-goal-disabled-prompt-" (fun root ->
@@ -2242,6 +2324,7 @@ let test_orchestrator_skips_stage_goal_when_disabled () =
                   {
                     Config.states = [ "Todo" ];
                     agent = "engineer";
+                    skills = [];
                     start_status = None;
                     success_status = Some "In review";
                     retry_status = Some "Todo";
@@ -2352,6 +2435,7 @@ let test_orchestrator_commits_stage_before_success_status () =
                   {
                     Config.states = [ "In progress" ];
                     agent = "engineer";
+                    skills = [];
                     start_status = None;
                     success_status = Some "In review";
                     retry_status = Some "Todo";
@@ -2498,6 +2582,7 @@ let test_orchestrator_retries_push_failure_before_success_status () =
                   {
                     Config.states = [ "In progress" ];
                     agent = "engineer";
+                    skills = [];
                     start_status = None;
                     success_status = Some "In review";
                     retry_status = Some "Todo";
@@ -2583,6 +2668,7 @@ let test_stage_commit_requires_code_changes () =
           {
             Config.states = [ "In progress" ];
             agent = "engineer";
+            skills = [];
             start_status = None;
             success_status = Some "In review";
             retry_status = Some "Todo";
@@ -2634,6 +2720,7 @@ let test_orchestrator_does_not_retry_empty_commit () =
                   {
                     Config.states = [ "In progress" ];
                     agent = "engineer";
+                    skills = [];
                     start_status = None;
                     success_status = Some "In review";
                     retry_status = Some "Todo";
@@ -2977,6 +3064,7 @@ let test_stage_commit_pushes_task_branch () =
           {
             Config.states = [ "In progress" ];
             agent = "engineer";
+            skills = [];
             start_status = None;
             success_status = Some "In review";
             retry_status = Some "Todo";
@@ -3169,6 +3257,7 @@ let () =
           Alcotest.test_case "parses git policy and stage push" `Quick test_config_parses_git_policy_and_stage_push;
           Alcotest.test_case "parses stage goal and readiness" `Quick test_config_parses_stage_goal_and_readiness;
           Alcotest.test_case "disabled stage goal does not require codex goals" `Quick test_disabled_stage_goal_does_not_require_codex_goals;
+          Alcotest.test_case "parses stage skill load and readiness" `Quick test_config_parses_stage_skill_load_and_readiness;
           Alcotest.test_case "stage goal requires codex exec stdin support" `Quick test_stage_goal_requires_codex_exec_stdin_support;
           Alcotest.test_case "stage goal live stdin probe" `Quick test_stage_goal_live_stdin_probe;
           Alcotest.test_case "requires pull request base branch when enabled" `Quick test_pull_request_base_branch_readiness_gap;


### PR DESCRIPTION
## Summary
- Add stage-level `skills` configuration for Stage Agents
- Validate missing, malformed, and duplicate Stage Skill Load entries as Readiness Gaps
- Render ordered `$skill` references in Agent Prompt while keeping Stage Goal Context unchanged
- Document `skills` configuration and bootstrap empty arrays for default stages

## Verification
- `pnpm test`

Closes #23