### PR TITLE
Add manual task merge CLI

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,10 @@ _Avoid_: main branch, default branch, protected branch
 The project status for a task whose agent work completed but whose Task Branch could not be auto-merged.
 _Avoid_: retry status, review status, failed status
 
+**Manual Task Merge**:
+A one-shot operator CLI action that integrates explicitly selected completed Agent Worktrees or Task Branches into the current Loop-Start Branch.
+_Avoid_: manual auto-merge, branch merge mode, raw git merge
+
 **Environment Template**:
 The committed `.symphony/.env.example` file that lists required runtime variables without secret values.
 _Avoid_: sample env, example secrets
@@ -226,6 +230,11 @@ _Avoid_: reinitialize, reset
 - Symphony may auto-merge a completed **Task Branch** into the **Loop-Start Branch** only when the **Loop-Start Branch** is not a **Protected Trunk Branch**.
 - Auto-merge of a **Task Branch** into the **Loop-Start Branch** is fast-forward only.
 - When auto-merge fails, Symphony may move the task to a **Merge Attention Status**.
+- **Manual Task Merge** integrates selected completed task work with `--merge` without running normal orchestration.
+- **Manual Task Merge** accepts issue identifiers such as `20` and `#20`; it does not accept raw **Task Branch** names.
+- **Manual Task Merge** preflights every selected task before merging anything, requires clean Loop-Start and Agent Worktrees, and uses fast-forward-only semantics.
+- **Manual Task Merge** may target a **Protected Trunk Branch** because explicit selected issue identifiers are the operator action.
+- **Manual Task Merge** does not push branches, run Startup Reconciliation, dispatch agents, or open a Batch Pull Request.
 - The default **Merge Attention Status** is `Human attention`.
 - The **Merge Attention Status** is paused and not dispatchable.
 - The default **Task Cleanup Policy** removes an **Agent Worktree** after its **Task Branch** is merged.

--- a/apps/backend/bin/main.ml
+++ b/apps/backend/bin/main.ml
@@ -225,7 +225,37 @@ let parse_ordered_queue_arg = function
       | Ok queue -> (Some queue, [])
       | Error problems -> (None, problems))
 
-let run_runtime port once web queue_arg =
+let render_manual_merge_report report =
+  List.iter
+    (fun (outcome : Manual_merge.outcome) ->
+      let action =
+        match outcome.integration with Manual_merge.Merged -> "merged" | Manual_merge.Already_integrated -> "already-integrated"
+      in
+      let status =
+        match outcome.status_update with None -> "" | Some status -> Printf.sprintf " status=%s" status
+      in
+      let cleanup =
+        match outcome.cleanup_error with None -> "" | Some error -> Printf.sprintf " cleanup=failed reason=%s" error
+      in
+      Printf.printf "merge %s branch=%s action=%s%s%s\n%!" outcome.issue.Issue.identifier outcome.branch action status
+        cleanup)
+    report.Manual_merge.outcomes;
+  Printf.printf "summary selected=%d merged=%d already_integrated=%d cleanup_failures=%d\n%!"
+    (List.length report.outcomes) report.merged report.already_integrated report.cleanup_failures
+
+let run_manual_merge config merge_args =
+  let tracker = Github_tracker.make config.Config.tracker in
+  let fetch_issues numbers = Github_tracker.fetch_project_issues_by_numbers tracker numbers in
+  let set_status issue status = Github_tracker.update_issue_status tracker issue status in
+  match Manual_merge.run ~fetch_issues ~set_status config merge_args with
+  | Ok report ->
+      render_manual_merge_report report;
+      if report.cleanup_failures = 0 then 0 else 1
+  | Error errors ->
+      List.iter (fun error -> Printf.eprintf "merge failed: %s\n%!" error) errors;
+      1
+
+let run_runtime port once web queue_arg merge_args =
   let run_until_stopped f =
     f ();
     0
@@ -241,52 +271,54 @@ let run_runtime port once web queue_arg =
         let config, prompt_template = load_runtime_config home in
         let ordered_queue, queue_parse_problems = parse_ordered_queue_arg queue_arg in
         let mode = Cli_mode.select ~web in
-        let state = readiness_state ?ordered_queue ~queue_parse_problems config in
         render_startup_completed ~mode:(Cli_mode.to_string mode) ~config ~runtime_home:home.runtime_dir;
-        if mode = Cli_mode.Web_dashboard then render_banner ();
-        if once then (
-          if mode = Cli_mode.Terminal_console then render_terminal_console config state;
-          0)
-        else
-          match Runtime_policy.action ~mode ~readiness_gaps:state.Runtime_state.readiness_gaps with
-          | Runtime_policy.Serve_readiness_state -> (
-              match mode with
-              | Cli_mode.Web_dashboard ->
-                  let port = Option.value port ~default:(Option.value config.server.port ~default:8080) in
-                  render_web_dashboard_starting ~port;
-                  let live = Server.create_live_state ~get_state:(fun () -> state) in
-                  run_until_stopped (fun () -> Server.serve ~live ~port ~get_state:(fun () -> state) ())
-              | Cli_mode.Terminal_console ->
-                  render_terminal_console config state;
-                  run_until_stopped (fun () ->
-                      while true do
-                        Unix.sleep 60
-                      done))
-          | Runtime_policy.Run_orchestrator ->
-              (match mode with
-              | Cli_mode.Web_dashboard ->
-                  let port = Option.value port ~default:(Option.value config.server.port ~default:8080) in
-                  render_web_dashboard_starting ~port;
-                  let orchestrator_ref = ref None in
-                  let live =
-                    Server.create_live_state ~get_state:(fun () ->
-                        match !orchestrator_ref with
-                        | Some orchestrator -> Orchestrator.get_state orchestrator
-                        | None -> state)
-                  in
-                  let orchestrator =
-                    Orchestrator.make ?ordered_queue ~config ~prompt_template
-                      ~notify_state:(fun _ -> Server.broadcast_live_state live)
-                      ()
-                  in
-                  orchestrator_ref := Some orchestrator;
-                  ignore (Thread.create Orchestrator.run_forever orchestrator);
-                  run_until_stopped (fun () ->
-                      Server.serve ~live ~port ~get_state:(fun () -> Orchestrator.get_state orchestrator) ())
-              | Cli_mode.Terminal_console ->
-                  let orchestrator = Orchestrator.make ?ordered_queue ~config ~prompt_template () in
-                  render_terminal_console config state;
-                  run_until_stopped (fun () -> Orchestrator.run_forever orchestrator))
+        if merge_args <> [] then run_manual_merge config merge_args
+        else (
+          let state = readiness_state ?ordered_queue ~queue_parse_problems config in
+          if mode = Cli_mode.Web_dashboard then render_banner ();
+          if once then (
+            if mode = Cli_mode.Terminal_console then render_terminal_console config state;
+            0)
+          else
+            match Runtime_policy.action ~mode ~readiness_gaps:state.Runtime_state.readiness_gaps with
+            | Runtime_policy.Serve_readiness_state -> (
+                match mode with
+                | Cli_mode.Web_dashboard ->
+                    let port = Option.value port ~default:(Option.value config.server.port ~default:8080) in
+                    render_web_dashboard_starting ~port;
+                    let live = Server.create_live_state ~get_state:(fun () -> state) in
+                    run_until_stopped (fun () -> Server.serve ~live ~port ~get_state:(fun () -> state) ())
+                | Cli_mode.Terminal_console ->
+                    render_terminal_console config state;
+                    run_until_stopped (fun () ->
+                        while true do
+                          Unix.sleep 60
+                        done))
+            | Runtime_policy.Run_orchestrator ->
+                (match mode with
+                | Cli_mode.Web_dashboard ->
+                    let port = Option.value port ~default:(Option.value config.server.port ~default:8080) in
+                    render_web_dashboard_starting ~port;
+                    let orchestrator_ref = ref None in
+                    let live =
+                      Server.create_live_state ~get_state:(fun () ->
+                          match !orchestrator_ref with
+                          | Some orchestrator -> Orchestrator.get_state orchestrator
+                          | None -> state)
+                    in
+                    let orchestrator =
+                      Orchestrator.make ?ordered_queue ~config ~prompt_template
+                        ~notify_state:(fun _ -> Server.broadcast_live_state live)
+                        ()
+                    in
+                    orchestrator_ref := Some orchestrator;
+                    ignore (Thread.create Orchestrator.run_forever orchestrator);
+                    run_until_stopped (fun () ->
+                        Server.serve ~live ~port ~get_state:(fun () -> Orchestrator.get_state orchestrator) ())
+                | Cli_mode.Terminal_console ->
+                    let orchestrator = Orchestrator.make ?ordered_queue ~config ~prompt_template () in
+                    render_terminal_console config state;
+                    run_until_stopped (fun () -> Orchestrator.run_forever orchestrator)))
   with
   | Runtime_home.Runtime_home_error msg | Config.Invalid_config msg | Prompt.Template_render_error msg
   | Workspace.Workspace_error msg ->
@@ -296,10 +328,10 @@ let run_runtime port once web queue_arg =
       Printf.eprintf "event=startup outcome=failed reason=%s\n%!" (Printexc.to_string exn);
       1
 
-let run workflow_path port once web queue_arg =
+let run workflow_path port once web queue_arg merge_args =
   match workflow_path with
   | Some path -> run_legacy path port once
-  | None -> run_runtime port once web queue_arg
+  | None -> run_runtime port once web queue_arg merge_args
 
 let init () =
   try
@@ -340,12 +372,20 @@ let queue_arg =
         ~doc:
           "Run an Ordered Queue from comma-separated Workspace Repository issue identifiers. Optional # prefixes are allowed. Only listed issues dispatch, in listed first-admission order, while still respecting agent.maxConcurrentAgents.")
 
+let merge_arg =
+  Arg.(
+    value
+    & opt_all string []
+    & info [ "merge" ] ~docv:"ISSUE"
+        ~doc:
+          "Run a one-shot Manual Task Merge for Workspace Repository issue identifiers. Optional # prefixes, comma-separated values, and repeated --merge flags are allowed.")
+
 let yes_arg =
   Arg.(value & flag & info [ "yes"; "y" ] ~doc:"Update without interactive confirmation.")
 
 let cmd =
   let doc = "Run Personal Symphony from a Git Workspace Repository root." in
-  let default = Term.(const run $ workflow_arg $ port_arg $ once_arg $ web_arg $ queue_arg) in
+  let default = Term.(const run $ workflow_arg $ port_arg $ once_arg $ web_arg $ queue_arg $ merge_arg) in
   let init_cmd =
     Cmd.v (Cmd.info "init" ~doc:"Create missing .symphony runtime files without overwriting edits.") Term.(const init $ const ())
   in

--- a/apps/backend/lib/manual_merge.ml
+++ b/apps/backend/lib/manual_merge.ml
@@ -1,0 +1,215 @@
+type selector = { raw : string; number : int; identifier : string }
+
+type integration = Merged | Already_integrated
+
+type outcome = {
+  issue : Issue.t;
+  branch : string;
+  workspace : Workspace.t;
+  integration : integration;
+  status_update : string option;
+  cleanup_error : string option;
+}
+
+type report = { outcomes : outcome list; merged : int; already_integrated : int; cleanup_failures : int }
+
+type fetch_issues = int list -> (int * Github_tracker.project_issue option) list
+type set_status = Issue.t -> string -> (unit, string) result
+
+let split_comma text =
+  text |> String.split_on_char ',' |> List.map Util.trim |> List.filter (fun part -> part <> "")
+
+let digits_only text =
+  text <> ""
+  && String.for_all
+       (function
+         | '0' .. '9' -> true
+         | _ -> false)
+       text
+
+let normalize_one raw =
+  let trimmed = Util.trim raw in
+  let body =
+    if String.length trimmed > 0 && trimmed.[0] = '#' then String.sub trimmed 1 (String.length trimmed - 1)
+    else trimmed
+  in
+  if digits_only body then
+    match int_of_string_opt body with
+    | Some number when number > 0 -> Ok { raw = trimmed; number; identifier = "#" ^ string_of_int number }
+    | _ -> Error (Printf.sprintf "invalid Manual Task Merge selector %S" raw)
+  else Error (Printf.sprintf "invalid Manual Task Merge selector %S; expected an issue identifier like 20 or #20" raw)
+
+let normalize_selectors args =
+  let raw_selectors = List.concat_map split_comma args in
+  if raw_selectors = [] then Error [ "Manual Task Merge requires at least one issue identifier" ]
+  else
+    let seen = Hashtbl.create 8 in
+    let rec loop acc errors = function
+      | [] -> if errors = [] then Ok (List.rev acc) else Error (List.rev errors)
+      | raw :: rest -> (
+          match normalize_one raw with
+          | Error error -> loop acc (error :: errors) rest
+          | Ok selector ->
+              if Hashtbl.mem seen selector.number then
+                loop acc
+                  (Printf.sprintf "duplicate Manual Task Merge selector %s" selector.identifier :: errors)
+                  rest
+              else (
+                Hashtbl.add seen selector.number ();
+                loop (selector :: acc) errors rest))
+    in
+    loop [] [] raw_selectors
+
+let command_ok ~cwd command =
+  match Orchestrator.run_shell_capture ~cwd command with Ok _ -> true | Error _ -> false
+
+let rev_parse ~cwd refname =
+  Orchestrator.run_shell_capture ~cwd (Printf.sprintf "git rev-parse %s" (Util.shell_quote refname))
+  |> Result.map Util.trim
+
+let is_ancestor ~cwd ~ancestor ~descendant =
+  command_ok ~cwd
+    (Printf.sprintf "git merge-base --is-ancestor %s %s" (Util.shell_quote ancestor) (Util.shell_quote descendant))
+
+let cleanup config issue workspace =
+  let errors = ref [] in
+  (if config.Config.git.cleanup.remove_worktree_after_merge then
+    match
+      Orchestrator.run_shell_capture ~cwd:config.Config.repository_root
+        (Printf.sprintf "git worktree remove %s" (Util.shell_quote workspace.Workspace.path))
+    with
+    | Ok _ -> ()
+    | Error error -> errors := ("worktree cleanup failed: " ^ error) :: !errors);
+  (if not config.Config.git.cleanup.keep_task_branch then
+    match
+      Orchestrator.run_shell_capture ~cwd:config.Config.repository_root
+        (Printf.sprintf "git branch -d %s" (Util.shell_quote (Orchestrator.task_branch config issue)))
+    with
+    | Ok _ -> ()
+    | Error error -> errors := ("task branch cleanup failed: " ^ error) :: !errors);
+  match List.rev !errors with [] -> None | errors -> Some (String.concat "; " errors)
+
+let review_success_status config issue =
+  match Orchestrator.stage_for_issue config issue with
+  | Some stage -> stage.Config.success_status
+  | None -> None
+
+type preflight = {
+  selector : selector;
+  issue : Issue.t;
+  branch : string;
+  workspace : Workspace.t;
+  already_integrated : bool;
+}
+
+let preflight_one config ~projected_tip row selector =
+  match row with
+  | None -> Error (Printf.sprintf "%s is missing from the Workspace Repository issue tracker" selector.identifier)
+  | Some { Github_tracker.project_status = None; _ } ->
+      Error
+        (Printf.sprintf "%s is absent from GitHub Project #%d" selector.identifier config.Config.tracker.project_number)
+  | Some { issue; _ } ->
+      let branch = Orchestrator.task_branch config issue in
+      let workspace = Workspace.create_for_issue ~root:config.Config.workspace.root issue.Issue.identifier in
+      let terminal = Github_tracker.status_is_terminal ~config:config.Config.tracker issue.Issue.state in
+      if not (Orchestrator.git_ref_exists config.repository_root branch) then
+        Error (Printf.sprintf "%s expected Task Branch %s does not exist" selector.identifier branch)
+      else
+        match Orchestrator.worktree_branch workspace.path with
+        | None -> Error (Printf.sprintf "%s expected Agent Worktree at %s" selector.identifier workspace.path)
+        | Some existing when existing <> branch ->
+            Error (Printf.sprintf "%s Agent Worktree uses %s but expected %s" selector.identifier existing branch)
+        | Some _ -> (
+            match Orchestrator.has_worktree_changes workspace.path with
+            | Error error -> Error (Printf.sprintf "%s Agent Worktree status failed at %s: %s" selector.identifier workspace.path error)
+            | Ok true -> Error (Printf.sprintf "%s Agent Worktree must be clean: %s" selector.identifier workspace.path)
+            | Ok false ->
+                let already_integrated =
+                  is_ancestor ~cwd:config.repository_root ~ancestor:branch ~descendant:projected_tip
+                in
+                if already_integrated then Ok ({ selector; issue; branch; workspace; already_integrated }, projected_tip)
+                else if terminal then
+                  Error
+                    (Printf.sprintf "%s is terminal in project state %S but %s is not on the Loop-Start Branch"
+                       selector.identifier issue.state branch)
+                else if is_ancestor ~cwd:config.repository_root ~ancestor:projected_tip ~descendant:branch then (
+                  match rev_parse ~cwd:config.repository_root branch with
+                  | Ok next_tip -> Ok ({ selector; issue; branch; workspace; already_integrated }, next_tip)
+                  | Error error ->
+                      Error (Printf.sprintf "%s Task Branch tip could not be resolved: %s" selector.identifier error))
+                else
+                  Error
+                    (Printf.sprintf "%s Task Branch %s cannot fast-forward from projected Loop-Start Branch tip"
+                       selector.identifier branch))
+
+let preflight config ~fetch_issues selectors =
+  if not (Orchestrator.is_git_repository config.Config.repository_root) then Error [ "Manual Task Merge requires a Git Workspace Repository" ]
+  else
+    match Orchestrator.has_worktree_changes config.repository_root with
+    | Error error -> Error [ "Loop-Start Worktree status failed at " ^ config.repository_root ^ ": " ^ error ]
+    | Ok true -> Error [ "Loop-Start Worktree must be clean: " ^ config.repository_root ]
+    | Ok false -> (
+        let fetched = fetch_issues (List.map (fun selector -> selector.number) selectors) in
+        let row_for number = List.assoc_opt number fetched |> Option.join in
+        match rev_parse ~cwd:config.repository_root "HEAD" with
+        | Error error -> Error [ "Loop-Start Branch tip could not be resolved: " ^ error ]
+        | Ok head ->
+            let rec loop projected acc errors = function
+              | [] -> if errors = [] then Ok (List.rev acc) else Error (List.rev errors)
+              | selector :: rest -> (
+                  match preflight_one config ~projected_tip:projected (row_for selector.number) selector with
+                  | Ok (item, next_tip) -> loop next_tip (item :: acc) errors rest
+                  | Error error -> loop projected acc (error :: errors) rest)
+            in
+            loop head [] [] selectors)
+
+let integrate_one config ~set_status item =
+  let integration =
+    if item.already_integrated then Ok Already_integrated
+    else
+      match
+        Orchestrator.run_shell_capture ~cwd:config.Config.repository_root
+          (Printf.sprintf "git merge --ff-only %s" (Util.shell_quote item.branch))
+      with
+      | Ok _ -> Ok Merged
+      | Error error -> Error error
+  in
+  match integration with
+  | Error error -> Error (Printf.sprintf "%s merge failed after preflight: %s" item.selector.identifier error)
+  | Ok integration ->
+      let status_update =
+        match review_success_status config item.issue with
+        | None -> None
+        | Some status -> (
+            match set_status item.issue status with
+            | Ok () -> Some status
+            | Error error -> raise (Failure (Printf.sprintf "%s tracker status update failed: %s" item.selector.identifier error)))
+      in
+      let cleanup_error = cleanup config item.issue item.workspace in
+      Ok { issue = item.issue; branch = item.branch; workspace = item.workspace; integration; status_update; cleanup_error }
+
+let run ~fetch_issues ~set_status config args =
+  match normalize_selectors args with
+  | Error errors -> Error errors
+  | Ok selectors -> (
+      match preflight config ~fetch_issues selectors with
+      | Error errors -> Error errors
+      | Ok items -> (
+          try
+            let outcomes =
+              List.map
+                (fun item ->
+                  match integrate_one config ~set_status item with Ok outcome -> outcome | Error error -> raise (Failure error))
+                items
+            in
+            let merged =
+              List.fold_left
+                (fun count outcome -> match outcome.integration with Merged -> count + 1 | Already_integrated -> count)
+                0 outcomes
+            in
+            let already_integrated = List.length outcomes - merged in
+            let cleanup_failures =
+              outcomes |> List.filter (fun outcome -> Option.is_some outcome.cleanup_error) |> List.length
+            in
+            Ok { outcomes; merged; already_integrated; cleanup_failures }
+          with Failure error -> Error [ error ]))

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -3145,6 +3145,165 @@ let test_auto_merge_failure_moves_human_attention () =
       Alcotest.(check int) "issue error" 1 (List.length state.issue_errors);
       Alcotest.(check bool) "worktree kept for inspection" true (Sys.file_exists workspace.path))
 
+let manual_merge_config ?(keep_task_branch = true) root =
+  if not (Sys.file_exists (Filename.concat root ".gitignore")) then (
+    Util.write_file (Filename.concat root ".gitignore") ".symphony/\nagents/\n";
+    ignore (run_ok ~cwd:root "ignore runtime files" "git add .gitignore && git commit -q -m ignore-runtime-files"));
+  let git =
+    {
+      (git_policy ~auto_merge:false ()) with
+      cleanup = { Config.remove_worktree_after_merge = true; keep_task_branch };
+    }
+  in
+  {
+    (base_orchestrator_config root git) with
+    stage_agents =
+      {
+        enabled = true;
+        root = Filename.concat root "agents";
+        default_agent = None;
+        stages =
+          [
+            {
+              states = [ "In review" ];
+              start_status = None;
+              success_status = Some "Done";
+              retry_status = None;
+              agent = "reviewer";
+              goal = None;
+              commit = None;
+            };
+          ];
+      };
+  }
+
+let project_issue issue = Some { Github_tracker.issue; project_status = Some issue.Issue.state; closed = false }
+
+let run_manual_merge_test config issues selectors =
+  let fetch numbers =
+    List.map
+      (fun number ->
+        ( number,
+          match issues |> List.find_opt (fun issue -> issue.Issue.identifier = "#" ^ string_of_int number) with
+          | None -> None
+          | Some issue -> project_issue issue ))
+      numbers
+  in
+  let statuses = ref [] in
+  let set_status issue status =
+    statuses := (issue.Issue.identifier, status) :: !statuses;
+    Ok ()
+  in
+  (Manual_merge.run ~fetch_issues:fetch ~set_status config selectors, statuses)
+
+let test_manual_merge_rejects_invalid_and_duplicate_selectors () =
+  with_temp_dir "symphony-manual-merge-selectors-" (fun root ->
+      init_repo root "feature/start";
+      let config = manual_merge_config root in
+      let result, _ = run_manual_merge_test config [] [ "20,#20"; "symphony/task-21" ] in
+      match result with
+      | Ok _ -> Alcotest.fail "expected selector preflight errors"
+      | Error errors ->
+          Alcotest.(check int) "two selector errors" 2 (List.length errors);
+          Alcotest.(check bool) "duplicate rejected" true
+            (List.exists (fun error -> String.contains error 'd') errors);
+          Alcotest.(check bool) "branch selector rejected" true
+            (List.exists (fun error -> String.contains error '/') errors))
+
+let test_manual_merge_fast_forwards_protected_trunk_and_updates_review_status () =
+  with_temp_dir "symphony-manual-merge-protected-" (fun root ->
+      init_repo root "main";
+      let config = manual_merge_config root in
+      let issue = Issue.empty ~id:"I20" ~identifier:"#20" ~title:"Twenty" ~state:"In review" in
+      let workspace =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"main" issue with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Util.write_file (Filename.concat workspace.path "manual.txt") "manual\n";
+      ignore (run_ok ~cwd:workspace.path "task commit" "git add manual.txt && git commit -q -m task");
+      let result, statuses = run_manual_merge_test config [ issue ] [ "#20" ] in
+      let report = match result with Ok report -> report | Error errors -> Alcotest.fail (String.concat "; " errors) in
+      Alcotest.(check int) "merged" 1 report.merged;
+      Alcotest.(check int) "already integrated" 0 report.already_integrated;
+      Alcotest.(check bool) "merged file present" true (Sys.file_exists (Filename.concat root "manual.txt"));
+      Alcotest.(check bool) "worktree removed" false (Sys.file_exists workspace.path);
+      Alcotest.(check (list (pair string string))) "review status advanced" [ ("#20", "Done") ] (List.rev !statuses))
+
+let test_manual_merge_preflight_is_all_or_nothing () =
+  with_temp_dir "symphony-manual-merge-preflight-" (fun root ->
+      init_repo root "feature/start";
+      let config = manual_merge_config root in
+      let issue20 = Issue.empty ~id:"I20" ~identifier:"#20" ~title:"Twenty" ~state:"In review" in
+      let issue21 = Issue.empty ~id:"I21" ~identifier:"#21" ~title:"Twenty one" ~state:"In review" in
+      let workspace20 =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"feature/start" issue20 with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Util.write_file (Filename.concat workspace20.path "twenty.txt") "twenty\n";
+      ignore (run_ok ~cwd:workspace20.path "task commit" "git add twenty.txt && git commit -q -m task");
+      let workspace21 =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"feature/start" issue21 with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Util.write_file (Filename.concat workspace21.path "dirty.txt") "dirty\n";
+      let result, statuses = run_manual_merge_test config [ issue20; issue21 ] [ "20,21" ] in
+      (match result with
+      | Ok _ -> Alcotest.fail "expected dirty Agent Worktree preflight failure"
+      | Error errors ->
+          Alcotest.(check int) "one preflight error" 1 (List.length errors);
+          Alcotest.(check bool) "diagnostic names dirty path" true (List.exists (fun error -> String.contains error '/') errors));
+      Alcotest.(check bool) "first branch not merged" false (Sys.file_exists (Filename.concat root "twenty.txt"));
+      Alcotest.(check (list (pair string string))) "no status updates" [] (List.rev !statuses))
+
+let test_manual_merge_accepts_cumulative_fast_forward_order () =
+  with_temp_dir "symphony-manual-merge-chain-" (fun root ->
+      init_repo root "feature/start";
+      let config = manual_merge_config root in
+      let issue20 = Issue.empty ~id:"I20" ~identifier:"#20" ~title:"Twenty" ~state:"In review" in
+      let workspace20 =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"feature/start" issue20 with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Util.write_file (Filename.concat workspace20.path "twenty.txt") "twenty\n";
+      ignore (run_ok ~cwd:workspace20.path "task commit" "git add twenty.txt && git commit -q -m task");
+      let issue21 = Issue.empty ~id:"I21" ~identifier:"#21" ~title:"Twenty one" ~state:"In review" in
+      ignore (run_ok ~cwd:root "create dependent branch" "git branch symphony/task-21 symphony/task-20");
+      let workspace21 =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"feature/start" issue21 with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Util.write_file (Filename.concat workspace21.path "twenty-one.txt") "twenty-one\n";
+      ignore (run_ok ~cwd:workspace21.path "task commit" "git add twenty-one.txt && git commit -q -m task");
+      let result, _ = run_manual_merge_test config [ issue20; issue21 ] [ "#20"; "#21" ] in
+      let report = match result with Ok report -> report | Error errors -> Alcotest.fail (String.concat "; " errors) in
+      Alcotest.(check int) "merged both" 2 report.merged;
+      Alcotest.(check bool) "first file present" true (Sys.file_exists (Filename.concat root "twenty.txt"));
+      Alcotest.(check bool) "second file present" true (Sys.file_exists (Filename.concat root "twenty-one.txt")))
+
+let test_manual_merge_cleans_already_integrated_terminal_task () =
+  with_temp_dir "symphony-manual-merge-terminal-" (fun root ->
+      init_repo root "feature/start";
+      let config = manual_merge_config root in
+      let issue = Issue.empty ~id:"I22" ~identifier:"#22" ~title:"Twenty two" ~state:"Done" in
+      let workspace =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"feature/start" issue with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Util.write_file (Filename.concat workspace.path "done.txt") "done\n";
+      ignore (run_ok ~cwd:workspace.path "task commit" "git add done.txt && git commit -q -m task");
+      ignore (run_ok ~cwd:root "pre-integrate" "git merge --ff-only symphony/task-22");
+      let result, statuses = run_manual_merge_test config [ issue ] [ "22" ] in
+      let report = match result with Ok report -> report | Error errors -> Alcotest.fail (String.concat "; " errors) in
+      Alcotest.(check int) "already integrated" 1 report.already_integrated;
+      Alcotest.(check bool) "worktree removed" false (Sys.file_exists workspace.path);
+      Alcotest.(check (list (pair string string))) "terminal status unchanged" [] (List.rev !statuses))
+
 let () =
   Alcotest.run "symphony-backend"
     [
@@ -3253,5 +3412,17 @@ let () =
           Alcotest.test_case "can remove task branch after merge" `Quick test_cleanup_can_remove_task_branch_after_merge;
           Alcotest.test_case "skips auto-merge on protected trunk" `Quick test_auto_merge_skips_protected_trunk_branch;
           Alcotest.test_case "moves merge failures to human attention" `Quick test_auto_merge_failure_moves_human_attention;
+        ] );
+      ( "manual-merge",
+        [
+          Alcotest.test_case "rejects invalid and duplicate selectors" `Quick
+            test_manual_merge_rejects_invalid_and_duplicate_selectors;
+          Alcotest.test_case "fast-forwards protected trunk and updates review status" `Quick
+            test_manual_merge_fast_forwards_protected_trunk_and_updates_review_status;
+          Alcotest.test_case "preflight is all or nothing" `Quick test_manual_merge_preflight_is_all_or_nothing;
+          Alcotest.test_case "accepts cumulative fast-forward order" `Quick
+            test_manual_merge_accepts_cumulative_fast_forward_order;
+          Alcotest.test_case "cleans already integrated terminal task" `Quick
+            test_manual_merge_cleans_already_integrated_terminal_task;
         ] );
     ]

--- a/docs/adr/0012-manual-task-merge-protected-trunks.md
+++ b/docs/adr/0012-manual-task-merge-protected-trunks.md
@@ -1,0 +1,35 @@
+# ADR 0012: Manual Task Merge can target protected trunks
+
+## Status
+
+Accepted
+
+## Context
+
+Auto-merge and Startup Reconciliation are automated integration paths. They stay conservative around Protected Trunk Branches because they can run as part of orchestration without an explicit per-task operator selection at merge time.
+
+Operators also need a one-shot Manual Task Merge action for known completed Agent Worktrees. In that flow the operator provides explicit issue identifiers, such as `--merge 20` or `--merge #20`, and expects Symphony to preserve Task Branch naming, clean-worktree checks, fast-forward-only semantics, Task Cleanup Policy, and tracker transitions.
+
+## Decision
+
+Personal Symphony allows Manual Task Merge to integrate selected Task Branches into the current Loop-Start Branch even when that branch is a Protected Trunk Branch.
+
+The selected issue identifiers are the operator confirmation of intent. No additional protected-trunk confirmation flag is required.
+
+Manual Task Merge still:
+
+- accepts issue identifiers only, not raw Task Branch names;
+- rejects duplicate normalized selectors;
+- requires clean Loop-Start and Agent Worktrees;
+- preflights the full selected set before merging anything;
+- evaluates multi-task fast-forward viability cumulatively in operator-provided order;
+- uses fast-forward-only integration;
+- applies the configured Task Cleanup Policy after successful or already-contained integration;
+- does not push Task Branches or the Loop-Start Branch;
+- does not run normal orchestration, Startup Reconciliation, Stage Push, Batch Branch Push, or Batch Pull Request behavior.
+
+## Consequences
+
+Operators can explicitly integrate selected completed task work while on `main` or another Protected Trunk Branch without leaving Symphony's Runtime Contract.
+
+Automated flows remain conservative: auto-merge and Startup Reconciliation still do not integrate Task Branch work into Protected Trunk Branches.


### PR DESCRIPTION
## Summary
- add a one-shot Manual Task Merge backend workflow and --merge CLI flag
- preserve task branch naming, clean-worktree preflight, fast-forward-only integration, cleanup policy, and review-stage tracker advancement
- document Manual Task Merge semantics in CONTEXT.md and ADR 0012

## Verification
- pnpm backend:build
- pnpm test

Closes #20