### PR TITLE
Add startup reconciliation for task branches

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -144,6 +144,10 @@ _Avoid_: setup error, config problem
 A Loop-Start Branch checkout with no uncommitted Workspace Repository changes.
 _Avoid_: clean repo, safe branch
 
+**Startup Reconciliation**:
+The startup-time recovery pass that checks completed-stage Agent Worktrees for Task Branch commits not present on the Loop-Start Branch.
+_Avoid_: startup merge, branch sweep, cleanup scan
+
 **Terminal Console**:
 The default terminal interface for operating Personal Symphony in a Workspace Repository.
 _Avoid_: TUI, terminal UI
@@ -235,6 +239,11 @@ _Avoid_: reinitialize, reset
 - **Manual Task Merge** preflights every selected task before merging anything, requires clean Loop-Start and Agent Worktrees, and uses fast-forward-only semantics.
 - **Manual Task Merge** may target a **Protected Trunk Branch** because explicit selected issue identifiers are the operator action.
 - **Manual Task Merge** does not push branches, run Startup Reconciliation, dispatch agents, or open a Batch Pull Request.
+- **Startup Reconciliation** runs once per process startup before normal dispatch or agent launch.
+- **Startup Reconciliation** evaluates completed-stage **Agent Worktrees** in deterministic issue order.
+- **Startup Reconciliation** integrates safe committed **Task Branch** work into the **Loop-Start Branch** by fast-forward only.
+- **Startup Reconciliation** does not create a **Stage Commit**, reconcile retained **Task Branches** without **Agent Worktrees**, or change tracker status after successful or already-contained reconciliation.
+- **Startup Reconciliation** moves unsafe, contradictory, non-fast-forward, or Protected Trunk Branch candidates to the **Merge Attention Status** and records Runtime State diagnostics.
 - The default **Merge Attention Status** is `Human attention`.
 - The **Merge Attention Status** is paused and not dispatchable.
 - The default **Task Cleanup Policy** removes an **Agent Worktree** after its **Task Branch** is merged.

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -32,6 +32,7 @@ type t = {
   batch_pull_request_handoff : batch_pull_request_handoff;
   notify_state : notify_state;
   loop_start_branch : string;
+  mutable startup_reconciliation_done : bool;
   mutable batch_pull_request_completed : bool;
   ordered_queue : Ordered_queue.t option;
 }
@@ -155,6 +156,17 @@ let render_ordered_queue_finished queue =
     Printf.eprintf "%s%s %s %s %s\n%!" clear_line (dim (clock_time ())) (cyan "ordered-queue") (yellow "skipped")
       (String.concat "; " skipped)
 
+let render_startup_reconciliation category issue_identifier message =
+  let label =
+    match category with
+    | "merged" | "already_reconciled" -> green category
+    | category when Util.starts_with ~prefix:"attention_" category -> yellow category
+    | category when Util.starts_with ~prefix:"skipped_" category -> dim category
+    | category -> category
+  in
+  Printf.eprintf "%s%s %s %s %s %s\n%!" clear_line (dim (clock_time ())) (cyan "startup-reconcile") label
+    issue_identifier message
+
 let running_ids state = List.map (fun (row : Runtime_state.running) -> row.issue.id) state.Runtime_state.running
 let is_running state issue = List.exists (( = ) issue.Issue.id) (running_ids state)
 let string_equal_ci a b = String.lowercase_ascii a = String.lowercase_ascii b
@@ -204,6 +216,8 @@ let queue_issue_number issue =
   match Util.drop_prefix ~prefix:"#" issue.Issue.identifier with
   | Some number -> int_of_string_opt number
   | None -> None
+
+let issue_numeric_key issue = Option.value (queue_issue_number issue) ~default:max_int
 
 let queue_contains_issue queue issue =
   match queue_issue_number issue with
@@ -411,6 +425,16 @@ let git_ref_exists root refname =
   | Ok _ -> true
   | Error _ -> false
 
+let git_ref_contained_in_head root refname =
+  match run_shell_capture ~cwd:root (Printf.sprintf "git merge-base --is-ancestor %s HEAD" (Util.shell_quote refname)) with
+  | Ok _ -> true
+  | Error _ -> false
+
+let git_head_can_fast_forward_to root refname =
+  match run_shell_capture ~cwd:root (Printf.sprintf "git merge-base --is-ancestor HEAD %s" (Util.shell_quote refname)) with
+  | Ok _ -> true
+  | Error _ -> false
+
 let worktree_branch path =
   if Sys.file_exists path && Sys.is_directory path then
     match (run_shell_capture ~cwd:path "git rev-parse --show-toplevel", run_shell_capture ~cwd:path "git branch --show-current") with
@@ -427,6 +451,9 @@ let issue_branch_key issue =
   if digits <> "" then digits else Workspace.sanitize issue.id
 
 let task_branch config issue = config.Config.git.task_branch_prefix ^ issue_branch_key issue
+
+let task_workspace_path config issue =
+  Filename.concat config.Config.workspace.root (Workspace.sanitize issue.Issue.identifier)
 
 let require_clean_loop_start root =
   match run_shell_capture ~cwd:root "git status --porcelain" with
@@ -642,6 +669,7 @@ let make ?ordered_queue ?(launch = shell_launch) ?(fetch = Github_tracker.fetch_
     batch_pull_request_handoff;
     notify_state;
     loop_start_branch = current_branch config.repository_root;
+    startup_reconciliation_done = false;
     batch_pull_request_completed = false;
     ordered_queue;
   }
@@ -902,6 +930,129 @@ let issue_is_active orchestrator issue =
 let issue_needs_attention orchestrator issue =
   string_equal_ci issue.Issue.state orchestrator.config.git.merge_attention_status || is_blocked orchestrator issue
 
+let protected_loop_start orchestrator =
+  List.exists
+    (fun branch -> String.lowercase_ascii branch = String.lowercase_ascii orchestrator.loop_start_branch)
+    orchestrator.config.git.protected_trunk_branches
+
+let completed_stage_success_statuses config =
+  if not config.Config.stage_agents.enabled then []
+  else
+    config.stage_agents.stages
+    |> List.filter_map (fun (stage : Config.stage_agent) -> stage.success_status)
+
+let issue_is_completed_stage config issue =
+  completed_stage_success_statuses config
+  |> List.exists (fun status -> string_equal_ci status issue.Issue.state)
+
+let startup_candidate_order config left right =
+  match compare (issue_numeric_key left) (issue_numeric_key right) with
+  | 0 -> compare (task_branch config left) (task_branch config right)
+  | result -> result
+
+let record_startup_reconciliation orchestrator ?issue ?task_branch ?workspace_path category message =
+  let row =
+    {
+      Runtime_state.issue_id = Option.map (fun issue -> issue.Issue.id) issue;
+      issue_identifier = Option.map (fun issue -> issue.Issue.identifier) issue;
+      task_branch;
+      workspace_path;
+      category;
+      message;
+    }
+  in
+  update_state orchestrator (fun state ->
+    { state with startup_reconciliation = state.startup_reconciliation @ [ row ] });
+  let issue_identifier = match issue with Some issue -> issue.Issue.identifier | None -> "-" in
+  render_startup_reconciliation category issue_identifier message
+
+let record_startup_attention orchestrator issue branch workspace_path category message =
+  record_startup_reconciliation orchestrator ~issue ~task_branch:branch ~workspace_path category message;
+  ignore (move_issue_status orchestrator issue orchestrator.config.git.merge_attention_status);
+  Hashtbl.replace orchestrator.blocked (block_key issue) message;
+  Hashtbl.replace orchestrator.blocked (block_key { issue with Issue.state = orchestrator.config.git.merge_attention_status }) message;
+  update_state orchestrator (fun state ->
+    {
+      state with
+      issue_errors =
+        {
+          Runtime_state.issue_id = issue.id;
+          issue_identifier = issue.identifier;
+          error = message;
+          goal_usage = None;
+        }
+        :: List.filter (fun (issue_error : Runtime_state.issue_error) -> issue_error.issue_id <> issue.id) state.issue_errors;
+      last_error = Some message;
+    })
+
+let cleanup_task_worktree_for_issue config issue workspace_path =
+  if config.Config.git.cleanup.remove_worktree_after_merge then
+    ignore
+      (run_shell_capture ~cwd:config.repository_root
+         (Printf.sprintf "git worktree remove %s" (Util.shell_quote workspace_path)));
+  if not config.git.cleanup.keep_task_branch then
+    ignore
+      (run_shell_capture ~cwd:config.repository_root
+         (Printf.sprintf "git branch -d %s" (Util.shell_quote (task_branch config issue))))
+
+let reconcile_startup_candidate orchestrator issue =
+  let workspace_path = task_workspace_path orchestrator.config issue in
+  let branch = task_branch orchestrator.config issue in
+  match worktree_branch workspace_path with
+  | None ->
+      record_startup_attention orchestrator issue branch workspace_path "skipped_not_git_worktree"
+        (workspace_path ^ " exists but is not an Agent Worktree")
+  | Some existing_branch when existing_branch <> branch ->
+      record_startup_attention orchestrator issue branch workspace_path "attention_wrong_branch"
+        (Printf.sprintf "Agent Worktree is on %s but expected %s" existing_branch branch)
+  | Some _ when not (git_ref_exists orchestrator.config.repository_root branch) ->
+      record_startup_attention orchestrator issue branch workspace_path "attention_missing_task_branch"
+        ("expected Task Branch is missing: " ^ branch)
+  | Some _ -> (
+      match has_worktree_changes workspace_path with
+      | Error error -> record_startup_attention orchestrator issue branch workspace_path "attention_uncommitted_changes" error
+      | Ok true ->
+          record_startup_attention orchestrator issue branch workspace_path "attention_uncommitted_changes"
+            "Agent Worktree has uncommitted changes"
+      | Ok false ->
+          let root = orchestrator.config.repository_root in
+          if git_ref_contained_in_head root branch then (
+            cleanup_task_worktree_for_issue orchestrator.config issue workspace_path;
+            record_startup_reconciliation orchestrator ~issue ~task_branch:branch ~workspace_path "already_reconciled"
+              "Task Branch is already contained in the Loop-Start Branch")
+          else if protected_loop_start orchestrator then
+            record_startup_attention orchestrator issue branch workspace_path "attention_protected_trunk"
+              "committed Task Branch work exists but Loop-Start Branch is protected"
+          else if git_head_can_fast_forward_to root branch then
+            match run_shell_capture ~cwd:root (Printf.sprintf "git merge --ff-only %s" (Util.shell_quote branch)) with
+            | Ok _ ->
+                cleanup_task_worktree_for_issue orchestrator.config issue workspace_path;
+                record_startup_reconciliation orchestrator ~issue ~task_branch:branch ~workspace_path "merged"
+                  "Task Branch fast-forwarded into the Loop-Start Branch"
+            | Error error ->
+                record_startup_attention orchestrator issue branch workspace_path "attention_non_fast_forward"
+                  ("Task Branch could not fast-forward: " ^ error)
+          else
+            record_startup_attention orchestrator issue branch workspace_path "attention_non_fast_forward"
+              "Task Branch could not fast-forward")
+
+let reconcile_startup orchestrator candidates =
+  if not orchestrator.startup_reconciliation_done then (
+    orchestrator.startup_reconciliation_done <- true;
+    let candidates =
+      candidates
+      |> List.filter (issue_is_completed_stage orchestrator.config)
+      |> List.filter (fun issue -> Sys.file_exists (task_workspace_path orchestrator.config issue))
+      |> List.sort (startup_candidate_order orchestrator.config)
+    in
+    if candidates <> [] then
+      match require_clean_loop_start orchestrator.config.repository_root with
+      | Error error ->
+          let message = "Startup Reconciliation blocked: " ^ error in
+          record_startup_reconciliation orchestrator "startup_blocked_dirty_loop_start" message;
+          set_error orchestrator message
+      | Ok () -> List.iter (reconcile_startup_candidate orchestrator) candidates)
+
 let set_pull_request_handoff orchestrator status ?url ?error () =
   let policy = orchestrator.config.Config.pull_request in
   update_state orchestrator (fun state ->
@@ -1098,20 +1249,8 @@ let complete_child orchestrator child =
   update_ordered_queue_entries orchestrator ~completed_identifier:child.issue_identifier ~candidates:[ child.issue ] ();
   render_dispatch_completed child.issue_identifier child.issue_title
 
-let protected_loop_start orchestrator =
-  List.exists
-    (fun branch -> String.lowercase_ascii branch = String.lowercase_ascii orchestrator.loop_start_branch)
-    orchestrator.config.git.protected_trunk_branches
-
 let cleanup_task_worktree orchestrator child =
-  if orchestrator.config.git.cleanup.remove_worktree_after_merge then
-    ignore
-      (run_shell_capture ~cwd:orchestrator.config.repository_root
-         (Printf.sprintf "git worktree remove %s" (Util.shell_quote child.workspace.path)));
-  if not orchestrator.config.git.cleanup.keep_task_branch then
-    ignore
-      (run_shell_capture ~cwd:orchestrator.config.repository_root
-         (Printf.sprintf "git branch -d %s" (Util.shell_quote (task_branch orchestrator.config child.issue))))
+  cleanup_task_worktree_for_issue orchestrator.config child.issue child.workspace.path
 
 let auto_merge_child orchestrator child =
   if (not (is_git_repository orchestrator.config.repository_root)) || (not orchestrator.config.git.auto_merge) || protected_loop_start orchestrator then Ok ()
@@ -1251,6 +1390,7 @@ let poll_once orchestrator =
         let candidates = orchestrator.fetch orchestrator.tracker in
         let last_error = if Hashtbl.length orchestrator.blocked = 0 then None else orchestrator.state.last_error in
         update_state orchestrator (fun state -> { state with Runtime_state.issues = candidates; last_error });
+        reconcile_startup orchestrator candidates;
         let available = orchestrator.config.agent.max_concurrent_agents - List.length orchestrator.state.running in
         let dispatchable =
           candidates

--- a/apps/backend/lib/runtime_state.ml
+++ b/apps/backend/lib/runtime_state.ml
@@ -30,6 +30,14 @@ type ordered_queue_entry = {
   skip_reason : string option;
 }
 type ordered_queue = { entries : ordered_queue_entry list }
+type startup_reconciliation = {
+  issue_id : string option;
+  issue_identifier : string option;
+  task_branch : string option;
+  workspace_path : string option;
+  category : string;
+  message : string;
+}
 type pull_request_handoff = {
   enabled : bool;
   head_branch : string option;
@@ -51,6 +59,7 @@ type t = {
   rate_limits : Yojson.Safe.t option;
   pull_request : pull_request_handoff option;
   ordered_queue : ordered_queue option;
+  startup_reconciliation : startup_reconciliation list;
   last_error : string option;
 }
 
@@ -67,6 +76,7 @@ let empty ?(readiness_gaps = []) ?(status_order = []) ?ordered_queue ?last_error
     rate_limits = None;
     pull_request = None;
     ordered_queue;
+    startup_reconciliation = [];
     last_error;
   }
 
@@ -141,7 +151,7 @@ let issue_error_to_yojson (row : issue_error) =
 let readiness_gap_to_yojson row =
   `Assoc [ ("requirement", `String row.requirement); ("remediation", `String row.remediation) ]
 
-let ordered_queue_entry_to_yojson row =
+let ordered_queue_entry_to_yojson (row : ordered_queue_entry) =
   `Assoc
     [
       ("issue_identifier", `String row.issue_identifier);
@@ -150,8 +160,19 @@ let ordered_queue_entry_to_yojson row =
       ("skip_reason", (match row.skip_reason with Some s -> `String s | None -> `Null));
     ]
 
-let ordered_queue_to_yojson row =
+let ordered_queue_to_yojson (row : ordered_queue) =
   `Assoc [ ("entries", `List (List.map ordered_queue_entry_to_yojson row.entries)) ]
+
+let startup_reconciliation_to_yojson (row : startup_reconciliation) =
+  `Assoc
+    [
+      ("issue_id", (match row.issue_id with Some s -> `String s | None -> `Null));
+      ("issue_identifier", (match row.issue_identifier with Some s -> `String s | None -> `Null));
+      ("task_branch", (match row.task_branch with Some s -> `String s | None -> `Null));
+      ("workspace_path", (match row.workspace_path with Some s -> `String s | None -> `Null));
+      ("category", `String row.category);
+      ("message", `String row.message);
+    ]
 
 let json_member name = function
   | `Assoc fields -> List.assoc_opt name fields
@@ -210,5 +231,6 @@ let to_yojson state =
       ("rate_limits", Option.value state.rate_limits ~default:`Null);
       ("pull_request", (match state.pull_request with Some row -> pull_request_handoff_to_yojson row | None -> `Null));
       ("ordered_queue", (match state.ordered_queue with Some row -> ordered_queue_to_yojson row | None -> `Null));
+      ("startup_reconciliation", `List (List.map startup_reconciliation_to_yojson state.startup_reconciliation));
       ("last_error", (match state.last_error with Some s -> `String s | None -> `Null));
     ]

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -39,6 +39,10 @@ let init_repo root branch =
   Util.write_file (Filename.concat root "README.md") "initial\n";
   ignore (run_ok ~cwd:root "initial commit" "git add README.md && git commit -q -m initial")
 
+let ignore_runtime_home root =
+  Util.write_file (Filename.concat root ".gitignore") ".symphony/\n";
+  ignore (run_ok ~cwd:root "ignore runtime home" "git add .gitignore && git commit -q -m ignore-runtime-home")
+
 let git_policy ?(auto_merge = false) ?(protected_trunk_branches = [ "main"; "master" ])
     ?(merge_attention_status = "Human attention") ?(remove_worktree_after_merge = true) () =
   {
@@ -2808,6 +2812,249 @@ let base_orchestrator_config root git =
     stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
   }
 
+let completed_stage_config root git =
+  {
+    (base_orchestrator_config root git) with
+    Config.stage_agents =
+      {
+        enabled = true;
+        root = Filename.concat root "agents";
+        default_agent = None;
+        stages =
+          [
+            {
+              Config.states = [ "In progress" ];
+              agent = "engineer";
+              skills = [];
+              start_status = Some "In progress";
+              success_status = Some "In review";
+              retry_status = Some "Todo";
+              goal = None;
+              commit = None;
+            };
+          ];
+      };
+  }
+
+let diagnostic_categories state =
+  List.map (fun (row : Runtime_state.startup_reconciliation) -> row.category) state.Runtime_state.startup_reconciliation
+
+let create_task_worktree config issue =
+  match Orchestrator.shell_prepare_workspace config ~loop_start_branch:(Orchestrator.current_branch config.Config.repository_root) issue with
+  | Ok workspace -> workspace
+  | Error error -> Alcotest.fail error
+
+let commit_file ~cwd file content message =
+  Util.write_file (Filename.concat cwd file) content;
+  ignore (run_ok ~cwd "commit file" (Printf.sprintf "git add %s && git commit -q -m %s" (Util.shell_quote file) (Util.shell_quote message)))
+
+let test_startup_reconciliation_merges_completed_worktrees_in_order () =
+  with_temp_dir "symphony-startup-reconcile-order-" (fun root ->
+      init_repo root "feature/start";
+      ignore_runtime_home root;
+      let config = completed_stage_config root (git_policy ~auto_merge:true ()) in
+      let issue_22 = Issue.empty ~id:"I22" ~identifier:"#22" ~title:"Twenty two" ~state:"In review" in
+      let issue_21 = Issue.empty ~id:"I21" ~identifier:"#21" ~title:"Twenty one" ~state:"In review" in
+      let workspace_21 = create_task_worktree config issue_21 in
+      commit_file ~cwd:workspace_21.path "a.txt" "a\n" "task 21";
+      ignore (run_ok ~cwd:root "create second task branch" "git branch symphony/task-22 symphony/task-21");
+      let workspace_22 = create_task_worktree config issue_22 in
+      commit_file ~cwd:workspace_22.path "b.txt" "b\n" "task 22";
+      let statuses = ref [] in
+      let orchestrator =
+        Orchestrator.make ~fetch:(fun _ -> [ issue_22; issue_21 ])
+          ~set_status:(fun _ issue status ->
+            statuses := (issue.Issue.identifier, status) :: !statuses;
+            Ok ())
+          ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check bool) "first file merged" true (Sys.file_exists (Filename.concat root "a.txt"));
+      Alcotest.(check bool) "second file merged" true (Sys.file_exists (Filename.concat root "b.txt"));
+      Alcotest.(check (list string)) "diagnostic order" [ "merged"; "merged" ]
+        (diagnostic_categories (Orchestrator.get_state orchestrator));
+      let log = run_ok ~cwd:root "log" "git log --reverse --format=%s" |> Util.split_lines in
+      Alcotest.(check (list string)) "merge order" [ "initial"; "ignore-runtime-home"; "task 21"; "task 22" ] log;
+      Alcotest.(check (list (pair string string))) "no status changes after success" [] (List.rev !statuses))
+
+let test_startup_reconciliation_already_contained_applies_cleanup_without_status_change () =
+  with_temp_dir "symphony-startup-reconcile-contained-" (fun root ->
+      init_repo root "feature/start";
+      ignore_runtime_home root;
+      let config = completed_stage_config root (git_policy ~auto_merge:true ()) in
+      let issue = Issue.empty ~id:"I23" ~identifier:"#23" ~title:"Twenty three" ~state:"In review" in
+      let workspace = create_task_worktree config issue in
+      commit_file ~cwd:workspace.path "contained.txt" "contained\n" "task 23";
+      ignore (run_ok ~cwd:root "manual merge" "git merge --ff-only symphony/task-23");
+      let statuses = ref [] in
+      let orchestrator =
+        Orchestrator.make ~fetch:(fun _ -> [ issue ])
+          ~set_status:(fun _ issue status ->
+            statuses := (issue.Issue.identifier, status) :: !statuses;
+            Ok ())
+          ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check (list string)) "diagnostics" [ "already_reconciled" ]
+        (diagnostic_categories (Orchestrator.get_state orchestrator));
+      Alcotest.(check bool) "worktree removed" false (Sys.file_exists workspace.path);
+      Alcotest.(check bool) "task branch kept" true
+        (Sys.command ("cd " ^ Util.shell_quote root ^ " && git show-ref --verify --quiet refs/heads/symphony/task-23") = 0);
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check int) "startup reconciliation runs once" 1
+        (List.length (Orchestrator.get_state orchestrator).Runtime_state.startup_reconciliation);
+      Alcotest.(check (list (pair string string))) "no status changes" [] (List.rev !statuses))
+
+let test_startup_reconciliation_moves_unsafe_candidates_to_attention () =
+  with_temp_dir "symphony-startup-reconcile-attention-" (fun root ->
+      init_repo root "feature/start";
+      ignore_runtime_home root;
+      let config = completed_stage_config root (git_policy ~auto_merge:true ()) in
+      let protected_issue = Issue.empty ~id:"I24" ~identifier:"#24" ~title:"Protected" ~state:"In review" in
+      let uncommitted_issue = Issue.empty ~id:"I25" ~identifier:"#25" ~title:"Uncommitted" ~state:"In review" in
+      let protected_workspace = create_task_worktree config protected_issue in
+      commit_file ~cwd:protected_workspace.path "protected.txt" "protected\n" "task 24";
+      let uncommitted_workspace = create_task_worktree config uncommitted_issue in
+      Util.write_file (Filename.concat uncommitted_workspace.path "dirty.txt") "dirty\n";
+      let protected_config =
+        {
+          config with
+          Config.git = { config.git with protected_trunk_branches = [ "feature/start" ] };
+        }
+      in
+      let statuses = ref [] in
+      let orchestrator =
+        Orchestrator.make ~fetch:(fun _ -> [ protected_issue; uncommitted_issue ])
+          ~set_status:(fun _ issue status ->
+            statuses := (issue.Issue.identifier, status) :: !statuses;
+            Ok ())
+          ~config:protected_config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check bool) "protected not merged" false (Sys.file_exists (Filename.concat root "protected.txt"));
+      Alcotest.(check int) "no stage commit created for uncommitted changes" 2
+        (List.length (run_ok ~cwd:uncommitted_workspace.path "log" "git log --format=%s" |> Util.split_lines));
+      Alcotest.(check (list string)) "diagnostics"
+        [ "attention_protected_trunk"; "attention_uncommitted_changes" ]
+        (diagnostic_categories (Orchestrator.get_state orchestrator));
+      Alcotest.(check (list (pair string string))) "attention statuses"
+        [ ("#24", "Human attention"); ("#25", "Human attention") ]
+        (List.rev !statuses);
+      Alcotest.(check int) "issue errors" 2 (List.length (Orchestrator.get_state orchestrator).issue_errors))
+
+let test_startup_reconciliation_continues_after_non_fast_forward () =
+  with_temp_dir "symphony-startup-reconcile-nonff-" (fun root ->
+      init_repo root "feature/start";
+      ignore_runtime_home root;
+      let config = completed_stage_config root (git_policy ~auto_merge:true ()) in
+      let nonff_issue = Issue.empty ~id:"I26" ~identifier:"#26" ~title:"Non fast forward" ~state:"In review" in
+      let later_issue = Issue.empty ~id:"I27" ~identifier:"#27" ~title:"Later" ~state:"In review" in
+      let nonff_workspace = create_task_worktree config nonff_issue in
+      commit_file ~cwd:nonff_workspace.path "nonff.txt" "task\n" "task 26";
+      commit_file ~cwd:root "loop.txt" "loop\n" "loop advance";
+      let later_workspace = create_task_worktree config later_issue in
+      commit_file ~cwd:later_workspace.path "later.txt" "later\n" "task 27";
+      let statuses = ref [] in
+      let orchestrator =
+        Orchestrator.make ~fetch:(fun _ -> [ nonff_issue; later_issue ])
+          ~set_status:(fun _ issue status ->
+            statuses := (issue.Issue.identifier, status) :: !statuses;
+            Ok ())
+          ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check bool) "non fast forward not merged" false (Sys.file_exists (Filename.concat root "nonff.txt"));
+      Alcotest.(check bool) "later candidate still merged" true (Sys.file_exists (Filename.concat root "later.txt"));
+      Alcotest.(check (list string)) "diagnostics" [ "attention_non_fast_forward"; "merged" ]
+        (diagnostic_categories (Orchestrator.get_state orchestrator));
+      Alcotest.(check (list (pair string string))) "only nonff moved to attention" [ ("#26", "Human attention") ]
+        (List.rev !statuses))
+
+let test_startup_reconciliation_detects_wrong_and_missing_task_branch () =
+  with_temp_dir "symphony-startup-reconcile-branch-state-" (fun root ->
+      init_repo root "feature/start";
+      ignore_runtime_home root;
+      let config = completed_stage_config root (git_policy ~auto_merge:true ()) in
+      let wrong_issue = Issue.empty ~id:"I28" ~identifier:"#28" ~title:"Wrong branch" ~state:"In review" in
+      let missing_issue = Issue.empty ~id:"I29" ~identifier:"#29" ~title:"Missing branch" ~state:"In review" in
+      let stale_issue = Issue.empty ~id:"I32" ~identifier:"#32" ~title:"Stale workspace" ~state:"In review" in
+      ignore (run_ok ~cwd:root "wrong branch" "git branch symphony/task-other feature/start");
+      Util.mkdir_p config.workspace.root;
+      let wrong_path = Filename.concat config.workspace.root "_28" in
+      ignore
+        (run_ok ~cwd:root "wrong worktree"
+           (Printf.sprintf "git worktree add %s symphony/task-other" (Util.shell_quote wrong_path)));
+      let missing_workspace = create_task_worktree config missing_issue in
+      ignore (run_ok ~cwd:root "delete expected branch" "git update-ref -d refs/heads/symphony/task-29");
+      let stale_path = Filename.concat config.workspace.root "_32" in
+      Unix.mkdir stale_path 0o755;
+      let statuses = ref [] in
+      let orchestrator =
+        Orchestrator.make ~fetch:(fun _ -> [ wrong_issue; missing_issue; stale_issue ])
+          ~set_status:(fun _ issue status ->
+            statuses := (issue.Issue.identifier, status) :: !statuses;
+            Ok ())
+          ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check bool) "missing worktree kept" true (Sys.file_exists missing_workspace.path);
+      Alcotest.(check (list string)) "diagnostics"
+        [ "attention_wrong_branch"; "attention_missing_task_branch"; "skipped_not_git_worktree" ]
+        (diagnostic_categories (Orchestrator.get_state orchestrator));
+      Alcotest.(check (list (pair string string))) "attention statuses"
+        [ ("#28", "Human attention"); ("#29", "Human attention"); ("#32", "Human attention") ]
+        (List.rev !statuses))
+
+let test_startup_reconciliation_blocks_when_loop_start_dirty () =
+  with_temp_dir "symphony-startup-reconcile-dirty-loop-" (fun root ->
+      init_repo root "feature/start";
+      ignore_runtime_home root;
+      let config = completed_stage_config root (git_policy ~auto_merge:true ()) in
+      let issue = Issue.empty ~id:"I30" ~identifier:"#30" ~title:"Dirty loop" ~state:"In review" in
+      let workspace = create_task_worktree config issue in
+      commit_file ~cwd:workspace.path "dirty-loop-task.txt" "task\n" "task 30";
+      Util.write_file (Filename.concat root "dirty-loop.txt") "dirty\n";
+      let statuses = ref [] in
+      let orchestrator =
+        Orchestrator.make ~fetch:(fun _ -> [ issue ])
+          ~set_status:(fun _ issue status ->
+            statuses := (issue.Issue.identifier, status) :: !statuses;
+            Ok ())
+          ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check bool) "not merged" false (Sys.file_exists (Filename.concat root "dirty-loop-task.txt"));
+      Alcotest.(check (list string)) "startup-level diagnostic" [ "startup_blocked_dirty_loop_start" ]
+        (diagnostic_categories (Orchestrator.get_state orchestrator));
+      Alcotest.(check (list (pair string string))) "no candidate status changes" [] (List.rev !statuses);
+      match (Orchestrator.get_state orchestrator).last_error with
+      | Some error ->
+          Alcotest.(check bool) "last error names startup reconciliation" true
+            (Util.starts_with ~prefix:"Startup Reconciliation blocked:" error)
+      | None -> Alcotest.fail "expected startup reconciliation error")
+
+let test_startup_reconciliation_ignores_retained_branch_without_worktree () =
+  with_temp_dir "symphony-startup-reconcile-no-worktree-" (fun root ->
+      init_repo root "feature/start";
+      ignore_runtime_home root;
+      let config = completed_stage_config root (git_policy ~auto_merge:true ()) in
+      let issue = Issue.empty ~id:"I31" ~identifier:"#31" ~title:"No worktree" ~state:"In review" in
+      ignore (run_ok ~cwd:root "branch" "git branch symphony/task-31 feature/start");
+      let external_worktree = Filename.concat (Filename.dirname root) "external-task-31" in
+      ignore
+        (run_ok ~cwd:root "external worktree"
+           (Printf.sprintf "git worktree add %s symphony/task-31" (Util.shell_quote external_worktree)));
+      commit_file ~cwd:external_worktree "retained.txt" "retained\n" "task 31";
+      ignore (run_ok ~cwd:root "remove external worktree" (Printf.sprintf "git worktree remove %s" (Util.shell_quote external_worktree)));
+      let orchestrator =
+        Orchestrator.make ~fetch:(fun _ -> [ issue ]) ~set_status:(fun _ _ _ -> Alcotest.fail "unexpected status change")
+          ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check bool) "retained branch not merged" false (Sys.file_exists (Filename.concat root "retained.txt"));
+      Alcotest.(check (list string)) "no diagnostics for branch without worktree" []
+        (diagnostic_categories (Orchestrator.get_state orchestrator)))
+
 let test_orchestrator_creates_task_worktree_and_branch () =
   with_temp_dir "symphony-task-worktree-" (fun root ->
       init_repo root "feature/start";
@@ -3258,6 +3505,7 @@ let manual_merge_config ?(keep_task_branch = true) root =
               success_status = Some "Done";
               retry_status = None;
               agent = "reviewer";
+              skills = [];
               goal = None;
               commit = None;
             };
@@ -3486,6 +3734,20 @@ let () =
             `Quick test_orchestrator_parses_final_output_before_timeout_retry;
           Alcotest.test_case "preserves goal usage on blocked issue error"
             `Quick test_orchestrator_preserves_goal_usage_on_blocked_issue_error;
+          Alcotest.test_case "startup reconciliation merges completed worktrees in order"
+            `Quick test_startup_reconciliation_merges_completed_worktrees_in_order;
+          Alcotest.test_case "startup reconciliation cleans already-contained task branches"
+            `Quick test_startup_reconciliation_already_contained_applies_cleanup_without_status_change;
+          Alcotest.test_case "startup reconciliation moves unsafe candidates to attention"
+            `Quick test_startup_reconciliation_moves_unsafe_candidates_to_attention;
+          Alcotest.test_case "startup reconciliation continues after non-fast-forward"
+            `Quick test_startup_reconciliation_continues_after_non_fast_forward;
+          Alcotest.test_case "startup reconciliation detects wrong and missing branches"
+            `Quick test_startup_reconciliation_detects_wrong_and_missing_task_branch;
+          Alcotest.test_case "startup reconciliation blocks when loop-start is dirty"
+            `Quick test_startup_reconciliation_blocks_when_loop_start_dirty;
+          Alcotest.test_case "startup reconciliation ignores branches without worktrees"
+            `Quick test_startup_reconciliation_ignores_retained_branch_without_worktree;
           Alcotest.test_case "creates task worktree and branch" `Quick test_orchestrator_creates_task_worktree_and_branch;
           Alcotest.test_case "opens batch pull request once when idle" `Quick test_orchestrator_opens_batch_pull_request_once_when_idle;
           Alcotest.test_case "retries failed batch pull request handoff" `Quick test_orchestrator_retries_batch_pull_request_handoff_failure;

--- a/apps/frontend/src/Main.res
+++ b/apps/frontend/src/Main.res
@@ -67,6 +67,13 @@ type orderedQueueEntry = {
 
 type orderedQueue = {entries: array<orderedQueueEntry>}
 
+type startupReconciliation = {
+  issue_identifier: option<string>,
+  task_branch: option<string>,
+  category: string,
+  message: string,
+}
+
 type runningIssue = {
   issue_id: string,
   issue_identifier: string,
@@ -83,6 +90,7 @@ type runtimeState = {
   generated_at: string,
   last_error: option<string>,
   readiness_gaps: array<readinessGap>,
+  startup_reconciliation: array<startupReconciliation>,
   issues: array<runningIssue>,
   running: array<runningIssue>,
   retrying: array<taskError>,
@@ -106,6 +114,25 @@ let readinessText = state =>
     (arrayOrEmpty(state.readiness_gaps)
     ->Array.map(gap => gap.requirement ++ ": " ++ gap.remediation)
     ->Array.join("; "))
+  } else {
+    ""
+  }
+
+let startupReconciliationText = state =>
+  if Array.length(arrayOrEmpty(state.startup_reconciliation)) > 0 {
+    arrayOrEmpty(state.startup_reconciliation)
+    ->Array.map(row => {
+      let identifier = switch row.issue_identifier {
+      | Some(value) => value
+      | None => "startup"
+      }
+      let branch = switch row.task_branch {
+      | Some(value) => " " ++ value
+      | None => ""
+      }
+      identifier ++ branch ++ " " ++ row.category ++ ": " ++ row.message
+    })
+    ->Array.join("; ")
   } else {
     ""
   }
@@ -275,6 +302,7 @@ let snapshotFromState = state => {
   tokens: state.codex_totals.total_tokens->Int.toString,
   generatedAt: state.generated_at,
   readinessGaps: readinessText(state),
+  startupReconciliation: startupReconciliationText(state),
   lastError: switch state.last_error {
   | Some(value) => value
   | None => ""

--- a/apps/frontend/src/Pages/Dashboard.res
+++ b/apps/frontend/src/Pages/Dashboard.res
@@ -21,6 +21,7 @@ type snapshot = {
   tokens: string,
   generatedAt: string,
   readinessGaps: string,
+  startupReconciliation: string,
   lastError: string,
   statusOrder: array<string>,
   issues: array<issueItem>,
@@ -238,6 +239,10 @@ let make = (~snapshot: option<snapshot>, ~error: option<string>) =>
         {switch data.readinessGaps {
         | "" => React.null
         | value => banner("warning", "Readiness Gaps", value)
+        }}
+        {switch data.startupReconciliation {
+        | "" => React.null
+        | value => banner("warning", "Startup Reconciliation", value)
         }}
         {switch data.lastError {
         | "" => React.null

--- a/docs/adr/0009-startup-reconciliation.md
+++ b/docs/adr/0009-startup-reconciliation.md
@@ -1,0 +1,25 @@
+# Startup Reconciliation
+
+## Status
+
+Accepted
+
+## Context
+
+Personal Symphony can restart with completed-stage Agent Worktrees whose Task Branch commits are not present on the Loop-Start Branch. This can happen after a crash, interrupted cleanup, or a protected-trunk skip. Without startup recovery, committed task work can remain stranded while normal dispatch resumes.
+
+## Decision
+
+Startup Reconciliation runs once per process startup after the first tracker fetch and before normal dispatch or agent launch. It considers only issues currently in a configured stage `successStatus` that also have an expected Agent Worktree path. Retained Task Branches without Agent Worktrees are outside the recovery scope.
+
+Candidates are sorted by numeric issue identifier and then Task Branch name. The Loop-Start Worktree must be clean before any candidate is merged. Each Agent Worktree must be a valid Git worktree, be checked out on the expected Task Branch, reference an existing Task Branch, and have no uncommitted changes.
+
+Safe committed work is integrated into the Loop-Start Branch with `git merge --ff-only`. Already-contained Task Branches are treated as reconciled. Successful and already-contained candidates apply the existing Task Cleanup Policy and do not change tracker status.
+
+Unsafe candidates move to the configured Merge Attention Status and are recorded in Runtime State issue errors. Protected Trunk Branch targets, wrong branches, missing Task Branches, uncommitted Agent Worktree changes, and non-fast-forward branches are attention cases. Startup Reconciliation does not create Stage Commits, does not resolve conflicts, does not rebase, does not force-push, and does not auto-merge into Protected Trunk Branches.
+
+Runtime State records startup reconciliation diagnostics for merged, already-reconciled, skipped, and attention outcomes. The Terminal Console also prints each outcome during startup.
+
+## Consequences
+
+Startup recovery is conservative and deterministic. Operators can see what was merged, what was already reconciled, what was ignored because it lacked an Agent Worktree, and what needs manual merge attention. Normal orchestration can continue after the pass, but attention tasks remain paused and non-dispatchable in the same startup session.


### PR DESCRIPTION
## Summary
- add Startup Reconciliation before normal dispatch to recover completed-stage Agent Worktrees
- persist reconciliation diagnostics in Runtime State and surface them in the Web Dashboard
- document the runtime semantics in CONTEXT.md and ADR 0009

## Verification
- pnpm backend:build
- pnpm frontend:build
- pnpm test

Closes #18