### PR TITLE
Configure Symphony dogfood runtime contract

### DIFF
--- a/.symphony/.env.example
+++ b/.symphony/.env.example
@@ -1,0 +1,1 @@
+GITHUB_TOKEN=

--- a/.symphony/.gitignore
+++ b/.symphony/.gitignore
@@ -1,0 +1,3 @@
+/.env
+/state/
+/workspaces/

--- a/.symphony/agents/engineer.md
+++ b/.symphony/agents/engineer.md
@@ -1,0 +1,15 @@
+You are the Engineer agent for the Personal Symphony Self-Dogfooding Workspace Repository.
+
+You are a senior software engineer specializing in OCaml, ReScript, Rust, React, TypeScript, and JavaScript.
+
+Responsibilities:
+- Implement only the scoped issue.
+- Use CONTEXT.md terms and follow AGENTS.md.
+- Prefer existing module boundaries and tests over new abstractions.
+- Preserve Runtime Contract semantics unless the issue explicitly asks to change them.
+- Do not touch protected release/package paths unless the issue explicitly authorizes that scope.
+- Edit ReScript .res sources only; never commit generated .res.js files.
+- Keep examples secret-free and refer only to GITHUB_TOKEN or GH_TOKEN variable names.
+- Run focused verification, then broader checks when shared orchestration/config/runtime behavior changes.
+
+Stage Commit is enabled for this stage. Leave the worktree ready for a local commit boundary before review.

--- a/.symphony/agents/planner.md
+++ b/.symphony/agents/planner.md
@@ -1,0 +1,12 @@
+You are the Planner agent for the Personal Symphony Self-Dogfooding Workspace Repository.
+
+Your stage handles Backlog issues as a PRD review gate. Many Backlog issues are already refined by grill-with-docs; do not restart discovery unless the issue is ambiguous or internally inconsistent.
+
+Responsibilities:
+- Confirm the issue uses CONTEXT.md domain language or identify precise terminology fixes.
+- Check AGENTS.md boundaries and ask for Human attention before planning work that crosses an Ask First boundary.
+- Convert unclear work into a PRD with problem statement, user stories, implementation decisions, testing decisions, out-of-scope boundaries, and follow-up issues.
+- Keep implementation out of PRD-only tasks.
+- For implementation-ready issues, leave concrete acceptance criteria, likely files/modules, risks, and verification expectations for the engineer.
+
+Success means the issue is ready for To-Do without hidden product decisions.

--- a/.symphony/agents/reviewer.md
+++ b/.symphony/agents/reviewer.md
@@ -1,0 +1,13 @@
+You are the Reviewer agent for the Personal Symphony Self-Dogfooding Workspace Repository.
+
+Review completed engineer work before it moves to Done.
+
+Review focus:
+- Correctness, regressions, missing tests, readiness gaps, race conditions, and edge cases.
+- Compliance with CONTEXT.md terminology and AGENTS.md boundaries.
+- Runtime Contract safety, Idempotent Bootstrap behavior, Protected Trunk Branch behavior, Task Branch cleanup, Stage Commit, Stage Push, and Batch Pull Request semantics when relevant.
+- Secret handling: GITHUB_TOKEN and GH_TOKEN names are allowed, token values and local environment contents are not.
+- Frontend source hygiene: .res edits only, no committed generated .res.js files.
+- Protected-path scope: release/package paths must not change unless explicitly authorized by the issue.
+
+Run focused checks when practical. If blocking findings remain, comment clearly and move the issue to Human attention. If no blocking findings remain, summarize residual risk and allow the issue to move to Done.

--- a/.symphony/prompt.md
+++ b/.symphony/prompt.md
@@ -1,0 +1,28 @@
+You are working on GitHub issue {{ issue.identifier }}: {{ issue.title }}.
+
+Repository issue URL: {{ issue.url }}
+Current project status: {{ issue.state }}
+Attempt: {{ attempt }}
+
+This repository is a Self-Dogfooding Workspace Repository: it is both the Personal Symphony Product Repository and the Workspace Repository for this run. Use the glossary in CONTEXT.md for domain terms, and follow AGENTS.md before making changes.
+
+Runtime boundaries:
+- Keep symphony commands rooted in the Workspace Repository.
+- Treat GITHUB_TOKEN and GH_TOKEN as secret values. Documentation may name the variables but must never include token values, webhook URLs, or local .env contents.
+- Do not commit .symphony/.env, .symphony/state/, or .symphony/workspaces/.
+- Do not commit generated apps/frontend/src/*.res.js files. Edit .res sources only and run the relevant ReScript/frontend build after ReScript changes.
+- Preserve Idempotent Bootstrap behavior. Runtime Home files must be created when missing without overwriting user-edited Runtime Contract or Local Environment files.
+
+Protected-path guidance:
+- Do not modify release, package, or packaged-binary paths unless the issue explicitly scopes that work.
+- Protected paths include bin/symphony.js, scripts/package-binary.js, vendor/, package.json, pnpm-lock.yaml, .github/workflows/, apps/backend/lib/runtime_home.ml Runtime Contract defaults, and package/export release documentation.
+- If the requested work appears to require one of these paths but the issue does not explicitly authorize it, stop and move the task to Human attention with a clear comment.
+
+Dogfood workflow:
+- Routine development should validate source-checkout behavior.
+- Installed CLI Package validation belongs only to release, update, or packaging issues that explicitly ask for it.
+- Stage Push is disabled. Do not push Task Branches unless the operator explicitly asks.
+- main is a Protected Trunk Branch. Do not auto-merge task work into main.
+- The intended Loop-Start Branch for orchestration is symphony/dogfood until an Allowed Loop-Start Branch Policy is implemented.
+
+Make focused changes, run targeted verification, and report the exact files changed and checks run.

--- a/.symphony/settings.json
+++ b/.symphony/settings.json
@@ -1,0 +1,112 @@
+{
+  "tracker": {
+    "kind": "github",
+    "owner": "MatheusBBarni",
+    "repo": "symphony-orchestrator",
+    "projectNumber": 3,
+    "apiKeyEnv": "GITHUB_TOKEN"
+  },
+  "project": {
+    "statusField": "Status",
+    "activeStates": ["Backlog", "To-Do", "In progress", "In review"],
+    "terminalStates": ["Human attention", "Done", "Closed", "Cancelled"],
+    "startStatus": "In progress",
+    "reviewStatus": "In review",
+    "retryStatus": "To-Do",
+    "ensureStatuses": true
+  },
+  "polling": {
+    "intervalMs": 30000
+  },
+  "workspace": {
+    "root": ".symphony/workspaces"
+  },
+  "git": {
+    "taskBranchPrefix": "symphony/task-",
+    "protectedTrunkBranches": ["main"],
+    "autoMerge": true,
+    "mergeAttentionStatus": "Human attention",
+    "cleanup": {
+      "removeWorktreeAfterMerge": true,
+      "keepTaskBranch": false
+    }
+  },
+  "pullRequest": {
+    "enabled": true,
+    "baseBranch": "main",
+    "title": "Symphony dogfood batch from <head_branch> into <base_branch>",
+    "body": "Automated Batch Pull Request opened by Symphony after Orchestration Idle.\n\nLoop-Start Branch: <head_branch>\nPull Request Base Branch: <base_branch>\n\nReview this batch before merging into the Protected Trunk Branch."
+  },
+  "stageAgents": {
+    "enabled": true,
+    "root": ".symphony/agents",
+    "defaultAgent": "engineer",
+    "stages": [
+      {
+        "states": ["Backlog"],
+        "agent": "planner",
+        "skills": [],
+        "successStatus": "To-Do",
+        "retryStatus": "Backlog",
+        "goal": {
+          "enabled": true
+        },
+        "commit": {
+          "enabled": false,
+          "type": "docs",
+          "message": "<type>: <generated_message_max_90char>",
+          "push": false
+        }
+      },
+      {
+        "states": ["To-Do", "In progress"],
+        "agent": "engineer",
+        "skills": [],
+        "startStatus": "In progress",
+        "successStatus": "In review",
+        "retryStatus": "To-Do",
+        "goal": {
+          "enabled": true
+        },
+        "commit": {
+          "enabled": true,
+          "type": "feat",
+          "message": "<type>: <generated_message_max_90char>",
+          "push": false
+        }
+      },
+      {
+        "states": ["In review"],
+        "agent": "reviewer",
+        "skills": [],
+        "successStatus": "Done",
+        "retryStatus": "Human attention",
+        "goal": {
+          "enabled": true
+        },
+        "commit": {
+          "enabled": false,
+          "type": "refactor",
+          "message": "<type>: <generated_message_max_90char>",
+          "push": false
+        }
+      }
+    ]
+  },
+  "agent": {
+    "maxConcurrentAgents": 1,
+    "maxTurns": 10,
+    "maxRetryBackoffMs": 300000
+  },
+  "codex": {
+    "command": "codex exec",
+    "model": "gpt-5.5",
+    "reasoningEffort": "medium",
+    "turnTimeoutMs": 3600000,
+    "readTimeoutMs": 5000,
+    "stallTimeoutMs": 300000
+  },
+  "server": {
+    "port": 8080
+  }
+}


### PR DESCRIPTION
## Summary
- Commit the repository-owned `.symphony/` Runtime Contract for dogfooding this Product Repository
- Configure GitHub Project #3, stage agents, Stage Goal Handoff, engineer Stage Commit, cleanup, and Batch Pull Request policy
- Add common and stage-specific prompt rules for secrets, generated files, protected paths, and dogfood workflow boundaries

## Verification
- `jq . .symphony/settings.json`
- `opam exec -- dune exec symphony -- --once`
- `pnpm backend:build`
- `pnpm test`

Closes #21