### PR TITLE
Add allowed Loop-Start Branch readiness policy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -280,7 +280,9 @@ _Avoid_: reinitialize, reset
 - Auto-merge of a **Task Branch** into the **Loop-Start Branch** is fast-forward only.
 - When auto-merge fails, Symphony may move the task to a **Merge Attention Status**.
 - Auto-merge, **Startup Reconciliation**, and **Manual Task Merge** are **Task Branch Integration** paths.
-- An **Allowed Loop-Start Branch Policy** prevents dispatch from any Loop-Start Branch outside the configured branch set.
+- An **Allowed Loop-Start Branch Policy** prevents dispatch from any Loop-Start Branch outside the configured literal branch set.
+- An omitted or empty **Allowed Loop-Start Branch Policy** allows any Loop-Start Branch.
+- A disallowed **Loop-Start Branch** is a **Readiness Gap** that keeps the **Terminal Console** and **Web Dashboard** available for inspection while blocking dispatch, **Startup Reconciliation**, and **Batch Pull Request** creation.
 - **Manual Task Merge** integrates selected completed task work with `--merge` without running normal orchestration.
 - **Manual Task Merge** accepts issue identifiers such as `20` and `#20`; it does not accept raw **Task Branch** names.
 - **Manual Task Merge** preflights every selected task before merging anything, requires clean Loop-Start and Agent Worktrees, and uses fast-forward-only semantics.

--- a/apps/backend/lib/config.ml
+++ b/apps/backend/lib/config.ml
@@ -20,6 +20,7 @@ type git_cleanup = { remove_worktree_after_merge : bool; keep_task_branch : bool
 type git = {
   task_branch_prefix : string;
   protected_trunk_branches : string list;
+  allowed_loop_start_branches : string list;
   auto_merge : bool;
   merge_attention_status : string;
   cleanup : git_cleanup;
@@ -86,6 +87,7 @@ let default_git =
   {
     task_branch_prefix = "symphony/task-";
     protected_trunk_branches = [ "main"; "master" ];
+    allowed_loop_start_branches = [];
     auto_merge = true;
     merge_attention_status = default_merge_attention_status;
     cleanup = { remove_worktree_after_merge = true; keep_task_branch = true };
@@ -267,6 +269,17 @@ let json_string_list name json ~default =
       values
       |> List.filter_map (function `String s -> Some s | `Int i -> Some (string_of_int i) | _ -> None)
   | _ -> default
+
+let json_branch_name_list name json ~default =
+  match member name json with
+  | `Null -> default
+  | `List values ->
+      values
+      |> List.map (function
+           | `String s when Util.trim s <> "" -> Util.trim s
+           | `String _ -> raise (Invalid_config ("git." ^ name ^ " must not contain empty branch names"))
+           | _ -> raise (Invalid_config ("git." ^ name ^ " must contain only branch name strings")))
+  | _ -> raise (Invalid_config ("git." ^ name ^ " must be a list of branch name strings"))
 
 let json_bool name json ~default =
   match member name json with `Bool b -> b | `String "true" -> true | `String "false" -> false | _ -> default
@@ -452,6 +465,8 @@ let from_settings_file ~workspace_root path =
         task_branch_prefix = json_string "taskBranchPrefix" git_raw ~default:default_git.task_branch_prefix;
         protected_trunk_branches =
           json_string_list "protectedTrunkBranches" git_raw ~default:default_git.protected_trunk_branches;
+        allowed_loop_start_branches =
+          json_branch_name_list "allowedLoopStartBranches" git_raw ~default:default_git.allowed_loop_start_branches;
         auto_merge = json_bool "autoMerge" git_raw ~default:default_git.auto_merge;
         merge_attention_status;
         cleanup =
@@ -633,6 +648,60 @@ let validate_stage_skill_load config add =
           stage.skills)
       config.stage_agents.stages
 
+let run_shell_capture ~cwd command =
+  let command = Printf.sprintf "cd %s && %s 2>&1" (Util.shell_quote cwd) command in
+  let ic = Unix.open_process_in command in
+  let output =
+    Fun.protect ~finally:(fun () -> ()) (fun () ->
+        let buffer = Buffer.create 128 in
+        (try
+           while true do
+             Buffer.add_string buffer (input_line ic);
+             Buffer.add_char buffer '\n'
+           done
+         with End_of_file -> ());
+        Buffer.contents buffer |> Util.trim)
+  in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> Ok output
+  | Unix.WEXITED code -> Error (Printf.sprintf "exit %d: %s" code output)
+  | Unix.WSIGNALED signal -> Error (Printf.sprintf "signal %d: %s" signal output)
+  | Unix.WSTOPPED signal -> Error (Printf.sprintf "stopped %d: %s" signal output)
+
+let current_loop_start_branch root =
+  match run_shell_capture ~cwd:root "git branch --show-current" with
+  | Ok branch when Util.trim branch <> "" -> Some (Util.trim branch)
+  | _ -> None
+
+let allowed_loop_start_branch_policy_gap config =
+  match config.git.allowed_loop_start_branches with
+  | [] -> None
+  | allowed_branches -> (
+      let allowed = String.concat ", " allowed_branches in
+      match current_loop_start_branch config.repository_root with
+      | Some current_branch when List.exists (( = ) current_branch) allowed_branches -> None
+      | Some current_branch ->
+          Some
+            {
+              requirement = "git.allowedLoopStartBranches";
+              remediation =
+                Printf.sprintf
+                  "Allowed Loop-Start Branch Policy blocked dispatch: current Loop-Start Branch %s is not allowed. \
+                   Allowed branches: %s. Switch to an allowed Loop-Start Branch or update Runtime Settings."
+                  current_branch allowed;
+            }
+      | None ->
+          Some
+            {
+              requirement = "git.allowedLoopStartBranches";
+              remediation =
+                Printf.sprintf
+                  "Allowed Loop-Start Branch Policy blocked dispatch: the current checkout does not have a named \
+                   Loop-Start Branch. Allowed branches: %s. Switch to an allowed Loop-Start Branch or update Runtime \
+                   Settings."
+                  allowed;
+            })
+
 let readiness_gaps config =
   let gaps = ref [] in
   let add requirement remediation = gaps := { requirement; remediation } :: !gaps in
@@ -658,6 +727,9 @@ let readiness_gaps config =
     add "project.terminalStates" "Add at least one terminal project state in .symphony/settings.json.";
   if config.pull_request.enabled && Util.trim config.pull_request.base_branch = "" then
     add "pullRequest.baseBranch" "Set pullRequest.baseBranch in .symphony/settings.json when pullRequest.enabled is true.";
+  (match allowed_loop_start_branch_policy_gap config with
+  | Some gap -> add gap.requirement gap.remediation
+  | None -> ());
   if stage_goal_handoff_enabled config then (
     let codex_config = codex_config_path () in
     if not (codex_goals_feature_enabled codex_config) then

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -96,6 +96,9 @@ let render_poll_paused seconds_remaining msg =
   Printf.eprintf "%s%s %s %s %s %s %ds\n%!" clear_line (dim (clock_time ())) (blue "poll") (yellow "waiting")
     msg (dim "retry_in") seconds_remaining
 
+let runtime_gap_of_config_gap (gap : Config.readiness_gap) =
+  { Runtime_state.requirement = gap.requirement; remediation = gap.remediation }
+
 let render_dispatch_started issue =
   Printf.eprintf "%s%s %s %s %s %s\n%!" clear_line (dim (clock_time ())) (cyan "dispatch") (green "started")
     issue.Issue.identifier issue.title
@@ -1378,7 +1381,31 @@ let reap_children orchestrator =
 let poll_once orchestrator =
   reap_children orchestrator;
   render_poll_started orchestrator;
-  match orchestrator.tracker_retry_due with
+  match Config.allowed_loop_start_branch_policy_gap orchestrator.config with
+  | Some gap ->
+      let runtime_gap = runtime_gap_of_config_gap gap in
+      update_state orchestrator (fun state ->
+        {
+          state with
+          readiness_gaps = [ runtime_gap ];
+          last_error = Some (gap.requirement ^ ": " ^ gap.remediation);
+        });
+      render_poll_failed ("readiness gap: " ^ gap.requirement)
+  | None -> (
+      if
+        List.exists
+          (fun (existing : Runtime_state.readiness_gap) -> existing.requirement = "git.allowedLoopStartBranches")
+          orchestrator.state.readiness_gaps
+      then
+        update_state orchestrator (fun state ->
+          {
+            state with
+            readiness_gaps =
+              List.filter
+                (fun (existing : Runtime_state.readiness_gap) -> existing.requirement <> "git.allowedLoopStartBranches")
+                state.readiness_gaps;
+          });
+      match orchestrator.tracker_retry_due with
   | Some due when Unix.time () < due ->
       let seconds = seconds_until due in
       let msg = tracker_retry_pause_message seconds in
@@ -1424,7 +1451,7 @@ let poll_once orchestrator =
       | exn ->
           let msg = Printexc.to_string exn in
           set_error orchestrator msg;
-          render_poll_failed msg)
+          render_poll_failed msg))
 
 let run_forever orchestrator =
   let finished_reported = ref false in

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -44,11 +44,13 @@ let ignore_runtime_home root =
   ignore (run_ok ~cwd:root "ignore runtime home" "git add .gitignore && git commit -q -m ignore-runtime-home")
 
 let git_policy ?(auto_merge = false) ?(protected_trunk_branches = [ "main"; "master" ])
+    ?(allowed_loop_start_branches = [])
     ?(merge_attention_status = "Human attention") ?(remove_worktree_after_merge = true) () =
   {
     Config.default_git with
     auto_merge;
     protected_trunk_branches;
+    allowed_loop_start_branches;
     merge_attention_status;
     cleanup = { Config.remove_worktree_after_merge = remove_worktree_after_merge; keep_task_branch = true };
   }
@@ -63,6 +65,7 @@ let test_config_parses_git_policy_and_stage_push () =
   "git": {
     "taskBranchPrefix": "agent/",
     "protectedTrunkBranches": ["main", "release"],
+    "allowedLoopStartBranches": ["symphony/dogfood"],
     "autoMerge": false,
     "mergeAttentionStatus": "Needs merge",
     "cleanup": {"removeWorktreeAfterMerge": false, "keepTaskBranch": true}
@@ -95,6 +98,8 @@ let test_config_parses_git_policy_and_stage_push () =
       let config = Config.from_settings_file ~workspace_root:root settings in
       Alcotest.(check string) "branch prefix" "agent/" config.git.task_branch_prefix;
       Alcotest.(check (list string)) "protected trunks" [ "main"; "release" ] config.git.protected_trunk_branches;
+      Alcotest.(check (list string)) "allowed loop-start branches" [ "symphony/dogfood" ]
+        config.git.allowed_loop_start_branches;
       Alcotest.(check bool) "auto merge" false config.git.auto_merge;
       Alcotest.(check string) "attention status" "Needs merge" config.git.merge_attention_status;
       Alcotest.(check bool) "attention status visible" true
@@ -108,6 +113,54 @@ let test_config_parses_git_policy_and_stage_push () =
           Alcotest.(check bool) "stage push" true engineer_commit.push;
           Alcotest.(check bool) "stage push default" false reviewer_commit.push
       | _ -> Alcotest.fail "expected stage commit policy")
+
+let test_config_parses_allowed_loop_start_branch_policy () =
+  with_temp_dir "symphony-loop-start-policy-" (fun root ->
+      Util.mkdir_p (Filename.concat root ".symphony/agents");
+      Util.write_file (Filename.concat root ".symphony/agents/engineer.md") "Engineer";
+      Unix.putenv "GITHUB_TOKEN" "token";
+      let write_settings body =
+        let settings = Filename.concat root ("settings-" ^ string_of_int (Random.bits ()) ^ ".json") in
+        Util.write_file settings body;
+        Config.from_settings_file ~workspace_root:root settings
+      in
+      let omitted =
+        write_settings
+          {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "stageAgents": {"enabled": false}
+}|}
+      in
+      Alcotest.(check (list string)) "omitted allows any branch" [] omitted.git.allowed_loop_start_branches;
+      let empty =
+        write_settings
+          {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "git": {"allowedLoopStartBranches": []},
+  "stageAgents": {"enabled": false}
+}|}
+      in
+      Alcotest.(check (list string)) "empty allows any branch" [] empty.git.allowed_loop_start_branches;
+      let valid =
+        write_settings
+          {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "git": {"allowedLoopStartBranches": ["symphony/dogfood", "release/train"]},
+  "stageAgents": {"enabled": false}
+}|}
+      in
+      Alcotest.(check (list string)) "valid branches" [ "symphony/dogfood"; "release/train" ]
+        valid.git.allowed_loop_start_branches;
+      Alcotest.check_raises "whitespace-only branch is invalid"
+        (Config.Invalid_config "git.allowedLoopStartBranches must not contain empty branch names")
+        (fun () ->
+          ignore
+            (write_settings
+               {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "git": {"allowedLoopStartBranches": ["   "]},
+  "stageAgents": {"enabled": false}
+}|})))
 
 let test_config_parses_stage_goal_and_readiness () =
   let original_home = Sys.getenv_opt "HOME" in
@@ -2812,6 +2865,27 @@ let base_orchestrator_config root git =
     stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
   }
 
+let test_allowed_loop_start_branch_readiness () =
+  with_temp_dir "symphony-loop-start-ready-" (fun root ->
+      init_repo root "symphony/dogfood";
+      let allowed = base_orchestrator_config root (git_policy ~allowed_loop_start_branches:[ "symphony/dogfood" ] ()) in
+      Alcotest.(check int) "allowed branch has no policy gap" 0
+        (Config.readiness_gaps allowed
+        |> List.filter (fun (gap : Config.readiness_gap) -> gap.requirement = "git.allowedLoopStartBranches")
+        |> List.length);
+      ignore (run_ok ~cwd:root "create main" "git switch -q -c main");
+      let blocked = base_orchestrator_config root (git_policy ~allowed_loop_start_branches:[ "symphony/dogfood" ] ()) in
+      let gaps = Config.readiness_gaps blocked in
+      let gap =
+        List.find_opt (fun (gap : Config.readiness_gap) -> gap.requirement = "git.allowedLoopStartBranches") gaps
+      in
+      Alcotest.(check bool) "disallowed branch is a readiness gap" true (Option.is_some gap);
+      let remediation = match gap with Some gap -> gap.remediation | None -> "" in
+      Alcotest.(check bool) "mentions current branch" true (contains_substring remediation "current Loop-Start Branch main");
+      Alcotest.(check bool) "mentions allowed branch" true (contains_substring remediation "symphony/dogfood");
+      Alcotest.(check bool) "mentions remediation" true
+        (contains_substring remediation "Switch to an allowed Loop-Start Branch or update Runtime Settings"))
+
 let completed_stage_config root git =
   {
     (base_orchestrator_config root git) with
@@ -3229,6 +3303,50 @@ let test_orchestrator_requires_clean_loop_start_for_new_worktree () =
         (Orchestrator.get_state orchestrator).last_error;
       Alcotest.(check bool) "no placeholder worktree left" false
         (Sys.file_exists (Filename.concat config.workspace.root "_4")))
+
+let test_orchestrator_blocks_disallowed_loop_start_before_side_effects () =
+  with_temp_dir "symphony-disallowed-loop-start-" (fun root ->
+      init_repo root "main";
+      let config =
+        completed_stage_config root (git_policy ~auto_merge:true ~allowed_loop_start_branches:[ "symphony/dogfood" ] ())
+      in
+      let issue = Issue.empty ~id:"I30" ~identifier:"#30" ~title:"Thirty" ~state:"In review" in
+      let workspace = create_task_worktree config issue in
+      Util.write_file (Filename.concat workspace.path "should-not-merge.txt") "blocked\n";
+      ignore (run_ok ~cwd:workspace.path "task commit" "git add should-not-merge.txt && git commit -q -m task");
+      let fetches = ref 0 in
+      let statuses = ref [] in
+      let launches = ref 0 in
+      let prs = ref 0 in
+      let launch ~config:_ ~workspace:_ ~prompt:_ ~issue =
+        incr launches;
+        { Orchestrator.pid = None; session_id = Some issue.Issue.id; event = "test-launch"; stdout_path = None; stderr_path = None }
+      in
+      let set_status _ _ status =
+        statuses := status :: !statuses;
+        Ok ()
+      in
+      let orchestrator =
+        Orchestrator.make ~launch ~fetch:(fun _ ->
+            incr fetches;
+            [ issue ])
+          ~set_status
+          ~batch_pull_request_handoff:(fun _ ~head_branch:_ ->
+            incr prs;
+            Ok (Some "https://example.test/pr/1"))
+          ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check int) "tracker not fetched" 0 !fetches;
+      Alcotest.(check int) "not launched" 0 !launches;
+      Alcotest.(check (list string)) "no status movement" [] (List.rev !statuses);
+      Alcotest.(check int) "no batch pull request" 0 !prs;
+      Alcotest.(check bool) "startup reconciliation did not merge" false
+        (Sys.file_exists (Filename.concat root "should-not-merge.txt"));
+      let state = Orchestrator.get_state orchestrator in
+      Alcotest.(check (list string)) "readiness gap"
+        [ "git.allowedLoopStartBranches" ]
+        (List.map (fun (gap : Runtime_state.readiness_gap) -> gap.requirement) state.readiness_gaps))
 
 let test_orchestrator_reuses_existing_task_branch_on_restart () =
   with_temp_dir "symphony-reuse-task-branch-" (fun root ->
@@ -3662,12 +3780,16 @@ let () =
           Alcotest.test_case "normalizes legacy codex app-server command" `Quick test_legacy_codex_app_server_command_normalizes_to_exec;
           Alcotest.test_case "derives kanban status order from transitions" `Quick test_project_status_order_uses_transition_flow;
           Alcotest.test_case "parses git policy and stage push" `Quick test_config_parses_git_policy_and_stage_push;
+          Alcotest.test_case "parses allowed loop-start branch policy" `Quick
+            test_config_parses_allowed_loop_start_branch_policy;
           Alcotest.test_case "parses stage goal and readiness" `Quick test_config_parses_stage_goal_and_readiness;
           Alcotest.test_case "disabled stage goal does not require codex goals" `Quick test_disabled_stage_goal_does_not_require_codex_goals;
           Alcotest.test_case "parses stage skill load and readiness" `Quick test_config_parses_stage_skill_load_and_readiness;
           Alcotest.test_case "stage goal requires codex exec stdin support" `Quick test_stage_goal_requires_codex_exec_stdin_support;
           Alcotest.test_case "stage goal live stdin probe" `Quick test_stage_goal_live_stdin_probe;
           Alcotest.test_case "requires pull request base branch when enabled" `Quick test_pull_request_base_branch_readiness_gap;
+          Alcotest.test_case "checks allowed loop-start branch readiness" `Quick
+            test_allowed_loop_start_branch_readiness;
         ] );
       ( "runtime-state",
         [
@@ -3754,6 +3876,8 @@ let () =
           Alcotest.test_case "blocks batch pull request on attention" `Quick test_orchestrator_blocks_batch_pull_request_on_attention;
           Alcotest.test_case "reuses existing batch pull request" `Quick test_batch_pull_request_handoff_reuses_existing_pr;
           Alcotest.test_case "requires clean loop-start worktree" `Quick test_orchestrator_requires_clean_loop_start_for_new_worktree;
+          Alcotest.test_case "blocks disallowed loop-start before side effects" `Quick
+            test_orchestrator_blocks_disallowed_loop_start_before_side_effects;
           Alcotest.test_case "reuses existing task branch on restart" `Quick test_orchestrator_reuses_existing_task_branch_on_restart;
           Alcotest.test_case "reuses worktree for existing in-progress task"
             `Quick test_orchestrator_reuses_worktree_for_existing_in_progress_task_before_launch;

--- a/docs/adr/0014-allowed-loop-start-branch-policy.md
+++ b/docs/adr/0014-allowed-loop-start-branch-policy.md
@@ -1,0 +1,23 @@
+# Allowed Loop-Start Branch Policy
+
+## Status
+
+Accepted
+
+## Context
+
+Protected Trunk Branches prevent automated Task Branch integration into configured trunks, but they do not stop Symphony from starting orchestration on an unsuitable Loop-Start Branch. A Self-Dogfooding Workspace Repository needs a readiness gate so automated dogfood dispatch starts from a dedicated integration branch instead of from the Product Repository trunk.
+
+## Decision
+
+Runtime Settings may define `git.allowedLoopStartBranches` as the Allowed Loop-Start Branch Policy. The first version matches literal local branch names only.
+
+When `git.allowedLoopStartBranches` is omitted or an empty list, Symphony allows any Loop-Start Branch to preserve existing Runtime Contract behavior and Bootstrap defaults. When the list is non-empty, Symphony compares the current named Loop-Start Branch to the configured set during readiness validation. If the branch is not allowed, or the checkout has no named branch, Symphony reports a Readiness Gap with the current branch state, allowed branch names, and the remediation to switch branches or update Runtime Settings.
+
+The policy is separate from `protectedTrunkBranches`. Protected Trunk Branches still control automated Task Branch integration. The Allowed Loop-Start Branch Policy controls whether automated orchestration may start at all.
+
+## Consequences
+
+A disallowed Loop-Start Branch blocks dispatch before creating Agent Worktrees, moving tracker statuses, running Startup Reconciliation integration, or opening a Batch Pull Request. The Terminal Console and Web Dashboard remain available because Readiness Gaps are served as Runtime State.
+
+Self-dogfooding setups can allow `symphony/dogfood` while keeping `main` as a Protected Trunk Branch. Existing Workspace Repositories that do not configure the policy keep their current behavior.


### PR DESCRIPTION
## Summary
- Add `git.allowedLoopStartBranches` under Git Policy with unrestricted behavior when omitted or empty
- Surface disallowed Loop-Start Branches as Readiness Gaps before orchestration side effects
- Document runtime semantics in `CONTEXT.md` and ADR 0014

## Verification
- `pnpm test`

Closes #30