### PR TITLE
feat: add safe parallel Task Branch integration

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -173,7 +173,7 @@ The startup-time recovery pass that checks completed-stage Agent Worktrees for T
 _Avoid_: startup merge, branch sweep, cleanup scan
 
 **Task Branch Integration**:
-The act of bringing completed Task Branch commits into the Loop-Start Branch.
+The serialized act of bringing completed Task Branch commits into the Loop-Start Branch, directly by fast-forward when possible or by first updating the Task Branch from the current Loop-Start Branch.
 _Avoid_: merge worktrees, copy workspace, finish branch
 
 **Terminal Console**:
@@ -244,7 +244,7 @@ _Avoid_: reinitialize, reset
 - A **Self-Dogfooding Workspace Repository** should keep **Stage Push** disabled unless remote branch publication is deliberately enabled.
 - A **Self-Dogfooding Workspace Repository** should use reviewer-stage comments and a **Human Attention Status** for review findings that require operator triage.
 - A **Self-Dogfooding Workspace Repository** should have the reviewer stage run focused verification when practical before moving work to `Done`.
-- A **Self-Dogfooding Workspace Repository** should use one concurrent agent until Personal Symphony can safely integrate multiple concurrently completed **Task Branches**.
+- A **Self-Dogfooding Workspace Repository** may increase concurrency when its **Loop-Start Branch** is not a **Protected Trunk Branch** because **Task Branch Integration** can integrate unrelated concurrently completed **Task Branches**.
 - A **Self-Dogfooding Workspace Repository** should use a dedicated non-trunk **Loop-Start Branch** so completed **Task Branches** do not auto-merge into the Product Repository trunk.
 - A **Self-Dogfooding Workspace Repository** may open a **Batch Pull Request** from its dedicated **Loop-Start Branch** to its **Protected Trunk Branch** after **Orchestration Idle**.
 - A **Self-Dogfooding Workspace Repository** should remove merged **Agent Worktrees** and delete merged **Task Branches** to avoid local branch buildup.
@@ -277,7 +277,8 @@ _Avoid_: reinitialize, reset
 - If Symphony starts while a task is already in the in-progress project state, Symphony creates or reuses that task's **Agent Worktree** before starting agent work.
 - Symphony requires a **Clean Loop-Start Worktree** before creating an **Agent Worktree**.
 - Symphony may auto-merge a completed **Task Branch** into the **Loop-Start Branch** only when the **Loop-Start Branch** is not a **Protected Trunk Branch**.
-- Auto-merge of a **Task Branch** into the **Loop-Start Branch** is fast-forward only.
+- Auto-merge of a **Task Branch** into the **Loop-Start Branch** keeps the final **Loop-Start Branch** update fast-forward only.
+- If the **Loop-Start Branch** cannot fast-forward directly to a completed **Task Branch**, Symphony may update the **Task Branch** by merging the current **Loop-Start Branch** into it from the **Agent Worktree**, then fast-forward the **Loop-Start Branch** to the updated **Task Branch**.
 - When auto-merge fails, Symphony may move the task to a **Merge Attention Status**.
 - Auto-merge, **Startup Reconciliation**, and **Manual Task Merge** are **Task Branch Integration** paths.
 - An **Allowed Loop-Start Branch Policy** prevents dispatch from any Loop-Start Branch outside the configured literal branch set.
@@ -290,9 +291,10 @@ _Avoid_: reinitialize, reset
 - **Manual Task Merge** does not push branches, run Startup Reconciliation, dispatch agents, or open a Batch Pull Request.
 - **Startup Reconciliation** runs once per process startup before normal dispatch or agent launch.
 - **Startup Reconciliation** evaluates completed-stage **Agent Worktrees** in deterministic issue order.
-- **Startup Reconciliation** integrates safe committed **Task Branch** work into the **Loop-Start Branch** by fast-forward only.
+- **Startup Reconciliation** uses the same safe **Task Branch Integration** path as normal completion.
 - **Startup Reconciliation** does not create a **Stage Commit**, reconcile retained **Task Branches** without **Agent Worktrees**, or change tracker status after successful or already-contained reconciliation.
-- **Startup Reconciliation** moves unsafe, contradictory, non-fast-forward, or Protected Trunk Branch candidates to the **Merge Attention Status** and records Runtime State diagnostics.
+- **Startup Reconciliation** moves unsafe, contradictory, conflicted, or Protected Trunk Branch candidates to the **Merge Attention Status** and records Runtime State diagnostics.
+- **Runtime State** records **Task Branch Integration** diagnostics for direct fast-forwards, update-then-fast-forward integrations, already-contained branches, and integration attention.
 - A **Merge Attention Status** is a **Human Attention Status**.
 - The default **Merge Attention Status** is `Human attention`.
 - A **Human Attention Status** is paused and not dispatchable.
@@ -311,6 +313,7 @@ _Avoid_: reinitialize, reset
 - A **Stage Push** uses the current **Task Branch** upstream when one exists.
 - A **Stage Push** creates an upstream on `origin` when the current **Task Branch** has no upstream.
 - A **Stage Push** happens before any auto-merge attempt.
+- **Task Branch Integration** must not force-push a **Task Branch** after **Stage Push**.
 - Symphony does not push the **Loop-Start Branch** after auto-merge.
 - A failed **Stage Push** prevents the stage from moving to its success project state.
 - A failed **Stage Push** is retryable.

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -998,6 +998,75 @@ let cleanup_task_worktree_for_issue config issue workspace_path =
       (run_shell_capture ~cwd:config.repository_root
          (Printf.sprintf "git branch -d %s" (Util.shell_quote (task_branch config issue))))
 
+type task_branch_integration_result =
+  | Already_contained
+  | Direct_fast_forward
+  | Updated_task_branch_then_fast_forward
+
+let task_branch_integration_result_name = function
+  | Already_contained -> "already_contained"
+  | Direct_fast_forward -> "direct_fast_forward"
+  | Updated_task_branch_then_fast_forward -> "updated_task_branch_then_fast_forwarded"
+
+let task_branch_integration_message = function
+  | Already_contained -> "Task Branch is already contained in the Loop-Start Branch"
+  | Direct_fast_forward -> "Task Branch fast-forwarded directly into the Loop-Start Branch"
+  | Updated_task_branch_then_fast_forward ->
+      "Task Branch was updated from the Loop-Start Branch, then fast-forwarded into the Loop-Start Branch"
+
+let record_task_branch_integration orchestrator issue ?workspace_path result =
+  let result_name = task_branch_integration_result_name result in
+  let row =
+    {
+      Runtime_state.issue_id = issue.Issue.id;
+      issue_identifier = issue.identifier;
+      task_branch = task_branch orchestrator.config issue;
+      workspace_path;
+      result = result_name;
+      direct_fast_forward = (result = Direct_fast_forward);
+      task_branch_updated_from_loop_start = (result = Updated_task_branch_then_fast_forward);
+      attention = None;
+      message = task_branch_integration_message result;
+    }
+  in
+  update_state orchestrator (fun state ->
+    { state with task_branch_integrations = state.task_branch_integrations @ [ row ] })
+
+let record_task_branch_integration_attention orchestrator issue ?workspace_path attention message =
+  let row =
+    {
+      Runtime_state.issue_id = issue.Issue.id;
+      issue_identifier = issue.identifier;
+      task_branch = task_branch orchestrator.config issue;
+      workspace_path;
+      result = "attention";
+      direct_fast_forward = false;
+      task_branch_updated_from_loop_start = false;
+      attention = Some attention;
+      message;
+    }
+  in
+  update_state orchestrator (fun state ->
+    { state with task_branch_integrations = state.task_branch_integrations @ [ row ] })
+
+let integrate_task_branch config ~loop_start_branch ~workspace_path branch =
+  let root = config.Config.repository_root in
+  if git_ref_contained_in_head root branch then Ok Already_contained
+  else if git_head_can_fast_forward_to root branch then
+    match run_shell_capture ~cwd:root (Printf.sprintf "git merge --ff-only %s" (Util.shell_quote branch)) with
+    | Ok _ -> Ok Direct_fast_forward
+    | Error error -> Error ("Task Branch could not fast-forward: " ^ error)
+  else
+    let merge_command =
+      Printf.sprintf "git merge --no-edit %s" (Util.shell_quote loop_start_branch)
+    in
+    match run_shell_capture ~cwd:workspace_path merge_command with
+    | Error error -> Error ("Task Branch could not update from the Loop-Start Branch: " ^ error)
+    | Ok _ -> (
+        match run_shell_capture ~cwd:root (Printf.sprintf "git merge --ff-only %s" (Util.shell_quote branch)) with
+        | Ok _ -> Ok Updated_task_branch_then_fast_forward
+        | Error error -> Error ("updated Task Branch could not fast-forward: " ^ error))
+
 let reconcile_startup_candidate orchestrator issue =
   let workspace_path = task_workspace_path orchestrator.config issue in
   let branch = task_branch orchestrator.config issue in
@@ -1021,23 +1090,23 @@ let reconcile_startup_candidate orchestrator issue =
           let root = orchestrator.config.repository_root in
           if git_ref_contained_in_head root branch then (
             cleanup_task_worktree_for_issue orchestrator.config issue workspace_path;
+            record_task_branch_integration orchestrator issue ~workspace_path Already_contained;
             record_startup_reconciliation orchestrator ~issue ~task_branch:branch ~workspace_path "already_reconciled"
               "Task Branch is already contained in the Loop-Start Branch")
           else if protected_loop_start orchestrator then
             record_startup_attention orchestrator issue branch workspace_path "attention_protected_trunk"
               "committed Task Branch work exists but Loop-Start Branch is protected"
-          else if git_head_can_fast_forward_to root branch then
-            match run_shell_capture ~cwd:root (Printf.sprintf "git merge --ff-only %s" (Util.shell_quote branch)) with
-            | Ok _ ->
-                cleanup_task_worktree_for_issue orchestrator.config issue workspace_path;
-                record_startup_reconciliation orchestrator ~issue ~task_branch:branch ~workspace_path "merged"
-                  "Task Branch fast-forwarded into the Loop-Start Branch"
-            | Error error ->
-                record_startup_attention orchestrator issue branch workspace_path "attention_non_fast_forward"
-                  ("Task Branch could not fast-forward: " ^ error)
           else
-            record_startup_attention orchestrator issue branch workspace_path "attention_non_fast_forward"
-              "Task Branch could not fast-forward")
+            match integrate_task_branch orchestrator.config ~loop_start_branch:orchestrator.loop_start_branch ~workspace_path branch with
+            | Ok result ->
+                cleanup_task_worktree_for_issue orchestrator.config issue workspace_path;
+                record_task_branch_integration orchestrator issue ~workspace_path result;
+                record_startup_reconciliation orchestrator ~issue ~task_branch:branch ~workspace_path
+                  (task_branch_integration_result_name result)
+                  (task_branch_integration_message result)
+            | Error error ->
+                record_task_branch_integration_attention orchestrator issue ~workspace_path "attention_integration_failed" error;
+                record_startup_attention orchestrator issue branch workspace_path "attention_integration_failed" error)
 
 let reconcile_startup orchestrator candidates =
   if not orchestrator.startup_reconciliation_done then (
@@ -1259,14 +1328,29 @@ let auto_merge_child orchestrator child =
   if (not (is_git_repository orchestrator.config.repository_root)) || (not orchestrator.config.git.auto_merge) || protected_loop_start orchestrator then Ok ()
   else
     let branch = task_branch orchestrator.config child.issue in
-    match
-      run_shell_capture ~cwd:orchestrator.config.repository_root
-        (Printf.sprintf "git merge --ff-only %s" (Util.shell_quote branch))
-    with
-    | Ok _ ->
-        cleanup_task_worktree orchestrator child;
-        Ok ()
-    | Error error -> Error ("auto-merge failed: " ^ error)
+    match has_worktree_changes child.workspace.path with
+    | Error error ->
+        record_task_branch_integration_attention orchestrator child.issue ~workspace_path:child.workspace.path
+          "attention_uncommitted_changes" error;
+        Error ("auto-merge failed: " ^ error)
+    | Ok true ->
+        let error = "Agent Worktree has uncommitted changes" in
+        record_task_branch_integration_attention orchestrator child.issue ~workspace_path:child.workspace.path
+          "attention_uncommitted_changes" error;
+        Error ("auto-merge failed: " ^ error)
+    | Ok false -> (
+        match
+          integrate_task_branch orchestrator.config ~loop_start_branch:orchestrator.loop_start_branch
+            ~workspace_path:child.workspace.path branch
+        with
+        | Ok result ->
+            record_task_branch_integration orchestrator child.issue ~workspace_path:child.workspace.path result;
+            cleanup_task_worktree orchestrator child;
+            Ok ()
+        | Error error ->
+            record_task_branch_integration_attention orchestrator child.issue ~workspace_path:child.workspace.path
+              "attention_integration_failed" error;
+            Error ("auto-merge failed: " ^ error))
 
 let mark_merge_attention orchestrator child error =
   set_error orchestrator error;

--- a/apps/backend/lib/runtime_state.ml
+++ b/apps/backend/lib/runtime_state.ml
@@ -38,6 +38,17 @@ type startup_reconciliation = {
   category : string;
   message : string;
 }
+type task_branch_integration = {
+  issue_id : string;
+  issue_identifier : string;
+  task_branch : string;
+  workspace_path : string option;
+  result : string;
+  direct_fast_forward : bool;
+  task_branch_updated_from_loop_start : bool;
+  attention : string option;
+  message : string;
+}
 type pull_request_handoff = {
   enabled : bool;
   head_branch : string option;
@@ -60,6 +71,7 @@ type t = {
   pull_request : pull_request_handoff option;
   ordered_queue : ordered_queue option;
   startup_reconciliation : startup_reconciliation list;
+  task_branch_integrations : task_branch_integration list;
   last_error : string option;
 }
 
@@ -77,6 +89,7 @@ let empty ?(readiness_gaps = []) ?(status_order = []) ?ordered_queue ?last_error
     pull_request = None;
     ordered_queue;
     startup_reconciliation = [];
+    task_branch_integrations = [];
     last_error;
   }
 
@@ -174,6 +187,20 @@ let startup_reconciliation_to_yojson (row : startup_reconciliation) =
       ("message", `String row.message);
     ]
 
+let task_branch_integration_to_yojson (row : task_branch_integration) =
+  `Assoc
+    [
+      ("issue_id", `String row.issue_id);
+      ("issue_identifier", `String row.issue_identifier);
+      ("task_branch", `String row.task_branch);
+      ("workspace_path", (match row.workspace_path with Some s -> `String s | None -> `Null));
+      ("result", `String row.result);
+      ("direct_fast_forward", `Bool row.direct_fast_forward);
+      ("task_branch_updated_from_loop_start", `Bool row.task_branch_updated_from_loop_start);
+      ("attention", (match row.attention with Some s -> `String s | None -> `Null));
+      ("message", `String row.message);
+    ]
+
 let json_member name = function
   | `Assoc fields -> List.assoc_opt name fields
   | _ -> None
@@ -232,5 +259,6 @@ let to_yojson state =
       ("pull_request", (match state.pull_request with Some row -> pull_request_handoff_to_yojson row | None -> `Null));
       ("ordered_queue", (match state.ordered_queue with Some row -> ordered_queue_to_yojson row | None -> `Null));
       ("startup_reconciliation", `List (List.map startup_reconciliation_to_yojson state.startup_reconciliation));
+      ("task_branch_integrations", `List (List.map task_branch_integration_to_yojson state.task_branch_integrations));
       ("last_error", (match state.last_error with Some s -> `String s | None -> `Null));
     ]

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -2918,6 +2918,22 @@ let create_task_worktree config issue =
   | Ok workspace -> workspace
   | Error error -> Alcotest.fail error
 
+let completed_child issue workspace =
+  {
+    Orchestrator.pid = 0;
+    issue;
+    issue_id = issue.Issue.id;
+    issue_identifier = issue.identifier;
+    issue_title = issue.title;
+    workspace;
+    started_at = Unix.time ();
+    last_output_at = Unix.time ();
+    stdout_path = None;
+    stderr_path = None;
+    stdout_size = 0;
+    stderr_size = 0;
+  }
+
 let commit_file ~cwd file content message =
   Util.write_file (Filename.concat cwd file) content;
   ignore (run_ok ~cwd "commit file" (Printf.sprintf "git add %s && git commit -q -m %s" (Util.shell_quote file) (Util.shell_quote message)))
@@ -2945,7 +2961,7 @@ let test_startup_reconciliation_merges_completed_worktrees_in_order () =
       Orchestrator.poll_once orchestrator;
       Alcotest.(check bool) "first file merged" true (Sys.file_exists (Filename.concat root "a.txt"));
       Alcotest.(check bool) "second file merged" true (Sys.file_exists (Filename.concat root "b.txt"));
-      Alcotest.(check (list string)) "diagnostic order" [ "merged"; "merged" ]
+      Alcotest.(check (list string)) "diagnostic order" [ "direct_fast_forward"; "direct_fast_forward" ]
         (diagnostic_categories (Orchestrator.get_state orchestrator));
       let log = run_ok ~cwd:root "log" "git log --reverse --format=%s" |> Util.split_lines in
       Alcotest.(check (list string)) "merge order" [ "initial"; "ignore-runtime-home"; "task 21"; "task 22" ] log;
@@ -3016,7 +3032,7 @@ let test_startup_reconciliation_moves_unsafe_candidates_to_attention () =
         (List.rev !statuses);
       Alcotest.(check int) "issue errors" 2 (List.length (Orchestrator.get_state orchestrator).issue_errors))
 
-let test_startup_reconciliation_continues_after_non_fast_forward () =
+let test_startup_reconciliation_updates_task_branch_before_fast_forward () =
   with_temp_dir "symphony-startup-reconcile-nonff-" (fun root ->
       init_repo root "feature/start";
       ignore_runtime_home root;
@@ -3037,11 +3053,12 @@ let test_startup_reconciliation_continues_after_non_fast_forward () =
           ~config ~prompt_template:"Issue {{ issue.identifier }}" ()
       in
       Orchestrator.poll_once orchestrator;
-      Alcotest.(check bool) "non fast forward not merged" false (Sys.file_exists (Filename.concat root "nonff.txt"));
+      Alcotest.(check bool) "non fast forward merged" true (Sys.file_exists (Filename.concat root "nonff.txt"));
       Alcotest.(check bool) "later candidate still merged" true (Sys.file_exists (Filename.concat root "later.txt"));
-      Alcotest.(check (list string)) "diagnostics" [ "attention_non_fast_forward"; "merged" ]
+      Alcotest.(check (list string)) "diagnostics"
+        [ "updated_task_branch_then_fast_forwarded"; "updated_task_branch_then_fast_forwarded" ]
         (diagnostic_categories (Orchestrator.get_state orchestrator));
-      Alcotest.(check (list (pair string string))) "only nonff moved to attention" [ ("#26", "Human attention") ]
+      Alcotest.(check (list (pair string string))) "no attention status" []
         (List.rev !statuses))
 
 let test_startup_reconciliation_detects_wrong_and_missing_task_branch () =
@@ -3558,6 +3575,46 @@ let test_auto_merge_skips_protected_trunk_branch () =
       Alcotest.(check bool) "worktree kept" true (Sys.file_exists workspace.path);
       Alcotest.(check (list string)) "still advances status" [ "In review" ] (List.rev !statuses))
 
+let test_auto_merge_integrates_parallel_unrelated_task_branches () =
+  with_temp_dir "symphony-parallel-task-integration-" (fun root ->
+      init_repo root "feature/start";
+      ignore_runtime_home root;
+      let git = git_policy ~auto_merge:true () in
+      let config =
+        {
+          (base_orchestrator_config root git) with
+          Config.agent = { Config.max_concurrent_agents = 2; max_turns = 10; max_retry_backoff_ms = 1000 };
+        }
+      in
+      let issue_11 = Issue.empty ~id:"I11" ~identifier:"#11" ~title:"Eleven" ~state:"In progress" in
+      let issue_12 = Issue.empty ~id:"I12" ~identifier:"#12" ~title:"Twelve" ~state:"In progress" in
+      let workspace_11 = create_task_worktree config issue_11 in
+      let workspace_12 = create_task_worktree config issue_12 in
+      commit_file ~cwd:workspace_11.path "one.txt" "one\n" "task 11";
+      commit_file ~cwd:workspace_12.path "two.txt" "two\n" "task 12";
+      let statuses = ref [] in
+      let set_status _ issue status =
+        statuses := (issue.Issue.identifier, status) :: !statuses;
+        Ok ()
+      in
+      let orchestrator = Orchestrator.make ~set_status ~config ~prompt_template:"Issue {{ issue.identifier }}" () in
+      Orchestrator.mark_completed orchestrator (completed_child issue_11 workspace_11);
+      Orchestrator.mark_completed orchestrator (completed_child issue_12 workspace_12);
+      Alcotest.(check bool) "first file merged" true (Sys.file_exists (Filename.concat root "one.txt"));
+      Alcotest.(check bool) "second file merged" true (Sys.file_exists (Filename.concat root "two.txt"));
+      Alcotest.(check bool) "first worktree removed" false (Sys.file_exists workspace_11.path);
+      Alcotest.(check bool) "second worktree removed" false (Sys.file_exists workspace_12.path);
+      Alcotest.(check (list (pair string string))) "both statuses advance"
+        [ ("#11", "In review"); ("#12", "In review") ]
+        (List.rev !statuses);
+      let state = Orchestrator.get_state orchestrator in
+      Alcotest.(check int) "no issue errors" 0 (List.length state.issue_errors);
+      Alcotest.(check (list string)) "integration results"
+        [ "direct_fast_forward"; "updated_task_branch_then_fast_forwarded" ]
+        (List.map
+           (fun (row : Runtime_state.task_branch_integration) -> row.result)
+           state.Runtime_state.task_branch_integrations))
+
 let test_auto_merge_failure_moves_human_attention () =
   with_temp_dir "symphony-auto-merge-fail-" (fun root ->
       init_repo root "feature/start";
@@ -3568,10 +3625,12 @@ let test_auto_merge_failure_moves_human_attention () =
         | Ok workspace -> workspace
         | Error error -> Alcotest.fail error
       in
-      Util.write_file (Filename.concat workspace.path "task.txt") "task\n";
-      ignore (run_ok ~cwd:workspace.path "task commit" "git add task.txt && git commit -q -m task");
-      Util.write_file (Filename.concat root "loop.txt") "loop\n";
-      ignore (run_ok ~cwd:root "loop commit" "git add loop.txt && git commit -q -m loop");
+      Util.write_file (Filename.concat root "shared.txt") "base\n";
+      ignore (run_ok ~cwd:root "base commit" "git add shared.txt && git commit -q -m base-shared");
+      Util.write_file (Filename.concat workspace.path "shared.txt") "task\n";
+      ignore (run_ok ~cwd:workspace.path "task commit" "git add shared.txt && git commit -q -m task");
+      Util.write_file (Filename.concat root "shared.txt") "loop\n";
+      ignore (run_ok ~cwd:root "loop commit" "git add shared.txt && git commit -q -m loop");
       let statuses = ref [] in
       let set_status _ _ status =
         statuses := status :: !statuses;
@@ -3596,7 +3655,11 @@ let test_auto_merge_failure_moves_human_attention () =
       Alcotest.(check (list string)) "attention status only" [ "Human attention" ] (List.rev !statuses);
       let state = Orchestrator.get_state orchestrator in
       Alcotest.(check int) "issue error" 1 (List.length state.issue_errors);
-      Alcotest.(check bool) "worktree kept for inspection" true (Sys.file_exists workspace.path))
+      Alcotest.(check bool) "worktree kept for inspection" true (Sys.file_exists workspace.path);
+      Alcotest.(check (list string)) "attention diagnostic" [ "attention" ]
+        (List.map
+           (fun (row : Runtime_state.task_branch_integration) -> row.result)
+           state.Runtime_state.task_branch_integrations))
 
 let manual_merge_config ?(keep_task_branch = true) root =
   if not (Sys.file_exists (Filename.concat root ".gitignore")) then (
@@ -3862,8 +3925,8 @@ let () =
             `Quick test_startup_reconciliation_already_contained_applies_cleanup_without_status_change;
           Alcotest.test_case "startup reconciliation moves unsafe candidates to attention"
             `Quick test_startup_reconciliation_moves_unsafe_candidates_to_attention;
-          Alcotest.test_case "startup reconciliation continues after non-fast-forward"
-            `Quick test_startup_reconciliation_continues_after_non_fast_forward;
+          Alcotest.test_case "startup reconciliation updates task branch before fast-forward"
+            `Quick test_startup_reconciliation_updates_task_branch_before_fast_forward;
           Alcotest.test_case "startup reconciliation detects wrong and missing branches"
             `Quick test_startup_reconciliation_detects_wrong_and_missing_task_branch;
           Alcotest.test_case "startup reconciliation blocks when loop-start is dirty"
@@ -3886,6 +3949,8 @@ let () =
           Alcotest.test_case "fast-forwards task branch and removes worktree" `Quick test_auto_merge_fast_forwards_and_removes_worktree;
           Alcotest.test_case "can remove task branch after merge" `Quick test_cleanup_can_remove_task_branch_after_merge;
           Alcotest.test_case "skips auto-merge on protected trunk" `Quick test_auto_merge_skips_protected_trunk_branch;
+          Alcotest.test_case "integrates parallel unrelated task branches"
+            `Quick test_auto_merge_integrates_parallel_unrelated_task_branches;
           Alcotest.test_case "moves merge failures to human attention" `Quick test_auto_merge_failure_moves_human_attention;
         ] );
       ( "manual-merge",

--- a/docs/adr/0005-per-task-git-worktrees.md
+++ b/docs/adr/0005-per-task-git-worktrees.md
@@ -18,13 +18,13 @@ Runtime Settings include a Git Policy for:
 
 - Task Branch Prefix.
 - Protected Trunk Branches.
-- fast-forward-only auto-merge.
+- serialized Task Branch Integration with a fast-forward-only final Loop-Start Branch update.
 - Merge Attention Status.
 - Task Cleanup Policy.
 
 Stage Commit still happens before a task moves to its success status. When a stage commit policy enables Stage Push, Symphony pushes the current Task Branch after the Stage Commit and before any auto-merge attempt.
 
-Completed Task Branches may auto-merge into the Loop-Start Branch only when the Loop-Start Branch is not a configured Protected Trunk Branch. Auto-merge is fast-forward only. Symphony does not push the Loop-Start Branch after auto-merge.
+Completed Task Branches may auto-merge into the Loop-Start Branch only when the Loop-Start Branch is not a configured Protected Trunk Branch. The final Loop-Start Branch update is fast-forward only. When the Loop-Start Branch cannot fast-forward directly to a completed Task Branch, Symphony may merge the current Loop-Start Branch into the Task Branch from the Agent Worktree, then fast-forward the Loop-Start Branch to the updated Task Branch. Symphony does not push the Loop-Start Branch after auto-merge.
 
 The default cleanup policy removes the Agent Worktree after a successful merge and keeps the Task Branch. If configured not to keep the Task Branch, Symphony deletes it after the worktree is removed.
 
@@ -32,4 +32,4 @@ The default cleanup policy removes the Agent Worktree after a successful merge a
 
 Concurrent task work is isolated by Git instead of by convention. Operators can inspect, push, merge, or discard each Task Branch independently.
 
-Merge conflicts and non-fast-forward integration failures are treated as human attention events. Symphony moves the task to the configured Merge Attention Status, which defaults to `Human attention`, instead of retrying agent work against an integration problem.
+Merge conflicts and integration failures are treated as human attention events. Symphony moves the task to the configured Merge Attention Status, which defaults to `Human attention`, instead of retrying agent work against an integration problem.

--- a/docs/adr/0009-startup-reconciliation.md
+++ b/docs/adr/0009-startup-reconciliation.md
@@ -14,9 +14,9 @@ Startup Reconciliation runs once per process startup after the first tracker fet
 
 Candidates are sorted by numeric issue identifier and then Task Branch name. The Loop-Start Worktree must be clean before any candidate is merged. Each Agent Worktree must be a valid Git worktree, be checked out on the expected Task Branch, reference an existing Task Branch, and have no uncommitted changes.
 
-Safe committed work is integrated into the Loop-Start Branch with `git merge --ff-only`. Already-contained Task Branches are treated as reconciled. Successful and already-contained candidates apply the existing Task Cleanup Policy and do not change tracker status.
+Safe committed work uses the same Task Branch Integration path as normal completion. Already-contained Task Branches are treated as reconciled. If the Loop-Start Branch can fast-forward directly to the Task Branch, Startup Reconciliation preserves that direct fast-forward. If direct fast-forward is not possible, Startup Reconciliation may merge the current Loop-Start Branch into the Task Branch from the Agent Worktree, then fast-forward the Loop-Start Branch to the updated Task Branch. Successful and already-contained candidates apply the existing Task Cleanup Policy and do not change tracker status.
 
-Unsafe candidates move to the configured Merge Attention Status and are recorded in Runtime State issue errors. Protected Trunk Branch targets, wrong branches, missing Task Branches, uncommitted Agent Worktree changes, and non-fast-forward branches are attention cases. Startup Reconciliation does not create Stage Commits, does not resolve conflicts, does not rebase, does not force-push, and does not auto-merge into Protected Trunk Branches.
+Unsafe candidates move to the configured Merge Attention Status and are recorded in Runtime State issue errors. Protected Trunk Branch targets, wrong branches, missing Task Branches, uncommitted Agent Worktree changes, and conflicted integration are attention cases. Startup Reconciliation does not create Stage Commits, does not resolve conflicts, does not rebase, does not force-push, and does not auto-merge into Protected Trunk Branches.
 
 Runtime State records startup reconciliation diagnostics for merged, already-reconciled, skipped, and attention outcomes. The Terminal Console also prints each outcome during startup.
 

--- a/docs/adr/0015-safe-parallel-task-branch-integration.md
+++ b/docs/adr/0015-safe-parallel-task-branch-integration.md
@@ -1,0 +1,43 @@
+# ADR 0015: Safe Parallel Task Branch Integration
+
+## Status
+
+Accepted
+
+## Context
+
+When `agent.maxConcurrentAgents` is greater than `1`, multiple Task Branches can start from the same Loop-Start Branch tip. After the first completed Task Branch fast-forwards the Loop-Start Branch, another unrelated Task Branch from the original tip is no longer a direct fast-forward even when its file changes do not conflict.
+
+Treating that non-fast-forward shape as merge attention blocks useful parallel work. Rebasing the Task Branch would require force-pushing if Stage Push already published it. Creating a direct merge commit on the Loop-Start Branch would change the current model where the Loop-Start Branch moves only by fast-forwarding to a Task Branch tip.
+
+## Decision
+
+Automated Task Branch Integration is serialized and keeps the final Loop-Start Branch update fast-forward only.
+
+Stage Commit still runs before Stage Push. Stage Push, when enabled, remains non-force and runs before Task Branch Integration.
+
+If the Loop-Start Branch is a Protected Trunk Branch, Symphony does not run automated Task Branch Integration.
+
+If the Loop-Start Branch already contains the Task Branch, Symphony treats the task as already integrated and applies eligible Task Cleanup Policy.
+
+If the Loop-Start Branch can fast-forward directly to the completed Task Branch, Symphony preserves the direct fast-forward path.
+
+If direct fast-forward is not possible, Symphony merges the current Loop-Start Branch into the completed Task Branch from the Agent Worktree. When that update succeeds, Symphony fast-forwards the Loop-Start Branch to the updated Task Branch tip. The integration merge commit belongs to the Task Branch and exists only to connect the current Loop-Start Branch history with the completed task work.
+
+If the Task Branch update conflicts or the updated Task Branch still cannot fast-forward the Loop-Start Branch, Symphony moves the task to the Merge Attention Status and keeps the Agent Worktree for inspection.
+
+Startup Reconciliation uses the same Task Branch Integration rules as normal completion. Manual Task Merge keeps its explicit operator-selected fast-forward-only semantics.
+
+Runtime State records Task Branch Integration diagnostics so operators can distinguish already-contained work, direct fast-forward, update-then-fast-forward, and attention outcomes.
+
+## Consequences
+
+Unrelated concurrently completed Task Branches can integrate into the Loop-Start Branch without avoidable merge attention.
+
+Published Task Branches do not need force-push because integration updates are ordinary merge commits on the Task Branch.
+
+Protected Trunk Branch behavior is unchanged.
+
+True conflicts remain visible as human attention, with the Agent Worktree retained for inspection.
+
+Batch Pull Request behavior remains based on work already integrated into the Loop-Start Branch and remains blocked while Merge Attention Status or unresolved orchestration attention exists.


### PR DESCRIPTION
## Summary
- add serialized Task Branch Integration that updates completed Task Branches from the current Loop-Start Branch before final fast-forward when needed
- expose Runtime State diagnostics for direct fast-forward, update-then-fast-forward, already-contained, and attention outcomes
- update CONTEXT.md and ADRs for the new runtime semantics

## Verification
- pnpm test
- pnpm backend:build

Closes #36