### PR TITLE
Fix task branch merge fallback and issue comments

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -321,6 +321,7 @@ _Avoid_: reinitialize, reset
 - A **Stage Goal Handoff** is not a global Codex launch mode.
 - Runtime Settings configure **Stage Goal Handoff** with `goal.enabled` on a stage.
 - A missing `goal` setting means **Stage Goal Handoff** is disabled for that stage.
+- A rendered **Agent Prompt** includes GitHub issue comments when they are present.
 - Bootstrapped Runtime Settings include `goal.enabled` as `false` in each example stage.
 - A **Stage Goal Handoff** uses **Stage Goal Context** as its Codex goal payload.
 - A **Stage Goal Handoff** supplements the normal **Agent Prompt**.
@@ -333,7 +334,7 @@ _Avoid_: reinitialize, reset
 - Symphony sends the Codex `/goal` command before the normal rendered **Agent Prompt** when performing a **Stage Goal Handoff**.
 - Implementation of **Stage Goal Handoff** must verify that `codex exec` accepts `/goal` from standard input before treating the feature as supported.
 - If `codex exec` does not accept `/goal` from standard input, Symphony must surface the blocker instead of pretending **Stage Goal Handoff** works.
-- **Stage Goal Context** includes issue identifier, title, description, URL, current project status, labels, priority when present, blocker references when present, attempt, and stage agent name.
+- **Stage Goal Context** includes issue identifier, title, description, comments, URL, current project status, labels, priority when present, blocker references when present, attempt, and stage agent name.
 - **Stage Goal Context** does not include issue creation or update timestamps by default.
 - Symphony extracts **Goal Usage** from Codex output when Codex reports it in a parseable form.
 - Symphony does not invent **Goal Usage** when Codex output does not report it.

--- a/README.md
+++ b/README.md
@@ -192,11 +192,13 @@ skill files and does not include Stage Skill Load in Stage Goal Context. Missing
 duplicate skill identifiers are Readiness Gaps; Symphony checks all configured stages before
 dispatch, resolving Workspace Repository skills before Codex Home skills.
 
+Rendered Agent Prompts include GitHub issue comments as issue context in addition to the issue body.
+
 Set `goal.enabled` to `true` on a specific stage to enable Stage Goal Handoff for that stage only.
 When enabled, Symphony sends `/goal` with deterministic Stage Goal Context before the normal Agent
-Prompt. Stage Goal Context includes issue identifier, title, description, URL, current GitHub Project
-status, labels, priority when present, blocker references when present, attempt, and stage agent
-name. It omits issue creation and update timestamps.
+Prompt. Stage Goal Context includes issue identifier, title, description, comments, URL, current
+GitHub Project status, labels, priority when present, blocker references when present, attempt, and
+stage agent name. It omits issue creation and update timestamps.
 
 Stage Goal Handoff requires Codex goals in `~/.codex/config.toml`:
 

--- a/apps/backend/lib/github_tracker.ml
+++ b/apps/backend/lib/github_tracker.ml
@@ -47,6 +47,14 @@ query($owner:String!, $repo:String!) {
         url
         createdAt
         updatedAt
+        comments(first:50) {
+          nodes {
+            body
+            createdAt
+            url
+            author { login }
+          }
+        }
         labels(first:20) { nodes { name } }
         projectItems(first:20) {
           nodes {
@@ -80,6 +88,14 @@ let queue_issue_query numbers =
         url
         createdAt
         updatedAt
+        comments(first:50) {
+          nodes {
+            body
+            createdAt
+            url
+            author { login }
+          }
+        }
         labels(first:20) { nodes { name } }
         projectItems(first:20) {
           nodes {
@@ -312,6 +328,23 @@ let issue_is_closed node =
   | Some state -> string_equal_ci state "CLOSED"
   | None -> false
 
+let comment_from_node node =
+  match node |> member "body" |> safe_to_string_option with
+  | None -> None
+  | Some body ->
+      Some
+        {
+          Issue.author = node |> member "author" |> member "login" |> safe_to_string_option;
+          body;
+          created_at = node |> member "createdAt" |> safe_to_string_option;
+          url = node |> member "url" |> safe_to_string_option;
+        }
+
+let comment_nodes node =
+  match node |> member "comments" with
+  | `Assoc _ as comments -> comments |> member "nodes" |> safe_to_list
+  | _ -> []
+
 let project_issue_from_node ~(config : Config.tracker) node =
   let number = node |> member "number" |> safe_to_int_option in
   match number with
@@ -326,6 +359,7 @@ let project_issue_from_node ~(config : Config.tracker) node =
              ~title:(node |> member "title" |> safe_to_string) ~state)
           with
           description = node |> member "body" |> safe_to_string_option;
+          comments = comment_nodes node |> List.filter_map comment_from_node;
           url = node |> member "url" |> safe_to_string_option;
           created_at = node |> member "createdAt" |> safe_to_string_option;
           updated_at = node |> member "updatedAt" |> safe_to_string_option;
@@ -352,6 +386,19 @@ let issue_from_project_node ~(config : Config.tracker) node =
              ~title:(node |> member "title" |> to_string) ~state)
           with
           description = node |> member "body" |> to_string_option;
+          comments =
+            comment_nodes node
+            |> List.filter_map (fun comment ->
+                   match comment |> member "body" |> to_string_option with
+                   | None -> None
+                   | Some body ->
+                       Some
+                         {
+                           Issue.author = comment |> member "author" |> member "login" |> to_string_option;
+                           body;
+                           created_at = comment |> member "createdAt" |> to_string_option;
+                           url = comment |> member "url" |> to_string_option;
+                         });
           url = node |> member "url" |> to_string_option;
           created_at = node |> member "createdAt" |> to_string_option;
           updated_at = node |> member "updatedAt" |> to_string_option;

--- a/apps/backend/lib/issue.ml
+++ b/apps/backend/lib/issue.ml
@@ -1,10 +1,12 @@
 type blocker = { id : string option; identifier : string option; state : string option }
+type comment = { author : string option; body : string; created_at : string option; url : string option }
 
 type t = {
   id : string;
   identifier : string;
   title : string;
   description : string option;
+  comments : comment list;
   priority : int option;
   state : string;
   branch_name : string option;
@@ -21,6 +23,7 @@ let empty ~id ~identifier ~title ~state =
     identifier;
     title;
     description = None;
+    comments = [];
     priority = None;
     state;
     branch_name = None;
@@ -33,6 +36,15 @@ let empty ~id ~identifier ~title ~state =
 
 let option_string = function Some s -> `String s | None -> `Null
 let option_int = function Some i -> `Int i | None -> `Null
+
+let comment_to_yojson comment =
+  `Assoc
+    [
+      ("author", option_string comment.author);
+      ("body", `String comment.body);
+      ("created_at", option_string comment.created_at);
+      ("url", option_string comment.url);
+    ]
 
 let blocker_to_yojson (b : blocker) =
   `Assoc
@@ -49,6 +61,7 @@ let to_yojson issue =
       ("identifier", `String issue.identifier);
       ("title", `String issue.title);
       ("description", option_string issue.description);
+      ("comments", `List (List.map comment_to_yojson issue.comments));
       ("priority", option_int issue.priority);
       ("state", `String issue.state);
       ("branch_name", option_string issue.branch_name);
@@ -64,6 +77,19 @@ let field issue = function
   | "identifier" -> Some issue.identifier
   | "title" -> Some issue.title
   | "description" -> Some (Option.value issue.description ~default:"")
+  | "comments" ->
+      Some
+        (issue.comments
+        |> List.map (fun comment ->
+               let prefix =
+                 match (comment.author, comment.created_at) with
+                 | Some author, Some created_at -> Printf.sprintf "%s at %s" author created_at
+                 | Some author, None -> author
+                 | None, Some created_at -> created_at
+                 | None, None -> "comment"
+               in
+               Printf.sprintf "%s:\n%s" prefix comment.body)
+        |> String.concat "\n\n")
   | "state" -> Some issue.state
   | "branch_name" -> Some (Option.value issue.branch_name ~default:"")
   | "url" -> Some (Option.value issue.url ~default:"")

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -316,6 +316,12 @@ let agent_prompt config issue =
         if Sys.file_exists path then Some (agent, stage, Util.read_file path |> Util.trim) else None
 
 let normal_prompt config issue base_prompt =
+  let comments_section =
+    match Issue.field issue "comments" with
+    | Some comments when Util.trim comments <> "" -> Printf.sprintf "\n\n---\n\nIssue comments:\n\n%s" comments
+    | _ -> ""
+  in
+  let base_prompt = base_prompt ^ comments_section in
   match agent_prompt config issue with
   | None -> base_prompt
   | Some (agent, stage, prompt) ->
@@ -340,6 +346,15 @@ let blocker_to_goal_json (blocker : Issue.blocker) =
       ("state", json_option_string blocker.state);
     ]
 
+let comment_to_goal_json (comment : Issue.comment) =
+  `Assoc
+    [
+      ("author", json_option_string comment.author);
+      ("body", `String comment.body);
+      ("created_at", json_option_string comment.created_at);
+      ("url", json_option_string comment.url);
+    ]
+
 let stage_goal_context issue attempt (stage : Config.stage_agent) =
   `Assoc
     [
@@ -347,6 +362,7 @@ let stage_goal_context issue attempt (stage : Config.stage_agent) =
       ("issue_identifier", `String issue.Issue.identifier);
       ("title", `String issue.title);
       ("description", json_option_string issue.description);
+      ("comments", `List (List.map comment_to_goal_json issue.comments));
       ("url", json_option_string issue.url);
       ("current_project_status", `String issue.state);
       ("labels", `List (List.map (fun label -> `String label) issue.labels));
@@ -1063,12 +1079,7 @@ let record_task_branch_integration_attention orchestrator issue ?workspace_path 
 
 let integrate_task_branch config ~loop_start_branch ~workspace_path branch =
   let root = config.Config.repository_root in
-  if git_ref_contained_in_head root branch then Ok Already_contained
-  else if git_head_can_fast_forward_to root branch then
-    match run_shell_capture ~cwd:root (Printf.sprintf "git merge --ff-only %s" (Util.shell_quote branch)) with
-    | Ok _ -> Ok Direct_fast_forward
-    | Error error -> Error ("Task Branch could not fast-forward: " ^ error)
-  else
+  let update_task_branch_then_fast_forward () =
     let merge_command =
       Printf.sprintf "git merge --no-edit %s" (Util.shell_quote loop_start_branch)
     in
@@ -1078,6 +1089,13 @@ let integrate_task_branch config ~loop_start_branch ~workspace_path branch =
         match run_shell_capture ~cwd:root (Printf.sprintf "git merge --ff-only %s" (Util.shell_quote branch)) with
         | Ok _ -> Ok Updated_task_branch_then_fast_forward
         | Error error -> Error ("updated Task Branch could not fast-forward: " ^ error))
+  in
+  if git_ref_contained_in_head root branch then Ok Already_contained
+  else if git_head_can_fast_forward_to root branch then
+    match run_shell_capture ~cwd:root (Printf.sprintf "git merge --ff-only %s" (Util.shell_quote branch)) with
+    | Ok _ -> Ok Direct_fast_forward
+    | Error _ -> update_task_branch_then_fast_forward ()
+  else update_task_branch_then_fast_forward ()
 
 let reconcile_startup_candidate orchestrator issue =
   let workspace_path = task_workspace_path orchestrator.config issue in

--- a/apps/backend/lib/runtime_state.ml
+++ b/apps/backend/lib/runtime_state.ml
@@ -116,6 +116,7 @@ let issue_to_yojson issue =
       ("issue_identifier", `String issue.identifier);
       ("title", `String issue.title);
       ("description", (match issue.description with Some s -> `String s | None -> `Null));
+      ("comments", `List (List.map Issue.comment_to_yojson issue.comments));
       ("url", (match issue.url with Some s -> `String s | None -> `Null));
       ("state", `String issue.state);
       ("created_at", (match issue.created_at with Some s -> `String s | None -> `Null));
@@ -129,6 +130,7 @@ let running_to_yojson row =
       ("issue_identifier", `String row.issue.identifier);
       ("title", `String row.issue.title);
       ("description", (match row.issue.description with Some s -> `String s | None -> `Null));
+      ("comments", `List (List.map Issue.comment_to_yojson row.issue.comments));
       ("url", (match row.issue.url with Some s -> `String s | None -> `Null));
       ("state", `String row.issue.state);
       ("session_id", (match row.session_id with Some s -> `String s | None -> `Null));

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -462,10 +462,27 @@ Issue {{ issue.identifier }}: {{ issue.title }}
       Alcotest.(check string) "prompt" "Issue {{ issue.identifier }}: {{ issue.title }}" workflow.prompt_template)
 
 let test_prompt_strict_rendering () =
-  let issue = Issue.empty ~id:"I_kw" ~identifier:"#42" ~title:"Fix build" ~state:"Todo" in
+  let issue =
+    {
+      (Issue.empty ~id:"I_kw" ~identifier:"#42" ~title:"Fix build" ~state:"Todo") with
+      comments =
+        [
+          {
+            Issue.author = Some "matheus";
+            body = "Please include issue comments.";
+            created_at = Some "2026-05-06T18:00:00Z";
+            url = Some "https://example.test/comment/1";
+          };
+        ];
+    }
+  in
   Alcotest.(check string)
     "rendered prompt" "Work on #42: Fix build attempt=2"
     (Prompt.render ~issue ~attempt:(Some 2) "Work on {{ issue.identifier }}: {{ issue.title }} attempt={{ attempt }}");
+  Alcotest.(check bool) "renders comments" true
+    (contains_substring
+       (Prompt.render ~issue ~attempt:None "Comments:\n{{ issue.comments }}")
+       "matheus at 2026-05-06T18:00:00Z:\nPlease include issue comments.");
   Alcotest.check_raises "unknown issue field fails"
     (Prompt.Template_render_error "unknown issue field: missing")
     (fun () -> ignore (Prompt.render ~issue ~attempt:None "{{ issue.missing }}"))
@@ -1634,6 +1651,14 @@ let test_github_project_field_parsing () =
   "url": "https://github.example/acme/widgets/issues/42",
   "createdAt": "2026-01-01T00:00:00Z",
   "updatedAt": "2026-01-02T00:00:00Z",
+  "comments": { "nodes": [
+    {
+      "body": "Needs the project comments in prompt.md",
+      "createdAt": "2026-05-06T18:00:00Z",
+      "url": "https://github.example/acme/widgets/issues/42#issuecomment-1",
+      "author": { "login": "matheus" }
+    }
+  ] },
   "labels": { "nodes": [{ "name": "Bug" }] },
   "projectItems": {
     "nodes": [
@@ -1654,6 +1679,8 @@ let test_github_project_field_parsing () =
   | Some issue ->
       Alcotest.(check string) "identifier" "#42" issue.identifier;
       Alcotest.(check string) "status" "In Progress" issue.state;
+      Alcotest.(check int) "comment count" 1 (List.length issue.comments);
+      Alcotest.(check string) "comment body" "Needs the project comments in prompt.md" (List.hd issue.comments).body;
       Alcotest.(check (list string)) "labels lowercased" [ "bug" ] issue.labels
 
 let test_github_active_state_filtering () =
@@ -2298,6 +2325,15 @@ let test_orchestrator_prepends_stage_goal_handoff () =
         {
           (Issue.empty ~id:"I1" ~identifier:"#1" ~title:"One" ~state:"Todo") with
           description = Some "Build the feature";
+          comments =
+            [
+              {
+                Issue.author = Some "reviewer";
+                body = "Remember the edge case from the thread.";
+                created_at = Some "2026-05-06T18:30:00Z";
+                url = Some "https://example.test/issues/1#issuecomment-1";
+              };
+            ];
           url = Some "https://example.test/issues/1";
           labels = [ "enhancement"; "codex" ];
           priority = Some 2;
@@ -2315,6 +2351,8 @@ let test_orchestrator_prepends_stage_goal_handoff () =
       Alcotest.(check bool) "goal command first" true (String.starts_with ~prefix:"/goal {\"kind\":\"Stage Goal Context\"" !captured_prompt);
       Alcotest.(check bool) "stage agent included" true (String.contains !captured_prompt 'E');
       Alcotest.(check bool) "normal prompt included" true (String.contains !captured_prompt '#');
+      Alcotest.(check bool) "normal prompt includes comments" true
+        (contains_substring !captured_prompt "Issue comments:\n\nreviewer at 2026-05-06T18:30:00Z:\nRemember the edge case from the thread.");
       Alcotest.(check bool) "skill load preserves order" true
         (contains_substring !captured_prompt "Stage Skill Load:\n$to-prd\n$github:gh-fix-ci");
       let goal_line =
@@ -2327,6 +2365,8 @@ let test_orchestrator_prepends_stage_goal_handoff () =
       Alcotest.(check string) "goal kind" "Stage Goal Context" (goal_json |> member "kind" |> to_string);
       Alcotest.(check string) "goal issue" "#1" (goal_json |> member "issue_identifier" |> to_string);
       Alcotest.(check string) "goal description" "Build the feature" (goal_json |> member "description" |> to_string);
+      Alcotest.(check string) "goal comment" "Remember the edge case from the thread."
+        (goal_json |> member "comments" |> to_list |> List.hd |> member "body" |> to_string);
       Alcotest.(check (list string)) "goal labels" [ "enhancement"; "codex" ]
         (goal_json |> member "labels" |> to_list |> List.map to_string);
       Alcotest.(check int) "goal priority" 2 (goal_json |> member "priority" |> to_int);

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>Personal Symphony</title>
+    <title>Symphony Orchestrator</title>
   </head>
   <body class="bg-zinc-950 text-zinc-100">
     <main id="root"></main>

--- a/docs/adr/0007-stage-goal-handoff.md
+++ b/docs/adr/0007-stage-goal-handoff.md
@@ -14,7 +14,7 @@ Codex goal support also depends on local Codex configuration and stdin slash-com
 
 Runtime Settings configure Stage Goal Handoff per stage with `goal.enabled`. Missing `goal` means disabled, and bootstrapped Runtime Settings include `goal.enabled: false` for every example stage.
 
-When a matching stage enables Stage Goal Handoff, Symphony prepends `/goal` plus deterministic Stage Goal Context before the normal rendered Agent Prompt. Stage Goal Context includes issue identifier, title, description, URL, current project status, labels, priority when present, blocker references when present, attempt, and stage agent name. It does not include issue creation or update timestamps by default.
+When a matching stage enables Stage Goal Handoff, Symphony prepends `/goal` plus deterministic Stage Goal Context before the normal rendered Agent Prompt. Stage Goal Context includes issue identifier, title, description, issue comments, URL, current project status, labels, priority when present, blocker references when present, attempt, and stage agent name. It does not include issue creation or update timestamps by default.
 
 Symphony treats missing Codex goal support as a Readiness Gap. It checks `~/.codex/config.toml` for:
 

--- a/docs/adr/0016-issue-comments-in-agent-context.md
+++ b/docs/adr/0016-issue-comments-in-agent-context.md
@@ -1,0 +1,11 @@
+# ADR 0016: Issue Comments in Agent Context
+
+Agents need the full GitHub issue discussion, not only the issue body. Important acceptance details,
+operator corrections, and review direction often live in comments after the original description.
+
+Symphony fetches issue comments with candidate issues and ordered queue issue lookups. Rendered Agent
+Prompts include those comments when present, and Stage Goal Context carries the same comment data
+when Stage Goal Handoff is enabled.
+
+Issue comments supplement the Agent Prompt and Stage Goal Context. They do not replace the issue
+description, Stage Agent instructions, Stage Skill Load, or Runtime Contract prompt template.


### PR DESCRIPTION
## Summary
- fall back to updating the Task Branch from the Loop-Start Branch when direct fast-forward merge fails
- fetch GitHub issue comments and include them in rendered Agent Prompts and Stage Goal Context
- document issue comment context semantics in README, CONTEXT, and ADR 0016

## Verification
- pnpm backend:build
- pnpm test