### PR TITLE
Fix stale agent worktree registration recovery

### DIFF
--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -480,6 +480,11 @@ let require_clean_loop_start root =
   | Ok _ -> Error "loop-start worktree must be clean before creating task worktrees"
   | Error error -> Error ("git status failed: " ^ error)
 
+let prune_stale_worktrees root =
+  match run_shell_capture ~cwd:root "git worktree prune" with
+  | Ok _ -> Ok ()
+  | Error error -> Error ("git worktree prune failed: " ^ error)
+
 let shell_prepare_workspace config ~loop_start_branch issue =
   let branch = task_branch config issue in
   if not (is_git_repository config.repository_root) then
@@ -495,26 +500,31 @@ let shell_prepare_workspace config ~loop_start_branch issue =
       match require_clean_loop_start config.repository_root with
       | Error _ as error -> error
       | Ok () ->
-          let workspace = Workspace.create_for_issue ~root:config.Config.workspace.root issue.Issue.identifier in
-          let create_branch =
-            if git_ref_exists config.repository_root branch then Ok ()
-            else
-              match
-                run_shell_capture ~cwd:config.repository_root
-                  (Printf.sprintf "git branch %s %s" (Util.shell_quote branch) (Util.shell_quote loop_start_branch))
-              with
-              | Ok _ -> Ok ()
-              | Error _ as error -> error
+          let prepare_workspace () =
+            let workspace = Workspace.create_for_issue ~root:config.Config.workspace.root issue.Issue.identifier in
+            let create_branch =
+              if git_ref_exists config.repository_root branch then Ok ()
+              else
+                match
+                  run_shell_capture ~cwd:config.repository_root
+                    (Printf.sprintf "git branch %s %s" (Util.shell_quote branch) (Util.shell_quote loop_start_branch))
+                with
+                | Ok _ -> Ok ()
+                | Error _ as error -> error
+            in
+            match create_branch with
+            | Error error -> Error ("task branch creation failed: " ^ error)
+            | Ok _ -> (
+                match
+                  run_shell_capture ~cwd:config.repository_root
+                    (Printf.sprintf "git worktree add %s %s" (Util.shell_quote workspace.path) (Util.shell_quote branch))
+                with
+                | Ok _ -> Ok workspace
+                | Error error -> Error ("agent worktree creation failed: " ^ error))
           in
-          (match create_branch with
-          | Error error -> Error ("task branch creation failed: " ^ error)
-          | Ok _ -> (
-              match
-                run_shell_capture ~cwd:config.repository_root
-                  (Printf.sprintf "git worktree add %s %s" (Util.shell_quote workspace.path) (Util.shell_quote branch))
-              with
-              | Ok _ -> Ok workspace
-              | Error error -> Error ("agent worktree creation failed: " ^ error)))
+          match prune_stale_worktrees config.repository_root with
+          | Error _ as error -> error
+          | Ok () -> prepare_workspace ()
 
 let has_worktree_changes root =
   match run_shell_capture ~cwd:root "git status --porcelain" with

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -3536,6 +3536,21 @@ let test_orchestrator_reuses_existing_task_branch_on_restart () =
       Alcotest.(check string) "reused branch checked out" "symphony/task-8"
         (run_ok ~cwd:workspace.path "branch" "git branch --show-current"))
 
+let test_orchestrator_prunes_missing_registered_worktree () =
+  with_temp_dir "symphony-missing-registered-worktree-" (fun root ->
+      init_repo root "feature/start";
+      let config = base_orchestrator_config root (git_policy ()) in
+      let issue = Issue.empty ~id:"I13" ~identifier:"#13" ~title:"Thirteen" ~state:"In progress" in
+      let workspace = create_task_worktree config issue in
+      ignore (run_ok ~cwd:root "delete worktree directory" (Printf.sprintf "rm -rf %s" (Util.shell_quote workspace.path)));
+      let workspace =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"feature/start" issue with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Alcotest.(check string) "recreated branch checked out" "symphony/task-13"
+        (run_ok ~cwd:workspace.path "branch" "git branch --show-current"))
+
 let test_orchestrator_reuses_worktree_for_existing_in_progress_task_before_launch () =
   with_temp_dir "symphony-existing-progress-" (fun root ->
       init_repo root "feature/start";
@@ -4103,6 +4118,8 @@ let () =
           Alcotest.test_case "blocks disallowed loop-start before side effects" `Quick
             test_orchestrator_blocks_disallowed_loop_start_before_side_effects;
           Alcotest.test_case "reuses existing task branch on restart" `Quick test_orchestrator_reuses_existing_task_branch_on_restart;
+          Alcotest.test_case "prunes missing registered worktree" `Quick
+            test_orchestrator_prunes_missing_registered_worktree;
           Alcotest.test_case "reuses worktree for existing in-progress task"
             `Quick test_orchestrator_reuses_worktree_for_existing_in_progress_task_before_launch;
           Alcotest.test_case "rejects existing non-worktree workspace" `Quick test_orchestrator_rejects_existing_non_worktree_workspace;


### PR DESCRIPTION
## Summary
- prune stale Git worktree registrations before recreating Agent Worktrees
- keep existing non-worktree workspace safety checks intact
- add a regression test for manually deleted but still registered Agent Worktrees

## Verification
- pnpm backend:build
- pnpm test