### PR TITLE
Add task pull request mode for Task Branch reviews into main

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -164,16 +164,24 @@ _Avoid_: queue item, queued issue, queue row
 A single pull request opened from the Loop-Start Branch either after Symphony reaches Orchestration Idle or, when configured, after task work moves to the review status.
 _Avoid_: per-task PR, task pull request, queue PR
 
+**Task Pull Request**:
+A pull request opened from one Task Branch to the configured Pull Request Base Branch when that task moves to the review status.
+_Avoid_: batch PR, agent PR, worktree PR
+
 **Batch Branch Push**:
 An optional non-force push of the Loop-Start Branch before opening a Batch Pull Request.
 _Avoid_: final push, queue push, release push
 
 **Pull Request Base Branch**:
-The configured target branch for a Batch Pull Request.
+The configured target branch for a Batch Pull Request or Task Pull Request.
 _Avoid_: inferred base, default branch, protected branch
 
+**Pull Request Mode**:
+The Runtime Settings choice that selects Batch Pull Request behavior or Task Pull Request behavior.
+_Avoid_: PR kind, PR strategy
+
 **Pull Request Policy**:
-The Runtime Settings section that controls automatic Batch Pull Request creation.
+The Runtime Settings section that controls automatic pull request creation.
 _Avoid_: PR config, GitHub settings, git policy
 
 **Review Pull Request Handoff**:
@@ -181,7 +189,7 @@ An opt-in Pull Request Policy trigger that opens the Batch Pull Request immediat
 _Avoid_: per-task PR, review PR, agent PR
 
 **Pull Request Template**:
-The configured title or body pattern used when opening a Batch Pull Request.
+The configured title or body pattern used when opening a Batch Pull Request or Task Pull Request.
 _Avoid_: generated PR text, AI summary, PR prose
 
 **Readiness Gap**:
@@ -431,6 +439,9 @@ _Avoid_: reinitialize, reset
 - The **Terminal Console** should show compact **Ordered Queue** progress and explicit skip and completion events.
 - The **Web Dashboard** should show active **Ordered Queue Entries** in their original order with current progress and skipped-entry reasons.
 - Symphony reaches **Orchestration Idle** when no active issue is running, retrying, or dispatchable.
+- The default **Pull Request Mode** is `batch`.
+- A **Pull Request Mode** of `batch` preserves existing **Batch Pull Request** behavior.
+- A **Pull Request Mode** of `task` opens **Task Pull Requests** and disables **Batch Pull Request** creation.
 - A **Batch Pull Request** represents the combined task work already integrated into the **Loop-Start Branch**.
 - Symphony may open a **Batch Pull Request** after reaching **Orchestration Idle**.
 - Symphony must not open a **Batch Pull Request** while any issue remains in a **Merge Attention Status**.
@@ -440,12 +451,19 @@ _Avoid_: reinitialize, reset
 - Symphony reports a **Readiness Gap** when automatic **Batch Pull Request** creation is enabled and the current **Loop-Start Branch** is the same branch as the configured **Pull Request Base Branch**.
 - Symphony may retry opening a **Batch Pull Request** after a failed attempt when **Orchestration Idle** is reached again.
 - Symphony must not create a duplicate **Batch Pull Request** for the same head and base branches.
+- A **Task Pull Request** uses a completed task's **Task Branch** as its head branch.
+- A **Task Pull Request** uses the configured **Pull Request Base Branch** as its base branch.
+- Symphony opens or reuses a **Task Pull Request** when automatic pull request creation is enabled, the **Pull Request Mode** is `task`, and the task moves to the review status.
+- Symphony may open **Task Pull Requests** while the current **Loop-Start Branch** is the same branch as the configured **Pull Request Base Branch**.
+- A **Task Pull Request** does not require **Task Branch Integration** into the **Loop-Start Branch** before handoff.
+- A **Task Pull Request** handoff pushes the **Task Branch** non-force before opening or reusing the pull request.
 - A **Pull Request Base Branch** must be configured explicitly in Runtime Settings.
 - The **Runtime Settings** may contain a **Pull Request Policy**.
-- The **Pull Request Policy** controls whether Symphony opens a **Batch Pull Request** after **Orchestration Idle**.
+- The **Pull Request Policy** controls whether Symphony opens pull requests and which **Pull Request Mode** it uses.
 - The default **Pull Request Policy** disables automatic **Batch Pull Request** creation.
 - A **Pull Request Base Branch** is required when the **Pull Request Policy** enables automatic **Batch Pull Request** creation.
-- The **Pull Request Policy** may define **Pull Request Templates** for the **Batch Pull Request** title and body.
+- A **Pull Request Base Branch** is required when the **Pull Request Policy** enables automatic **Task Pull Request** creation.
+- The **Pull Request Policy** may define **Pull Request Templates** for pull request title and body.
 - Default **Pull Request Templates** are deterministic and do not require an agent-generated summary.
 - A **Batch Branch Push** happens before opening a **Batch Pull Request**.
 - A **Batch Branch Push** pushes the **Loop-Start Branch** to its remote head branch.
@@ -574,8 +592,9 @@ _Avoid_: reinitialize, reset
 - "error happens" was used broadly; resolved: use **Task Needs Attention** only when a new Runtime State issue error appears.
 - "tasks in queue" was used to mean there is no remaining orchestration work; resolved: use **Orchestration Idle** for the condition where no active issue is running, retrying, or dispatchable.
 - "Open PR after finishing all the tasks" was used to mean opening one pull request for combined task work; resolved: use **Batch Pull Request**, opened from the **Loop-Start Branch** after **Orchestration Idle** by default.
-- "Open PR after the agent reaches In review" means opening the same **Batch Pull Request** early through **Review Pull Request Handoff**, not creating a separate per-task pull request.
-- "base branch" for automatic PR creation was ambiguous because the **Loop-Start Branch** is the head of the **Batch Pull Request**; resolved: use configured **Pull Request Base Branch** for the target branch.
+- "Open PR after the agent reaches In review" in `batch` **Pull Request Mode** means opening the same **Batch Pull Request** early through **Review Pull Request Handoff**.
+- "Start on main, but open PRs from each Task Branch into main" means using `task` **Pull Request Mode** to open **Task Pull Requests**.
+- "base branch" for automatic PR creation was ambiguous because **Batch Pull Requests** and **Task Pull Requests** have different head branches; resolved: use configured **Pull Request Base Branch** for the target branch.
 - "merge the worktrees" was used to mean integrating completed **Task Branches**; resolved: Symphony fast-forward merges **Task Branches** into the **Loop-Start Branch**, not Agent Worktrees.
 - ".symphonyignore" was used to mean a repository-owned rule for files agents must not modify; resolved: use **Protected Path Policy** stored in **Runtime Settings** for the first version.
 - "allowed branch" was used to mean restricting where orchestration may start; resolved: use **Allowed Loop-Start Branch Policy**.

--- a/apps/backend/lib/config.ml
+++ b/apps/backend/lib/config.ml
@@ -38,7 +38,14 @@ type server = { port : int option }
 type protected_path_pattern = { name : string; pattern : string; reason : string option }
 type protected_path_authorization = { issue_section : string }
 type protected_paths = { patterns : protected_path_pattern list; authorization : protected_path_authorization }
-type pull_request = { enabled : bool; open_on_review : bool; base_branch : string; title : string; body : string }
+type pull_request = {
+  enabled : bool;
+  mode : string;
+  open_on_review : bool;
+  base_branch : string;
+  title : string;
+  body : string;
+}
 type stage_commit_classification = {
   default : string;
   label_map : (string * string) list;
@@ -100,7 +107,14 @@ let default_pull_request_body = "Opened automatically by Symphony after orchestr
 let default_protected_path_authorization = { issue_section = "Protected Path Authorization" }
 let default_protected_paths = { patterns = []; authorization = default_protected_path_authorization }
 let default_pull_request =
-  { enabled = false; open_on_review = false; base_branch = "main"; title = default_pull_request_title; body = default_pull_request_body }
+  {
+    enabled = false;
+    mode = "batch";
+    open_on_review = false;
+    base_branch = "main";
+    title = default_pull_request_title;
+    body = default_pull_request_body;
+  }
 let default_conflict_behavior = "human_attention"
 
 let default_git =
@@ -648,6 +662,9 @@ let from_settings_file ~workspace_root path =
     pull_request =
       {
         enabled = json_bool "enabled" pull_request_raw ~default:default_pull_request.enabled;
+        mode =
+          json_string "mode" pull_request_raw ~default:default_pull_request.mode
+          |> Util.trim |> String.lowercase_ascii;
         open_on_review = json_bool "openOnReview" pull_request_raw ~default:default_pull_request.open_on_review;
         base_branch = json_string "baseBranch" pull_request_raw ~default:default_pull_request.base_branch;
         title = json_string "title" pull_request_raw ~default:default_pull_request.title;
@@ -878,7 +895,16 @@ let readiness_gaps config =
     add "project.terminalStates" "Add at least one terminal project state in .symphony/settings.json.";
   if config.pull_request.enabled && Util.trim config.pull_request.base_branch = "" then
     add "pullRequest.baseBranch" "Set pullRequest.baseBranch in .symphony/settings.json when pullRequest.enabled is true.";
-  if config.pull_request.enabled && Util.trim config.pull_request.base_branch <> "" then (
+  if
+    config.pull_request.enabled
+    && not (List.exists (( = ) config.pull_request.mode) [ "batch"; "task" ])
+  then
+    add "pullRequest.mode" "Set pullRequest.mode to batch or task.";
+  if
+    config.pull_request.enabled
+    && config.pull_request.mode = "batch"
+    && Util.trim config.pull_request.base_branch <> ""
+  then (
     match current_loop_start_branch config.repository_root with
     | Some loop_start_branch when loop_start_branch = Util.trim config.pull_request.base_branch ->
         add "pullRequest.baseBranch"

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -1405,21 +1405,33 @@ let reconcile_startup orchestrator candidates =
           set_error orchestrator message
       | Ok () -> List.iter (reconcile_startup_candidate orchestrator) candidates)
 
-let set_pull_request_handoff orchestrator status ?url ?error () =
+let set_pull_request_handoff orchestrator ?issue ?head_branch status ?url ?error () =
   let policy = orchestrator.config.Config.pull_request in
+  let head_branch = Option.value head_branch ~default:orchestrator.loop_start_branch in
+  let issue_identifier = Option.map (fun issue -> issue.Issue.identifier) issue in
+  let row =
+    {
+      Runtime_state.enabled = policy.enabled;
+      mode = policy.mode;
+      issue_identifier;
+      head_branch = Some head_branch;
+      base_branch = Some policy.base_branch;
+      status;
+      url;
+      error;
+    }
+  in
+  let same_handoff existing =
+    existing.Runtime_state.mode = row.mode
+    && existing.issue_identifier = row.issue_identifier
+    && existing.head_branch = row.head_branch
+    && existing.base_branch = row.base_branch
+  in
   update_state orchestrator (fun state ->
     {
       state with
-      pull_request =
-        Some
-          {
-            Runtime_state.enabled = policy.enabled;
-            head_branch = Some orchestrator.loop_start_branch;
-            base_branch = Some policy.base_branch;
-            status;
-            url;
-            error;
-          };
+      pull_request = Some row;
+      pull_requests = row :: List.filter (fun existing -> not (same_handoff existing)) state.pull_requests;
       last_error = (match error with Some error -> Some error | None -> state.last_error);
     })
 
@@ -1435,20 +1447,33 @@ let attempt_batch_pull_request orchestrator =
       set_pull_request_handoff orchestrator "retryable_failure" ~error ();
       render_pull_request_failed orchestrator.loop_start_branch policy.base_branch error
 
+let attempt_task_pull_request orchestrator issue =
+  let policy = orchestrator.config.Config.pull_request in
+  let head_branch = task_branch orchestrator.config issue in
+  set_pull_request_handoff orchestrator ~issue ~head_branch "attempting" ();
+  match orchestrator.batch_pull_request_handoff orchestrator.config ~head_branch with
+  | Ok url ->
+      set_pull_request_handoff orchestrator ~issue ~head_branch "completed" ?url ();
+      render_pull_request_completed head_branch policy.base_branch
+  | Error error ->
+      set_pull_request_handoff orchestrator ~issue ~head_branch "retryable_failure" ~error ();
+      render_pull_request_failed head_branch policy.base_branch error
+
 let status_is_review_status config status =
   match config.Config.tracker.project_status_on_success with
   | Some review_status -> string_equal_ci status review_status
   | None -> false
 
-let maybe_open_review_pull_request orchestrator status =
+let maybe_open_review_pull_request orchestrator issue status =
   let policy = orchestrator.config.Config.pull_request in
-  if policy.enabled && policy.open_on_review && (not orchestrator.batch_pull_request_completed)
-     && status_is_review_status orchestrator.config status
-  then attempt_batch_pull_request orchestrator
+  if policy.enabled && status_is_review_status orchestrator.config status then
+    if policy.mode = "task" then attempt_task_pull_request orchestrator issue
+    else if policy.open_on_review && (not orchestrator.batch_pull_request_completed) then
+      attempt_batch_pull_request orchestrator
 
 let maybe_open_batch_pull_request orchestrator ~candidates ~dispatchable_count =
   let policy = orchestrator.config.Config.pull_request in
-  if policy.enabled && not orchestrator.batch_pull_request_completed then
+  if policy.enabled && policy.mode = "batch" && not orchestrator.batch_pull_request_completed then
     let has_attention = List.exists (issue_needs_attention orchestrator) candidates || orchestrator.state.issue_errors <> [] in
     let idle =
       dispatchable_count = 0
@@ -1766,7 +1791,7 @@ let mark_completed orchestrator child =
               if not (move_issue_status orchestrator child.issue status) then
                 mark_retrying orchestrator issue_id (Printf.sprintf "could not move issue to %s" status)
               else (
-                maybe_open_review_pull_request orchestrator status;
+                maybe_open_review_pull_request orchestrator child.issue status;
                 complete_child ~next_status:status orchestrator child)))
 
 let kill_child child =

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -1471,6 +1471,10 @@ let maybe_open_review_pull_request orchestrator issue status =
     else if policy.open_on_review && (not orchestrator.batch_pull_request_completed) then
       attempt_batch_pull_request orchestrator
 
+let task_pull_request_before_auto_merge orchestrator status =
+  let policy = orchestrator.config.Config.pull_request in
+  policy.enabled && policy.mode = "task" && status_is_review_status orchestrator.config status
+
 let maybe_open_batch_pull_request orchestrator ~candidates ~dispatchable_count =
   let policy = orchestrator.config.Config.pull_request in
   if policy.enabled && policy.mode = "batch" && not orchestrator.batch_pull_request_completed then
@@ -1782,17 +1786,32 @@ let mark_completed orchestrator child =
         mark_blocked orchestrator issue_id error)
       else mark_retrying orchestrator issue_id error
   | Ok () ->
-      (match auto_merge_child orchestrator child with
-      | Error error -> mark_merge_attention orchestrator child error
-      | Ok () -> (
-          match next_status with
-          | None -> complete_child orchestrator child
-          | Some status ->
-              if not (move_issue_status orchestrator child.issue status) then
-                mark_retrying orchestrator issue_id (Printf.sprintf "could not move issue to %s" status)
-              else (
-                maybe_open_review_pull_request orchestrator child.issue status;
-                complete_child ~next_status:status orchestrator child)))
+      let status_moved_before_merge =
+        match next_status with
+        | Some status when task_pull_request_before_auto_merge orchestrator status ->
+            if move_issue_status orchestrator child.issue status then (
+              attempt_task_pull_request orchestrator child.issue;
+              Some true)
+            else (
+              mark_retrying orchestrator issue_id (Printf.sprintf "could not move issue to %s" status);
+              None)
+        | _ -> Some false
+      in
+      (match status_moved_before_merge with
+      | None -> ()
+      | Some status_moved_before_merge -> (
+          match auto_merge_child orchestrator child with
+          | Error error -> mark_merge_attention orchestrator child error
+          | Ok () -> (
+              match next_status with
+              | None -> complete_child orchestrator child
+              | Some status ->
+                  if status_moved_before_merge then complete_child ~next_status:status orchestrator child
+                  else if not (move_issue_status orchestrator child.issue status) then
+                    mark_retrying orchestrator issue_id (Printf.sprintf "could not move issue to %s" status)
+                  else (
+                    maybe_open_review_pull_request orchestrator child.issue status;
+                    complete_child ~next_status:status orchestrator child))))
 
 let kill_child child =
   try Unix.kill child.pid Sys.sigterm with Unix.Unix_error _ -> ()

--- a/apps/backend/lib/runtime_home.ml
+++ b/apps/backend/lib/runtime_home.ml
@@ -51,6 +51,7 @@ let settings_json =
   },
   "pullRequest": {
     "enabled": false,
+    "mode": "batch",
     "baseBranch": "main",
     "title": "Symphony batch from <head_branch>",
     "body": "Opened automatically by Symphony after orchestration became idle."

--- a/apps/backend/lib/runtime_state.ml
+++ b/apps/backend/lib/runtime_state.ml
@@ -53,6 +53,8 @@ type task_branch_integration = {
 }
 type pull_request_handoff = {
   enabled : bool;
+  mode : string;
+  issue_identifier : string option;
   head_branch : string option;
   base_branch : string option;
   status : string;
@@ -71,6 +73,7 @@ type t = {
   seconds_running : float;
   rate_limits : Yojson.Safe.t option;
   pull_request : pull_request_handoff option;
+  pull_requests : pull_request_handoff list;
   ordered_queue : ordered_queue option;
   startup_reconciliation : startup_reconciliation list;
   task_branch_integrations : task_branch_integration list;
@@ -89,6 +92,7 @@ let empty ?(readiness_gaps = []) ?(status_order = []) ?ordered_queue ?last_error
     seconds_running = 0.;
     rate_limits = None;
     pull_request = None;
+    pull_requests = [];
     ordered_queue;
     startup_reconciliation = [];
     task_branch_integrations = [];
@@ -235,6 +239,8 @@ let pull_request_handoff_to_yojson row =
   `Assoc
     [
       ("enabled", `Bool row.enabled);
+      ("mode", `String row.mode);
+      ("issue_identifier", (match row.issue_identifier with Some s -> `String s | None -> `Null));
       ("head_branch", (match row.head_branch with Some s -> `String s | None -> `Null));
       ("base_branch", (match row.base_branch with Some s -> `String s | None -> `Null));
       ("status", `String row.status);
@@ -263,6 +269,7 @@ let to_yojson state =
           ] );
       ("rate_limits", Option.value state.rate_limits ~default:`Null);
       ("pull_request", (match state.pull_request with Some row -> pull_request_handoff_to_yojson row | None -> `Null));
+      ("pull_requests", `List (List.map pull_request_handoff_to_yojson state.pull_requests));
       ("ordered_queue", (match state.ordered_queue with Some row -> ordered_queue_to_yojson row | None -> `Null));
       ("startup_reconciliation", `List (List.map startup_reconciliation_to_yojson state.startup_reconciliation));
       ("task_branch_integrations", `List (List.map task_branch_integration_to_yojson state.task_branch_integrations));

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -72,6 +72,7 @@ let test_config_parses_git_policy_and_stage_push () =
   },
   "pullRequest": {
     "enabled": true,
+    "mode": "task",
     "openOnReview": true,
     "baseBranch": "main",
     "title": "Symphony batch from <head_branch> into <base_branch>",
@@ -126,6 +127,7 @@ let test_config_parses_git_policy_and_stage_push () =
         (List.exists (( = ) "Needs merge") config.tracker.terminal_states);
       Alcotest.(check bool) "cleanup worktree" false config.git.cleanup.remove_worktree_after_merge;
       Alcotest.(check bool) "pull request enabled" true config.pull_request.enabled;
+      Alcotest.(check string) "pull request mode" "task" config.pull_request.mode;
       Alcotest.(check bool) "pull request opens on review" true config.pull_request.open_on_review;
       Alcotest.(check string) "pull request base" "main" config.pull_request.base_branch;
       Alcotest.(check string) "pull request title" "Symphony batch from <head_branch> into <base_branch>" config.pull_request.title;
@@ -547,6 +549,23 @@ let test_pull_request_base_branch_must_differ_from_loop_start () =
           Alcotest.(check bool) "mentions Loop-Start Branch" true
             (contains_substring gap.remediation "current Loop-Start Branch main")
       | None -> Alcotest.fail "expected pull request base branch gap")
+
+let test_task_pull_request_allows_base_branch_to_equal_loop_start () =
+  with_temp_dir "symphony-settings-task-pr-same-branch-" (fun root ->
+      init_repo root "main";
+      let settings = Filename.concat root "settings.json" in
+      Util.mkdir_p (Filename.concat root ".symphony");
+      Unix.putenv "GITHUB_TOKEN" "token";
+      Util.write_file settings
+        {|{
+  "tracker": {"owner": "acme", "repo": "widgets", "projectNumber": 7},
+  "pullRequest": {"enabled": true, "mode": "task", "baseBranch": "main"},
+  "stageAgents": {"enabled": false}
+}|};
+      let config = Config.from_settings_file ~workspace_root:root settings in
+      let gaps = Config.readiness_gaps config in
+      Alcotest.(check bool) "no self-target gap for Task Pull Requests" false
+        (List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = "pullRequest.baseBranch") gaps))
 
 let test_workflow_and_config () =
   let content =
@@ -4138,6 +4157,7 @@ let pull_request_config config =
     Config.pull_request =
       {
         enabled = true;
+        mode = "batch";
         open_on_review = false;
         base_branch = "main";
         title = "Symphony batch from <head_branch>";
@@ -4147,6 +4167,20 @@ let pull_request_config config =
 
 let open_on_review_pull_request_config config =
   { config with Config.pull_request = { config.Config.pull_request with enabled = true; open_on_review = true } }
+
+let task_pull_request_config config =
+  {
+    config with
+    Config.pull_request =
+      {
+        enabled = true;
+        mode = "task";
+        open_on_review = false;
+        base_branch = "main";
+        title = "Symphony task from <head_branch>";
+        body = "Opened automatically by Symphony when the task reached review.";
+      };
+  }
 
 let test_orchestrator_opens_batch_pull_request_once_when_idle () =
   with_temp_dir "symphony-batch-pr-idle-" (fun root ->
@@ -4208,6 +4242,50 @@ let test_orchestrator_opens_batch_pull_request_on_review_status () =
           Alcotest.(check string) "status" "completed" handoff.status;
           Alcotest.(check (option string)) "url" (Some "https://github.example/acme/widgets/pull/33") handoff.url
       | None -> Alcotest.fail "expected pull request handoff state")
+
+let test_orchestrator_opens_task_pull_request_on_review_status_from_protected_loop_start () =
+  with_temp_dir "symphony-task-pr-review-" (fun root ->
+      init_repo root "main";
+      ignore_runtime_home root;
+      let config = base_orchestrator_config root (git_policy ~auto_merge:true ()) |> task_pull_request_config in
+      let issue = Issue.empty ~id:"I34" ~identifier:"#34" ~title:"Thirty four" ~state:"Todo" in
+      let attempts = ref [] in
+      let current_status = ref "Todo" in
+      let launch ~config:_ ~workspace ~prompt:_ ~issue =
+        commit_file ~cwd:workspace.Workspace.path "task-pr.txt" "ready\n" "task 34";
+        let pid = Unix.create_process "/bin/sh" [| "/bin/sh"; "-lc"; "true" |] Unix.stdin Unix.stdout Unix.stderr in
+        { Orchestrator.pid = Some pid; session_id = Some issue.Issue.id; event = "test-launch"; stdout_path = None; stderr_path = None }
+      in
+      let fetch _ =
+        if List.exists (fun status -> String.lowercase_ascii status = String.lowercase_ascii !current_status) config.tracker.active_states
+        then [ { issue with state = !current_status } ]
+        else []
+      in
+      let set_status _ _ status =
+        current_status := status;
+        Ok ()
+      in
+      let batch_pull_request_handoff _config ~head_branch =
+        attempts := head_branch :: !attempts;
+        Ok (Some "https://github.example/acme/widgets/pull/34")
+      in
+      let orchestrator =
+        Orchestrator.make ~launch ~fetch ~set_status ~batch_pull_request_handoff ~config
+          ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      Unix.sleepf 0.05;
+      Orchestrator.poll_once orchestrator;
+      Alcotest.(check (list string)) "handoff attempted from Task Branch" [ "symphony/task-34" ] (List.rev !attempts);
+      Alcotest.(check bool) "not merged into main" false (Sys.file_exists (Filename.concat root "task-pr.txt"));
+      match (Orchestrator.get_state orchestrator).Runtime_state.pull_request with
+      | Some handoff ->
+          Alcotest.(check string) "mode" "task" handoff.mode;
+          Alcotest.(check (option string)) "issue identifier" (Some "#34") handoff.issue_identifier;
+          Alcotest.(check (option string)) "head branch" (Some "symphony/task-34") handoff.head_branch;
+          Alcotest.(check string) "status" "completed" handoff.status;
+          Alcotest.(check (option string)) "url" (Some "https://github.example/acme/widgets/pull/34") handoff.url
+      | None -> Alcotest.fail "expected task pull request handoff state")
 
 let test_orchestrator_retries_batch_pull_request_handoff_failure () =
   with_temp_dir "symphony-batch-pr-retry-" (fun root ->
@@ -4901,6 +4979,8 @@ let () =
           Alcotest.test_case "requires pull request base branch when enabled" `Quick test_pull_request_base_branch_readiness_gap;
           Alcotest.test_case "requires pull request base branch to differ from loop start" `Quick
             test_pull_request_base_branch_must_differ_from_loop_start;
+          Alcotest.test_case "allows task pull request base branch to equal loop start" `Quick
+            test_task_pull_request_allows_base_branch_to_equal_loop_start;
           Alcotest.test_case "checks allowed loop-start branch readiness" `Quick
             test_allowed_loop_start_branch_readiness;
         ] );
@@ -5015,6 +5095,8 @@ let () =
           Alcotest.test_case "opens batch pull request once when idle" `Quick test_orchestrator_opens_batch_pull_request_once_when_idle;
           Alcotest.test_case "opens batch pull request on review status" `Quick
             test_orchestrator_opens_batch_pull_request_on_review_status;
+          Alcotest.test_case "opens task pull request on review status" `Quick
+            test_orchestrator_opens_task_pull_request_on_review_status_from_protected_loop_start;
           Alcotest.test_case "retries failed batch pull request handoff" `Quick test_orchestrator_retries_batch_pull_request_handoff_failure;
           Alcotest.test_case "blocks batch pull request on attention" `Quick test_orchestrator_blocks_batch_pull_request_on_attention;
           Alcotest.test_case "reuses existing batch pull request" `Quick test_batch_pull_request_handoff_reuses_existing_pr;

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -4287,6 +4287,55 @@ let test_orchestrator_opens_task_pull_request_on_review_status_from_protected_lo
           Alcotest.(check (option string)) "url" (Some "https://github.example/acme/widgets/pull/34") handoff.url
       | None -> Alcotest.fail "expected task pull request handoff state")
 
+let test_task_pull_request_opens_before_auto_merge_cleanup () =
+  with_temp_dir "symphony-task-pr-before-cleanup-" (fun root ->
+      init_repo root "feature/start";
+      ignore_runtime_home root;
+      let git =
+        {
+          (git_policy ~auto_merge:true ()) with
+          cleanup = { Config.remove_worktree_after_merge = true; keep_task_branch = false };
+        }
+      in
+      let config = base_orchestrator_config root git |> task_pull_request_config in
+      let issue = Issue.empty ~id:"I35" ~identifier:"#35" ~title:"Thirty five" ~state:"In progress" in
+      let workspace = create_task_worktree config issue in
+      commit_file ~cwd:workspace.path "task-pr-before-cleanup.txt" "ready\n" "task 35";
+      let statuses = ref [] in
+      let branch_exists_during_handoff = ref false in
+      let attempts = ref [] in
+      let set_status _ issue status =
+        statuses := (issue.Issue.identifier, status) :: !statuses;
+        Ok ()
+      in
+      let batch_pull_request_handoff _config ~head_branch =
+        branch_exists_during_handoff :=
+          Sys.command
+            ("cd " ^ Util.shell_quote root ^ " && git show-ref --verify --quiet refs/heads/"
+            ^ Util.shell_quote head_branch)
+          = 0;
+        attempts := head_branch :: !attempts;
+        Ok (Some "https://github.example/acme/widgets/pull/35")
+      in
+      let orchestrator =
+        Orchestrator.make ~set_status ~batch_pull_request_handoff ~config
+          ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.mark_completed orchestrator (completed_child issue workspace);
+      Alcotest.(check (list string)) "handoff attempted from Task Branch" [ "symphony/task-35" ] (List.rev !attempts);
+      Alcotest.(check bool) "Task Branch exists during handoff" true !branch_exists_during_handoff;
+      Alcotest.(check bool) "task merged into Loop-Start Branch" true
+        (Sys.file_exists (Filename.concat root "task-pr-before-cleanup.txt"));
+      Alcotest.(check bool) "Task Branch removed after cleanup" false
+        (Sys.command ("cd " ^ Util.shell_quote root ^ " && git show-ref --verify --quiet refs/heads/symphony/task-35") = 0);
+      Alcotest.(check (list (pair string string))) "review status before completion" [ ("#35", "In review") ]
+        (List.rev !statuses);
+      match (Orchestrator.get_state orchestrator).Runtime_state.pull_request with
+      | Some handoff ->
+          Alcotest.(check string) "status" "completed" handoff.status;
+          Alcotest.(check (option string)) "head branch" (Some "symphony/task-35") handoff.head_branch
+      | None -> Alcotest.fail "expected task pull request handoff state")
+
 let test_orchestrator_retries_batch_pull_request_handoff_failure () =
   with_temp_dir "symphony-batch-pr-retry-" (fun root ->
       init_repo root "feature/start";
@@ -5097,6 +5146,8 @@ let () =
             test_orchestrator_opens_batch_pull_request_on_review_status;
           Alcotest.test_case "opens task pull request on review status" `Quick
             test_orchestrator_opens_task_pull_request_on_review_status_from_protected_loop_start;
+          Alcotest.test_case "opens task pull request before auto-merge cleanup" `Quick
+            test_task_pull_request_opens_before_auto_merge_cleanup;
           Alcotest.test_case "retries failed batch pull request handoff" `Quick test_orchestrator_retries_batch_pull_request_handoff_failure;
           Alcotest.test_case "blocks batch pull request on attention" `Quick test_orchestrator_blocks_batch_pull_request_on_attention;
           Alcotest.test_case "reuses existing batch pull request" `Quick test_batch_pull_request_handoff_reuses_existing_pr;

--- a/docs/adr/0018-review-pull-request-handoff.md
+++ b/docs/adr/0018-review-pull-request-handoff.md
@@ -6,4 +6,4 @@ The Pull Request Policy now includes `openOnReview`, disabled by default. When b
 
 The default idle trigger remains in place. If the Review Pull Request Handoff fails, Runtime State records a retryable pull request handoff failure and a later idle poll can retry. If the handoff succeeds, Symphony marks Batch Pull Request creation complete so later polls do not create duplicates.
 
-This keeps the product language anchored on one Batch Pull Request while allowing earlier operator review for long-running batches. It also avoids changing Bootstrap defaults or introducing per-task pull requests.
+This kept the product language anchored on one Batch Pull Request while allowing earlier operator review for long-running batches. ADR 0020 later adds a separate Task Pull Request mode for Workspace Repositories that need one pull request per Task Branch.

--- a/docs/adr/0020-task-pull-request-mode.md
+++ b/docs/adr/0020-task-pull-request-mode.md
@@ -1,0 +1,17 @@
+# ADR 0020: Task Pull Request mode
+
+Some Workspace Repositories need orchestration to start from a Protected Trunk Branch such as `main`, while still preserving normal code review by opening one pull request per completed Task Branch into that same branch. That is not the same runtime model as the existing Batch Pull Request behavior, where completed task work is first integrated into a non-trunk Loop-Start Branch and then one pull request is opened from that Loop-Start Branch into the Pull Request Base Branch.
+
+The Pull Request Policy now includes `mode`, defaulting to `batch`. In `batch` mode, Symphony preserves existing Batch Pull Request semantics: the Loop-Start Branch is the pull request head, the Pull Request Base Branch must differ from the current Loop-Start Branch, and idle or review handoff opens or reuses one Batch Pull Request.
+
+In `task` mode, Symphony opens or reuses a Task Pull Request when a task moves to the review status. The pull request head is the task's Task Branch and the base is the configured Pull Request Base Branch. Because the head is the Task Branch, Symphony may run from `main` with `pullRequest.baseBranch` also set to `main`; the self-target readiness gap applies only to Batch Pull Request mode.
+
+Task Pull Request mode does not change Task Branch creation, Stage Commit, Stage Push, protected-trunk auto-merge rules, or Task Branch Integration semantics. When the Loop-Start Branch is protected, completed Task Branch work remains unintegrated locally, the Agent Worktree is retained for inspection, and the Task Pull Request provides the review path into the protected branch.
+
+Runtime State now records the Pull Request Mode and issue identifier for pull request handoffs, and keeps a list of recorded handoffs while preserving the existing latest `pull_request` field.
+
+Consequences:
+
+- Workspace Repositories can start orchestration on `main` while reviewing each Task Branch through its own pull request.
+- Existing Batch Pull Request users remain on the default `batch` mode.
+- Operators must choose the mode explicitly when they want per-task review; enabling pull requests without changing mode keeps Batch Pull Request behavior.


### PR DESCRIPTION
## Summary
- Add `pullRequest.mode` with `batch` as the default and preserve existing Batch Pull Request behavior.
- Introduce `task` mode to open or reuse a pull request from each Task Branch into the configured base branch when the task reaches review.
- Record pull request mode and issue identifiers in Runtime State, and update the runtime glossary plus ADRs for the new model.

## Testing
- Backend build passed.
- Full backend test suite passed, including new coverage for task-mode readiness and review-time pull request handoff.