### PR TITLE
feat: add Compozy tasks tracker integration

### DIFF
--- a/.compozy/tasks/compozy-tasks-run-integration/_tasks.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/_tasks.md
@@ -4,14 +4,14 @@
 
 | # | Title | Status | Complexity | Dependencies |
 |---|-------|--------|------------|--------------|
-| 01 | Add Compozy tracker Runtime Settings | pending | medium | — |
-| 02 | Add Compozy task file parser and frontmatter updater | pending | medium | task_01 |
-| 03 | Map Compozy PRD runs to Symphony issues | pending | medium | task_02 |
-| 04 | Build Compozy task-step prompt context | pending | medium | task_03 |
-| 05 | Add Compozy progress to Runtime State | pending | medium | task_03 |
-| 06 | Wire Compozy readiness and run selection in CLI startup | pending | high | task_01, task_03, task_05 |
-| 07 | Add sequential task-step orchestration in one worktree | pending | critical | task_04, task_06 |
-| 08 | Add Compozy task-step retry and skip behavior | pending | high | task_07 |
-| 09 | Add Compozy progress to terminal and dashboard surfaces | pending | medium | task_05, task_08 |
-| 10 | Support Compozy identifiers in queue and manual merge flows | pending | high | task_03, task_07 |
-| 11 | Update tracker documentation and examples | pending | medium | task_01, task_06, task_09, task_10 |
+| 01 | Add Compozy tracker Runtime Settings | completed | medium | — |
+| 02 | Add Compozy task file parser and frontmatter updater | completed | medium | task_01 |
+| 03 | Map Compozy PRD runs to Symphony issues | completed | medium | task_02 |
+| 04 | Build Compozy task-step prompt context | completed | medium | task_03 |
+| 05 | Add Compozy progress to Runtime State | completed | medium | task_03 |
+| 06 | Wire Compozy readiness and run selection in CLI startup | completed | high | task_01, task_03, task_05 |
+| 07 | Add sequential task-step orchestration in one worktree | completed | critical | task_04, task_06 |
+| 08 | Add Compozy task-step retry and skip behavior | completed | high | task_07 |
+| 09 | Add Compozy progress to terminal and dashboard surfaces | completed | medium | task_05, task_08 |
+| 10 | Support Compozy identifiers in queue and manual merge flows | completed | high | task_03, task_07 |
+| 11 | Update tracker documentation and examples | completed | medium | task_01, task_06, task_09, task_10 |

--- a/.compozy/tasks/compozy-tasks-run-integration/memory/MEMORY.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/memory/MEMORY.md
@@ -1,0 +1,20 @@
+# Workflow Memory
+
+Keep only durable, cross-task context here. Do not duplicate facts that are obvious from the repository, PRD documents, or git history.
+
+## Current State
+
+## Shared Decisions
+
+## Shared Learnings
+- Compozy tracker config parsing intentionally does not validate that `tracker.compozy.root` exists; file/directory validation belongs to later readiness/tracker tasks.
+- The repository has no configured backend coverage command or Bisect instrumentation; Compozy backend tasks have been verifying coverage expectations with focused Alcotest cases plus the full `pnpm test` suite unless coverage tooling is later added.
+- The frontend package also has no configured coverage command; Compozy frontend tasks should use focused live-state/render assertions plus `pnpm frontend:test` and `pnpm frontend:build` unless coverage tooling is added.
+- Do not run Dune commands such as `pnpm test` and `pnpm backend:build` concurrently, and do not run ReScript commands such as `pnpm frontend:test` and `pnpm frontend:build` concurrently; both toolchains use shared build state and can fail from runner contention.
+- CLI readiness state construction now lives in `Runtime_readiness`; `main.ml` delegates readiness state assembly there so startup readiness can be tested through the backend library.
+- Compozy task-step frontmatter mutations during orchestration must be applied to the Agent Worktree copy so Stage Commit and Task Branch Integration can carry the persisted task-step status changes.
+
+## Open Risks
+
+## Handoffs
+- The Compozy `Issue_tracker` adapter currently fetches runnable PRD-run candidates and reports local readiness, but `update_status` is intentionally no-op until the sequential task-step orchestration task wires frontmatter transitions.

--- a/.compozy/tasks/compozy-tasks-run-integration/memory/task_01.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/memory/task_01.md
@@ -1,0 +1,26 @@
+# Task Memory: task_01.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Add Runtime Settings support for `tracker.kind = "compozy_tasks"` in the backend config layer only, preserving GitHub as the default and avoiding `runtime_home.ml`.
+
+## Important Decisions
+- Keep this task scoped to parsed settings and readiness gating; Compozy file validation/orchestration remains for later PRD tasks.
+- Store Compozy settings as `tracker.compozy.root` and `tracker.compozy.maxTaskStepRetries`, leaving existing minibeads `tracker.root` parsing unchanged.
+- Use missing-path-preserving expansion for `tracker.compozy.root` so selecting the Compozy tracker does not require `.compozy/tasks` to exist during config parsing.
+
+## Learnings
+- Target code lives in `/Users/matheusbbarni/projects/symphony-orchestrator`, not the initial `pi-agent-native` cwd.
+- Pre-change signal: backend config/test code has no `compozy_tasks`, `compozy`, or `maxTaskStepRetries` support, and `parse_tracker_kind` accepts only `github` and `minibeads`.
+- There is no coverage command or Bisect setup in this repository; backend verification is the Alcotest suite via `pnpm test` plus build via `pnpm backend:build`.
+
+## Files / Surfaces
+- Touched surfaces: `apps/backend/lib/config.ml` and `apps/backend/test/test_backend.ml`.
+
+## Errors / Corrections
+- Initial inspection from `pi-agent-native` could not find the task files; corrected by switching to the Product Repository containing the PRD and backend.
+- First Compozy root parser used the stricter existing `expand_path`, which failed when `.compozy/` did not exist; corrected with missing-path-preserving expansion.
+
+## Ready for Next Run
+- Fresh verification passed before tracking updates: `pnpm test` ran 243 tests, and `pnpm backend:build` completed with exit 0.

--- a/.compozy/tasks/compozy-tasks-run-integration/memory/task_02.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/memory/task_02.md
@@ -1,0 +1,30 @@
+# Task Memory: task_02.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Implement the backend file foundation for Compozy PRD task-step parsing and frontmatter updates in `apps/backend/lib/compozy_tasks_tracker.ml`, with focused Alcotest coverage in `apps/backend/test/test_backend.ml`.
+
+## Important Decisions
+- Work in `/Users/matheusbbarni/projects/symphony-orchestrator`; the original shell cwd was `/Users/matheusbbarni/projects/pi-agent-native`, but the PRD task paths and backend sources belong to `symphony-orchestrator`.
+- Keep this task limited to parsing, ordering, scoped path validation, and frontmatter updates. PRD-run issue mapping, prompt assembly, runtime state projection, and orchestration are later tasks.
+- Implemented `Compozy_tasks_tracker` with string-result APIs instead of raising validation exceptions, matching existing backend preference for deterministic caller-facing errors.
+- Frontmatter updates replace or append only top-level `status`, `symphony_retry_count`, and `symphony_last_error` keys; Markdown body content after the closing delimiter is preserved.
+
+## Learnings
+- Repo-local guidance exists in `AGENTS.md`, `CLAUDE.md`, and `apps/backend/CLAUDE.md`; backend changes require `pnpm test`.
+- The checkout already has task 01 tracking edits and untracked workflow memory files before task 02 implementation; avoid reverting or staging unrelated tracking churn.
+- `Compozy_tasks_tracker` does not exist yet, so the pre-change signal is absence of `apps/backend/lib/compozy_tasks_tracker.ml`.
+- The parser supports the task-file dependency forms present in Compozy artifacts: inline lists such as `dependencies: []` and block lists under `dependencies:`.
+- Verification evidence after implementation: `pnpm test` passed with 250 tests, including the new Compozy parser/updater cases; `pnpm backend:build` passed.
+
+## Files / Surfaces
+- Added `apps/backend/lib/compozy_tasks_tracker.ml`.
+- Updated `apps/backend/test/test_backend.ml` with focused parser, updater, path-scope, and temp-directory integration coverage.
+
+## Errors / Corrections
+- Initial repo-root lookup in `pi-agent-native` failed to find `apps/backend`; corrected by switching to the PRD repository `symphony-orchestrator`.
+- Self-review tightened frontmatter replacement to top-level keys only and rejected negative retry-count writes.
+
+## Ready for Next Run
+- Task 03 can build PRD-run discovery on `Compozy_tasks_tracker.list_task_files`, `parse_task_file`, and the frontmatter update helpers. The module intentionally does not yet map PRD runs to `Issue.t` or assemble prompts.

--- a/.compozy/tasks/compozy-tasks-run-integration/memory/task_03.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/memory/task_03.md
@@ -1,0 +1,25 @@
+# Task Memory: task_03.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Implement task 03: map one `.compozy/tasks/<task_name>/` directory to one Symphony `Issue.t` with canonical `compozy:<task_name>` identity, progress aggregates, and Compozy-safe branch/workspace key behavior.
+
+## Important Decisions
+- `Compozy_tasks_tracker.prd_run` carries task steps, current step, counts, and `not_runnable_reason`; `Issue.t` mapping exposes only PRD-run identity/title/state.
+- Compozy branch keys use `Workspace.sanitize` on the full `compozy:<slug>` identifier, avoiding the legacy numeric extraction path.
+- Missing Compozy roots discover zero candidates; empty or duplicate-index PRD directories are represented as `not_runnable` PRD runs.
+
+## Learnings
+- Pre-change backend has Compozy task-file parsing/updating, but no PRD-run model, discovery API, issue mapping, or aggregate progress surface.
+- No repository coverage command or Bisect instrumentation was found; verification relied on focused Alcotest cases plus the required `pnpm test` backend suite.
+
+## Files / Surfaces
+- Touched surfaces: `apps/backend/lib/compozy_tasks_tracker.ml`, `apps/backend/lib/orchestrator.ml`, `apps/backend/test/test_backend.ml`.
+
+## Errors / Corrections
+- Initial compile failed on OCaml record-label inference around `state_of_steps`; fixed with explicit `task_counts` and `task_step option` annotations.
+- Initial tests used `Option.exists`, unavailable in this OCaml environment; replaced with a local test helper.
+
+## Ready for Next Run
+- Verification: `pnpm backend:build` passed; focused `test_backend.exe test config --quick-tests --show-errors` passed 63 tests; `pnpm test` exited 0; fresh direct backend test run `test_backend.exe test --quick-tests --show-errors` passed 258 tests after tracking updates; `git diff --check` passed.

--- a/.compozy/tasks/compozy-tasks-run-integration/memory/task_04.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/memory/task_04.md
@@ -1,0 +1,26 @@
+# Task Memory: task_04.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Build Compozy task-step base prompt assembly for the currently runnable `task_NN.md`, including `_prd.md` and `_techspec.md` when present, while preserving existing `Prompt.render`/GitHub composition behavior.
+
+## Important Decisions
+- Scope is limited to Compozy prompt base content and deterministic missing-runnable-step diagnostics; sequential relaunch, runtime state projection, retry/skip behavior, and readiness wiring remain later tasks.
+
+## Learnings
+- Task 04 depends on the current narrow Compozy tracker module added by task 03; GitHub prompt wrapping remains owned by `Orchestrator.compose_prompt_result`.
+- `Compozy_tasks_tracker.current_prompt` now selects `run.current_step`, reads the full current `task_NN.md`, and appends `_prd.md` / `_techspec.md` sections only when those files exist.
+- `Orchestrator.compose_compozy_task_step_prompt_result` wraps the Compozy base prompt through the existing `compose_prompt_result`; the normal GitHub `compose_prompt` path remains unchanged.
+- No repository coverage command or Bisect instrumentation was found in `package.json`, `dune-project`, or app files; task coverage evidence is focused Alcotest cases plus full `pnpm test`.
+
+## Files / Surfaces
+- Touched implementation surfaces: `apps/backend/lib/compozy_tasks_tracker.ml`, `apps/backend/lib/orchestrator.ml`, and focused cases in `apps/backend/test/test_backend.ml`.
+- Tracking/memory surfaces touched: `.compozy/tasks/compozy-tasks-run-integration/task_04.md`, `_tasks.md`, and `memory/task_04.md`.
+
+## Errors / Corrections
+- Initial prompt diagnostic test exposed completed PRD runs without a reason suffix; fixed `current_prompt` to report `PRD run is completed`.
+- A sequential optional-context read refactor briefly introduced an unmatched parenthesis; `pnpm test` caught the syntax error and the full suite passed after correction.
+
+## Ready for Next Run
+- Task 04 implementation and test evidence are ready for tracking update and commit after final verification.

--- a/.compozy/tasks/compozy-tasks-run-integration/memory/task_05.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/memory/task_05.md
@@ -1,0 +1,29 @@
+# Task Memory: task_05.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Add optional Runtime State `tracker_kind` and `compozy_progress` JSON support with backend serialization/parsing coverage, without wiring orchestrator population or frontend rendering.
+
+## Important Decisions
+- Keep this task scoped to `Runtime_state` model/projection and Alcotest coverage; later tasks own CLI/orchestrator population and dashboard rendering.
+- Runtime State now exposes `compozy_progress = null` when absent, matching existing optional-field JSON style such as `pull_request`.
+
+## Learnings
+- Shared memory notes that this repository has no configured backend coverage command; coverage expectations are being satisfied with focused Alcotest cases plus the full `pnpm test` suite unless coverage tooling appears.
+- The current Product Repository worktree already has modified Compozy task/tracking files from prior work; avoid reverting or staging unrelated tracking changes.
+- Compozy progress projection is derived from `Compozy_tasks_tracker.prd_run` counts/current step via `Runtime_state.compozy_progress_of_prd_run`.
+
+## Files / Surfaces
+- Touched: `apps/backend/lib/runtime_state.ml`
+- Touched: `apps/backend/test/test_backend.ml`
+- Tracking update: `.compozy/tasks/compozy-tasks-run-integration/task_05.md`
+- Tracking update: `.compozy/tasks/compozy-tasks-run-integration/_tasks.md`
+
+## Errors / Corrections
+- Self-review caught that the tracker-kind test initially replaced `minibeads` coverage; corrected it to keep `minibeads` and add `compozy_tasks`.
+
+## Ready for Next Run
+- Backend verification completed with `pnpm test` (266 Alcotest tests) and `pnpm backend:build`; both exited 0. Node emitted only the existing `NO_COLOR`/`FORCE_COLOR` warning.
+- Later tasks can populate `Runtime_state.compozy_progress` from discovered PRD runs; frontend parsing/rendering remains task_09 scope.
+- Local implementation commit created: `0ea1fe1 feat: add compozy progress to runtime state`.

--- a/.compozy/tasks/compozy-tasks-run-integration/memory/task_06.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/memory/task_06.md
@@ -1,0 +1,26 @@
+# Task Memory: task_06.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Wire `tracker.kind = "compozy_tasks"` into backend startup readiness so Compozy runs use local PRD-run checks and avoid GitHub remote readiness dependencies.
+
+## Important Decisions
+- Keep task 06 scoped to startup/readiness and initial Runtime State projection; sequential task-step orchestration remains task 07.
+- Extracted CLI readiness state construction into `Runtime_readiness` so startup readiness can be tested directly without shelling through the binary.
+- The Compozy `Issue_tracker` adapter currently discovers/fetches runnable PRD-run candidates and reports readiness; status updates intentionally remain no-op until task 07 implements task-step transitions.
+
+## Learnings
+- Baseline: `Issue_tracker.make` still rejects `compozy_tasks` with an unsupported-adapter `invalid_arg`, so CLI readiness can currently surface a generic `tracker.adapter` gap instead of Compozy readiness gaps.
+- Compozy readiness gaps use `tracker.compozy.root`, `tracker.compozy.prdRuns`, and `tracker.compozy.runnablePrdRun`; valid Compozy readiness omits GitHub owner/repo/project/token gaps.
+- `Runtime_state.initial_compozy_progress` seeds the first runnable PRD run, falling back to the first discovered run for non-runnable progress visibility.
+
+## Files / Surfaces
+- Planned surfaces: `apps/backend/lib/issue_tracker.ml`, `apps/backend/lib/compozy_tasks_tracker.ml`, `apps/backend/bin/main.ml`, and `apps/backend/test/test_backend.ml`.
+- Touched surfaces: `apps/backend/lib/runtime_readiness.ml`, `apps/backend/lib/runtime_state.ml`, `apps/backend/lib/orchestrator.ml`, and `apps/backend/lib/runtime_startup.ml` in addition to the planned files.
+
+## Errors / Corrections
+- No blocking corrections after implementation. Focused readiness/adapter tests and full `pnpm test` passed.
+
+## Ready for Next Run
+- Task 07 can build on the Compozy adapter and should replace the no-op `update_status` behavior with task-step frontmatter transitions and sequential relaunch.

--- a/.compozy/tasks/compozy-tasks-run-integration/memory/task_07.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/memory/task_07.md
@@ -1,0 +1,31 @@
+# Task Memory: task_07.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Implement sequential Compozy PRD task-step orchestration inside one Agent Worktree and Task Branch. Intermediate step completion must update task frontmatter and relaunch the next step without running final Stage Commit, Stage Push, Task Branch Integration, or cleanup.
+
+## Important Decisions
+- Kept the change scoped to the existing `orchestrator.ml` completion path plus small `Compozy_tasks_tracker` status helpers; no shared tracker abstraction was introduced for this task.
+- Dispatch now marks the selected Compozy task step `in_progress` in the Agent Worktree before composing the task-step prompt so Runtime State agrees with the active step that will be committed on the Task Branch.
+- Completion now marks the current Compozy task step `completed` in the Agent Worktree, refreshes Runtime State progress from that worktree copy, and relaunches the next runnable step before falling through to final completion behavior only when no current step remains.
+
+## Learnings
+- `Issue_tracker.compozy.update_status` is intentionally still no-op; task-step status persistence belongs to Compozy task frontmatter updates in `Compozy_tasks_tracker`.
+- The existing Agent Worktree reuse logic already keys Compozy workspaces and Task Branches by the stable `compozy:<slug>` identifier, so relaunch can reuse `dispatch_issue` after clearing the completed child runtime row.
+- Compozy task-step frontmatter updates must target the Agent Worktree copy, not only the Loop-Start checkout, so the final Stage Commit can include the task-step status changes.
+- Alcotest does not support `--list-test-cases`; use `test <suite-regex> [case-number]` or run a suite regex directly.
+
+## Files / Surfaces
+- `apps/backend/lib/orchestrator.ml`
+- `apps/backend/lib/compozy_tasks_tracker.ml`
+- `apps/backend/test/test_backend.ml`
+
+## Errors / Corrections
+- Initial test placement referenced helpers defined later in `test_backend.ml`; corrected by making the Compozy sequential test self-contained.
+- Self-review found that updating only the Loop-Start checkout would leave frontmatter out of the final Task Branch commit; corrected orchestration to derive the Compozy root inside the reused Agent Worktree.
+
+## Ready for Next Run
+- Verification after final code changes: `pnpm test` passed with 272 backend tests. `git diff --check` passed before the final full test run and no code changed afterward.
+- Task tracking was updated after verification: `task_07.md` status/checklists completed and `_tasks.md` row 07 completed.
+- Coverage target note: this repository still has no configured coverage command; evidence remains focused Alcotest coverage for the new sequential path plus the full backend test suite.

--- a/.compozy/tasks/compozy-tasks-run-integration/memory/task_08.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/memory/task_08.md
@@ -1,0 +1,24 @@
+# Task Memory: task_08.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Implement Compozy task-step retry handling for failed task launches: increment frontmatter retry metadata, retry the same step until `tracker.compozy.maxTaskStepRetries`, mark over-limit steps failed/skipped, advance to the next runnable task step, and surface failed/skipped counts in Runtime State without changing GitHub retry behavior.
+
+## Important Decisions
+- Use `failed` as the over-limit task-step state. The existing Runtime State projection already carries failed/skipped counts, and a failed terminal PRD run state keeps over-limit work visible when no runnable steps remain.
+
+## Learnings
+- Repository guidance requires backend runtime behavior changes to be verified with `pnpm test`.
+- Existing workspace already has uncommitted Compozy task tracking changes from earlier tasks; backend implementation should avoid reverting them and keep tracking updates scoped to task 08.
+- There is still no configured backend coverage command or Bisect instrumentation; task 08 verification used focused Alcotest coverage plus the full `pnpm test` suite, consistent with shared workflow memory.
+
+## Files / Surfaces
+- Touched surfaces: `apps/backend/lib/compozy_tasks_tracker.ml`, `apps/backend/lib/orchestrator.ml`, `apps/backend/test/test_backend.ml`, `.compozy/tasks/compozy-tasks-run-integration/task_08.md`, and `.compozy/tasks/compozy-tasks-run-integration/_tasks.md`.
+- `Runtime_state` already exposed failed/skipped counts through `compozy_progress`; task 08 updates the Compozy progress after failed-step transitions and adds regression coverage rather than changing the JSON shape.
+
+## Errors / Corrections
+
+## Ready for Next Run
+- Focused checks passed: `opam exec -- dune exec apps/backend/test/test_backend.exe -- test orchestrator --show-errors --color=never` and `opam exec -- dune exec apps/backend/test/test_backend.exe -- test config --show-errors --color=never`.
+- Full backend verification passed: `pnpm test` ran 275 tests successfully. It emitted only the existing Node warning that `NO_COLOR` is ignored because `FORCE_COLOR` is set.

--- a/.compozy/tasks/compozy-tasks-run-integration/memory/task_09.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/memory/task_09.md
@@ -1,0 +1,25 @@
+# Task Memory: task_09.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Add compact Compozy PRD-run progress to Runtime State terminal/dashboard surfaces: optional frontend parsing, old snapshot compatibility, tracker-neutral dashboard wording for Compozy runs, current step and completed/failed/skipped/total counts.
+
+## Important Decisions
+- Scope remains presentation-only: use the backend's existing optional `tracker_kind` and `compozy_progress` projection instead of changing Runtime State semantics.
+- The dashboard exposes a compact PRD-run panel only when `compozy_progress` is present; otherwise older Runtime State snapshots keep the existing dashboard shape with `compozyProgress` absent.
+- Terminal console now prints a PRD Run Progress section only when Runtime State carries Compozy progress.
+
+## Learnings
+- Pre-change frontend baseline drops `compozy_progress` from `snapshotFromState`; a Compozy fixture returned no progress-related dashboard keys.
+- Existing terminal console already labels Compozy issue/status sources neutrally, but it does not print PRD-run progress.
+- No configured frontend coverage command or coverage dependency exists; verification used focused live-state/render assertions plus `pnpm frontend:test`, `pnpm frontend:build`, `pnpm test`, and `pnpm backend:build`.
+
+## Files / Surfaces
+- Touched: `apps/frontend/src/RuntimeStateSnapshot.res`, `apps/frontend/src/Pages/Dashboard.res`, `apps/frontend/test/liveState.test.mjs`, `apps/backend/bin/main.ml`.
+
+## Errors / Corrections
+- Self-review caught a remaining Compozy-facing dashboard sentence that said "issue states"; corrected it to "work item states" for Compozy tracker snapshots.
+
+## Ready for Next Run
+- Task 09 implementation is verified. Remaining tracking/commit steps should include the four touched code/test files plus task 09 tracking/memory updates only, without generated `.res.js` files.

--- a/.compozy/tasks/compozy-tasks-run-integration/memory/task_10.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/memory/task_10.md
@@ -1,0 +1,26 @@
+# Task Memory: task_10.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Implement Task 10: support canonical `compozy:<task_name>` identifiers in Ordered Queue and Manual Task Merge where V1 requires them, while preserving numeric GitHub selector behavior.
+- Scope is backend only: `ordered_queue.ml`, `manual_merge.ml`, `main.ml`, `compozy_tasks_tracker.ml`, and targeted Alcotest coverage.
+
+## Important Decisions
+- Follow ADR-003 narrow path; do not introduce a broad selected-tracker abstraction unless the existing code forces it.
+- Ordered Queue and Manual Task Merge now normalize `compozy:<task_name>` locally before URL/cross-repository rejection; selected-tracker validation remains the boundary for existence/readiness.
+- Manual Task Merge keeps terminal-state rejection for GitHub/minibeads, but permits unintegrated terminal Compozy PRD runs only when the discovered run state is `completed`.
+
+## Learnings
+- The selected `Issue_tracker.compozy` adapter already resolves PRD-run identifiers without GitHub Project membership; Task 10 only needed parser/preflight support plus regression coverage.
+- Verification evidence: focused `runtime-state` and `manual-merge` Alcotest suites passed, full `pnpm test` passed with 277 tests, and `pnpm backend:build` passed.
+
+## Files / Surfaces
+- `apps/backend/lib/ordered_queue.ml`
+- `apps/backend/lib/manual_merge.ml`
+- `apps/backend/test/test_backend.ml`
+
+## Errors / Corrections
+
+## Ready for Next Run
+- Task 10 implementation and verification are complete. Tracking files were updated after clean verification and self-review.

--- a/.compozy/tasks/compozy-tasks-run-integration/memory/task_11.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/memory/task_11.md
@@ -1,0 +1,26 @@
+# Task Memory: task_11.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Update operator documentation for the Compozy-backed Local Issue Tracker after runtime behavior from tasks 01/06/09/10, including opt-in tracker selection, GitHub default preservation, PRD-run/task-step semantics, retry/progress behavior, selector support, and secret-free examples.
+- Baseline before docs edits: `pnpm docs:test` passed for existing GitHub/minibeads-only examples, but `rg "compozy_tasks|compozy:<task_name>|maxTaskStepRetries|\\.compozy/tasks/<task_name>|Compozy PRD" README.md .github/project-tracking.md CONTEXT.md scripts/validate-docs-examples.js` found no Compozy tracker documentation.
+
+## Important Decisions
+- Added glossary entries for **Compozy PRD Run** and **Compozy Task Step** because the main README now uses those terms as operator-facing domain language.
+- Kept `.github/project-tracking.md` scoped to the GitHub Tracker and added only a pointer to Compozy-backed Local Issue Tracker setup in the README.
+- Extended `scripts/validate-docs-examples.js` instead of adding a separate docs test runner so `pnpm docs:test` remains the focused documentation validation command.
+
+## Learnings
+- Existing `scripts/validate-docs-examples.js` is the focused docs verification surface and currently checks README plus `.github/project-tracking.md` JSON examples, secret-free wording, glossary usage, and GitHub tracker scoping.
+- `pnpm frontend:test` and `pnpm frontend:build` should not be run concurrently because both invoke ReScript build state. `pnpm test` and `pnpm backend:build` should not be run concurrently because both invoke Dune.
+
+## Files / Surfaces
+- Updated docs/test surfaces: `README.md`, `.github/project-tracking.md`, `CONTEXT.md`, and `scripts/validate-docs-examples.js`.
+
+## Errors / Corrections
+- Initial broad verification was run in parallel and produced build-state contention: `pnpm backend:build` failed with "Another Dune instance is currently running" while `pnpm test` was active, and concurrent ReScript commands emitted compiler-info replacement errors. Reran the verification commands sequentially.
+
+## Ready for Next Run
+- Sequential verification before tracking updates passed: `pnpm docs:test`, `pnpm test`, `pnpm backend:build`, `pnpm frontend:test`, and `pnpm frontend:build`. `frontend:build` emitted existing dependency "use client" bundling warnings and exited 0.
+- Self-review checks before tracking updates: docs secret scan returned no matches, no `apps/frontend/src` files changed, and legacy `WORKFLOW.md` references were scoped to existing legacy/fixture/history wording.

--- a/.compozy/tasks/compozy-tasks-run-integration/task_01.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/task_01.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: "Add Compozy tracker Runtime Settings"
 type: backend
 complexity: medium
@@ -30,11 +30,11 @@ Add Runtime Settings support for selecting the Compozy-backed tracker while keep
 </requirements>
 
 ## Subtasks
-- [ ] 1.1 Extend the Runtime Settings tracker model with Compozy tracker settings.
-- [ ] 1.2 Accept `github` and `compozy_tasks` as supported tracker kinds.
-- [ ] 1.3 Preserve existing GitHub parsing and defaults when `tracker.kind` is omitted.
-- [ ] 1.4 Gate GitHub-only readiness gaps behind GitHub tracker selection.
-- [ ] 1.5 Add configuration tests for Compozy defaults, explicit values, and unsupported kinds.
+- [x] 1.1 Extend the Runtime Settings tracker model with Compozy tracker settings.
+- [x] 1.2 Accept `github` and `compozy_tasks` as supported tracker kinds.
+- [x] 1.3 Preserve existing GitHub parsing and defaults when `tracker.kind` is omitted.
+- [x] 1.4 Gate GitHub-only readiness gaps behind GitHub tracker selection.
+- [x] 1.5 Add configuration tests for Compozy defaults, explicit values, and unsupported kinds.
 
 ## Implementation Details
 Update the configuration model described in TechSpec "Runtime Settings". Keep this task focused on parsed settings and readiness gating; Compozy file validation belongs to later tasks.
@@ -62,13 +62,13 @@ Update the configuration model described in TechSpec "Runtime Settings". Keep th
 
 ## Tests
 - Unit tests:
-  - [ ] Omitted `tracker.kind` parses as `github`.
-  - [ ] `tracker.kind = "compozy_tasks"` parses with default `root` and `maxTaskStepRetries`.
-  - [ ] Explicit Compozy `root` and `maxTaskStepRetries` values parse correctly.
-  - [ ] Unsupported tracker kind such as `linear` returns an actionable config error.
-  - [ ] GitHub tracker with placeholder GitHub fields still emits existing readiness gaps.
+  - [x] Omitted `tracker.kind` parses as `github`.
+  - [x] `tracker.kind = "compozy_tasks"` parses with default `root` and `maxTaskStepRetries`.
+  - [x] Explicit Compozy `root` and `maxTaskStepRetries` values parse correctly.
+  - [x] Unsupported tracker kind such as `linear` returns an actionable config error.
+  - [x] GitHub tracker with placeholder GitHub fields still emits existing readiness gaps.
 - Integration tests:
-  - [ ] Minimal Compozy tracker settings load without requiring GitHub owner, repo, project number, or token.
+  - [x] Minimal Compozy tracker settings load without requiring GitHub owner, repo, project number, or token.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/compozy-tasks-run-integration/task_02.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/task_02.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: "Add Compozy task file parser and frontmatter updater"
 type: backend
 complexity: medium
@@ -31,12 +31,12 @@ Create the backend module that reads Compozy task files and updates task-step pr
 </requirements>
 
 ## Subtasks
-- [ ] 2.1 Add `apps/backend/lib/compozy_tasks_tracker.ml` with task file parsing types.
-- [ ] 2.2 Parse valid `task_NN.md` files and ignore non-task metadata files.
-- [ ] 2.3 Add numeric ordering for task files.
-- [ ] 2.4 Add frontmatter update helpers for status, retry count, and last error.
-- [ ] 2.5 Add validation errors for malformed frontmatter and invalid paths.
-- [ ] 2.6 Add focused parser and updater tests.
+- [x] 2.1 Add `apps/backend/lib/compozy_tasks_tracker.ml` with task file parsing types.
+- [x] 2.2 Parse valid `task_NN.md` files and ignore non-task metadata files.
+- [x] 2.3 Add numeric ordering for task files.
+- [x] 2.4 Add frontmatter update helpers for status, retry count, and last error.
+- [x] 2.5 Add validation errors for malformed frontmatter and invalid paths.
+- [x] 2.6 Add focused parser and updater tests.
 
 ## Implementation Details
 Follow TechSpec "Task-Step Frontmatter" and "Compozy Artifacts". Avoid duplicating Compozy's whole parser; implement only the frontmatter behavior required by this feature.
@@ -61,14 +61,14 @@ Follow TechSpec "Task-Step Frontmatter" and "Compozy Artifacts". Avoid duplicati
 
 ## Tests
 - Unit tests:
-  - [ ] `task_01.md`, `task_02.md`, and `task_10.md` sort in numeric order.
-  - [ ] Non-task files such as `_prd.md` and `notes.md` are ignored.
-  - [ ] Valid frontmatter parses required metadata fields.
-  - [ ] Missing frontmatter returns a deterministic parse error.
-  - [ ] Status and retry updates preserve the Markdown body.
-  - [ ] Paths outside the configured Compozy root are rejected.
+  - [x] `task_01.md`, `task_02.md`, and `task_10.md` sort in numeric order.
+  - [x] Non-task files such as `_prd.md` and `notes.md` are ignored.
+  - [x] Valid frontmatter parses required metadata fields.
+  - [x] Missing frontmatter returns a deterministic parse error.
+  - [x] Status and retry updates preserve the Markdown body.
+  - [x] Paths outside the configured Compozy root are rejected.
 - Integration tests:
-  - [ ] Temporary Compozy task directory can be parsed and updated across multiple task files.
+  - [x] Temporary Compozy task directory can be parsed and updated across multiple task files.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/compozy-tasks-run-integration/task_03.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/task_03.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: "Map Compozy PRD runs to Symphony issues"
 type: backend
 complexity: medium
@@ -30,11 +30,11 @@ Map one Compozy workflow directory under `.compozy/tasks/<task_name>/` into one 
 </requirements>
 
 ## Subtasks
-- [ ] 3.1 Add PRD-run discovery from the configured Compozy root.
-- [ ] 3.2 Build the `prd_run` model from parsed task files.
-- [ ] 3.3 Map PRD runs into `Issue.t` values with stable identifiers and titles.
-- [ ] 3.4 Add safe branch/workspace key derivation for Compozy identifiers.
-- [ ] 3.5 Add tests for duplicate, missing, and multi-directory PRD-run cases.
+- [x] 3.1 Add PRD-run discovery from the configured Compozy root.
+- [x] 3.2 Build the `prd_run` model from parsed task files.
+- [x] 3.3 Map PRD runs into `Issue.t` values with stable identifiers and titles.
+- [x] 3.4 Add safe branch/workspace key derivation for Compozy identifiers.
+- [x] 3.5 Add tests for duplicate, missing, and multi-directory PRD-run cases.
 
 ## Implementation Details
 Use TechSpec "PRD-Run Identifier" and "Core Interfaces" as the source of truth. Keep individual task-step details in the Compozy tracker module; expose only PRD-run identity and progress needed by shared runtime code.
@@ -62,13 +62,13 @@ Use TechSpec "PRD-Run Identifier" and "Core Interfaces" as the source of truth. 
 
 ## Tests
 - Unit tests:
-  - [ ] `.compozy/tasks/example-feature/` maps to `compozy:example-feature`.
-  - [ ] `task_01.md` and `task_02.md` inside one directory do not create separate issues.
-  - [ ] Branch/workspace key for `compozy:feature-123` is stable and non-empty.
-  - [ ] Empty PRD-run directory is reported as not runnable.
-  - [ ] Two workflow directories with `task_01.md` produce distinct PRD-run identifiers.
+  - [x] `.compozy/tasks/example-feature/` maps to `compozy:example-feature`.
+  - [x] `task_01.md` and `task_02.md` inside one directory do not create separate issues.
+  - [x] Branch/workspace key for `compozy:feature-123` is stable and non-empty.
+  - [x] Empty PRD-run directory is reported as not runnable.
+  - [x] Two workflow directories with `task_01.md` produce distinct PRD-run identifiers.
 - Integration tests:
-  - [ ] Temporary Compozy root with two PRD directories yields two `Issue.t` candidates.
+  - [x] Temporary Compozy root with two PRD directories yields two `Issue.t` candidates.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/compozy-tasks-run-integration/task_04.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/task_04.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: "Build Compozy task-step prompt context"
 type: backend
 complexity: medium
@@ -30,11 +30,11 @@ Add prompt assembly for the current task step in a Compozy PRD run. Each prompt 
 </requirements>
 
 ## Subtasks
-- [ ] 4.1 Add current task-step prompt assembly to the Compozy tracker module.
-- [ ] 4.2 Include PRD and TechSpec sections when files are present.
-- [ ] 4.3 Produce deterministic diagnostics for missing runnable task files.
-- [ ] 4.4 Integrate the assembled prompt with existing orchestrator prompt composition hooks.
-- [ ] 4.5 Add prompt content tests.
+- [x] 4.1 Add current task-step prompt assembly to the Compozy tracker module.
+- [x] 4.2 Include PRD and TechSpec sections when files are present.
+- [x] 4.3 Produce deterministic diagnostics for missing runnable task files.
+- [x] 4.4 Integrate the assembled prompt with existing orchestrator prompt composition hooks.
+- [x] 4.5 Add prompt content tests.
 
 ## Implementation Details
 Reference TechSpec "Task-step prompt assembly" and "Compozy Artifacts". Do not duplicate prompt wrappers from `Orchestrator.compose_prompt`; this task should provide Compozy-specific base content for existing composition.
@@ -62,13 +62,13 @@ Reference TechSpec "Task-step prompt assembly" and "Compozy Artifacts". Do not d
 
 ## Tests
 - Unit tests:
-  - [ ] Prompt includes current task file title and body.
-  - [ ] Prompt includes `_prd.md` content when the file exists.
-  - [ ] Prompt includes `_techspec.md` content when the file exists.
-  - [ ] Prompt still succeeds when `_prd.md` or `_techspec.md` is absent.
-  - [ ] No runnable task files returns a deterministic error.
+  - [x] Prompt includes current task file title and body.
+  - [x] Prompt includes `_prd.md` content when the file exists.
+  - [x] Prompt includes `_techspec.md` content when the file exists.
+  - [x] Prompt still succeeds when `_prd.md` or `_techspec.md` is absent.
+  - [x] No runnable task files returns a deterministic error.
 - Integration tests:
-  - [ ] Orchestrator composition can wrap a Compozy task-step base prompt without changing GitHub prompt behavior.
+  - [x] Orchestrator composition can wrap a Compozy task-step base prompt without changing GitHub prompt behavior.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/compozy-tasks-run-integration/task_05.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/task_05.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: "Add Compozy progress to Runtime State"
 type: backend
 complexity: medium
@@ -29,11 +29,11 @@ Extend Runtime State with optional tracker kind and Compozy PRD-run progress fie
 </requirements>
 
 ## Subtasks
-- [ ] 5.1 Add backend Runtime State types for tracker kind and Compozy progress.
-- [ ] 5.2 Serialize optional fields in Runtime State snapshots.
-- [ ] 5.3 Parse optional fields where backend state is read from JSON.
-- [ ] 5.4 Add tests for absent fields and populated Compozy progress.
-- [ ] 5.5 Keep older Runtime State snapshots compatible.
+- [x] 5.1 Add backend Runtime State types for tracker kind and Compozy progress.
+- [x] 5.2 Serialize optional fields in Runtime State snapshots.
+- [x] 5.3 Parse optional fields where backend state is read from JSON.
+- [x] 5.4 Add tests for absent fields and populated Compozy progress.
+- [x] 5.5 Keep older Runtime State snapshots compatible.
 
 ## Implementation Details
 Use TechSpec "Runtime State Projection". This task only adds backend state shape and tests; frontend rendering belongs to task_09.
@@ -60,12 +60,12 @@ Use TechSpec "Runtime State Projection". This task only adds backend state shape
 
 ## Tests
 - Unit tests:
-  - [ ] Empty Runtime State omits or nulls Compozy progress without parse failure.
-  - [ ] Runtime State serializes `tracker_kind = "compozy_tasks"`.
-  - [ ] Runtime State serializes current step and aggregate counts.
-  - [ ] Runtime State parses older snapshots without the new fields.
+  - [x] Empty Runtime State omits or nulls Compozy progress without parse failure.
+  - [x] Runtime State serializes `tracker_kind = "compozy_tasks"`.
+  - [x] Runtime State serializes current step and aggregate counts.
+  - [x] Runtime State parses older snapshots without the new fields.
 - Integration tests:
-  - [ ] `/api/v1/state` payload shape can include Compozy progress without breaking existing required fields.
+  - [x] `/api/v1/state` payload shape can include Compozy progress without breaking existing required fields.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/compozy-tasks-run-integration/task_06.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/task_06.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: "Wire Compozy readiness and run selection in CLI startup"
 type: backend
 complexity: high
@@ -32,11 +32,11 @@ Connect the selected Compozy tracker kind to runtime startup and readiness behav
 </requirements>
 
 ## Subtasks
-- [ ] 6.1 Add Compozy tracker readiness checks for root and runnable PRD-run candidates.
-- [ ] 6.2 Route CLI startup by selected tracker kind.
-- [ ] 6.3 Skip GitHub remote readiness for Compozy tracker runs.
-- [ ] 6.4 Populate tracker kind and initial Compozy progress in Runtime State.
-- [ ] 6.5 Add startup/readiness tests for GitHub and Compozy paths.
+- [x] 6.1 Add Compozy tracker readiness checks for root and runnable PRD-run candidates.
+- [x] 6.2 Route CLI startup by selected tracker kind.
+- [x] 6.3 Skip GitHub remote readiness for Compozy tracker runs.
+- [x] 6.4 Populate tracker kind and initial Compozy progress in Runtime State.
+- [x] 6.5 Add startup/readiness tests for GitHub and Compozy paths.
 
 ## Implementation Details
 Follow TechSpec "Data Flow" and "Impact Analysis" for `main.ml`. Keep the narrow Compozy path isolated and preserve existing GitHub code paths.
@@ -65,13 +65,13 @@ Follow TechSpec "Data Flow" and "Impact Analysis" for `main.ml`. Keep the narrow
 
 ## Tests
 - Unit tests:
-  - [ ] Compozy tracker with missing root emits a Compozy readiness gap.
-  - [ ] Compozy tracker with no runnable task files emits a Compozy readiness gap.
-  - [ ] Compozy tracker readiness does not include GitHub owner, repo, project number, or token gaps.
-  - [ ] GitHub tracker readiness still includes GitHub gaps when configured incorrectly.
+  - [x] Compozy tracker with missing root emits a Compozy readiness gap.
+  - [x] Compozy tracker with no runnable task files emits a Compozy readiness gap.
+  - [x] Compozy tracker readiness does not include GitHub owner, repo, project number, or token gaps.
+  - [x] GitHub tracker readiness still includes GitHub gaps when configured incorrectly.
 - Integration tests:
-  - [ ] CLI readiness state for a valid Compozy fixture has no GitHub remote readiness dependency.
-  - [ ] CLI readiness state for GitHub tracker is unchanged.
+  - [x] CLI readiness state for a valid Compozy fixture has no GitHub remote readiness dependency.
+  - [x] CLI readiness state for GitHub tracker is unchanged.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/compozy-tasks-run-integration/task_07.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/task_07.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: "Add sequential task-step orchestration in one worktree"
 type: backend
 complexity: critical
@@ -31,12 +31,12 @@ Extend orchestration so a Compozy PRD run can execute multiple task-step launche
 </requirements>
 
 ## Subtasks
-- [ ] 7.1 Identify Compozy PRD-run children separately from normal GitHub issue children.
-- [ ] 7.2 Add intermediate task-step completion handling before final completion.
-- [ ] 7.3 Reuse the existing Agent Worktree and Task Branch for the next task step.
-- [ ] 7.4 Update Runtime State progress between task-step launches.
-- [ ] 7.5 Ensure final completion uses existing Stage Commit, Stage Push, and integration behavior.
-- [ ] 7.6 Add orchestration tests for same-worktree sequential execution.
+- [x] 7.1 Identify Compozy PRD-run children separately from normal GitHub issue children.
+- [x] 7.2 Add intermediate task-step completion handling before final completion.
+- [x] 7.3 Reuse the existing Agent Worktree and Task Branch for the next task step.
+- [x] 7.4 Update Runtime State progress between task-step launches.
+- [x] 7.5 Ensure final completion uses existing Stage Commit, Stage Push, and integration behavior.
+- [x] 7.6 Add orchestration tests for same-worktree sequential execution.
 
 ## Implementation Details
 Reference TechSpec "Git" and "Build Order" steps 7-8. This is the highest-risk task because it touches the completion path in `orchestrator.ml`; keep edits tightly scoped and regression-test existing completion behavior.
@@ -66,13 +66,13 @@ Reference TechSpec "Git" and "Build Order" steps 7-8. This is the highest-risk t
 
 ## Tests
 - Unit tests:
-  - [ ] Intermediate task-step completion does not call final branch integration.
-  - [ ] Next task step uses the same workspace path and Task Branch.
-  - [ ] Final task-step completion calls existing final completion behavior.
-  - [ ] GitHub issue completion behavior remains unchanged.
+  - [x] Intermediate task-step completion does not call final branch integration.
+  - [x] Next task step uses the same workspace path and Task Branch.
+  - [x] Final task-step completion calls existing final completion behavior.
+  - [x] GitHub issue completion behavior remains unchanged.
 - Integration tests:
-  - [ ] Two-task Compozy PRD run completes both task files in one Agent Worktree.
-  - [ ] Runtime State shows current step changing from `task_01.md` to `task_02.md`.
+  - [x] Two-task Compozy PRD run completes both task files in one Agent Worktree.
+  - [x] Runtime State shows current step changing from `task_01.md` to `task_02.md`.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/compozy-tasks-run-integration/task_08.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/task_08.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: "Add Compozy task-step retry and skip behavior"
 type: backend
 complexity: high
@@ -30,11 +30,11 @@ Implement the Compozy-specific retry limit for task steps. A failed task step re
 </requirements>
 
 ## Subtasks
-- [ ] 8.1 Track task-step retry counts in Compozy task frontmatter.
-- [ ] 8.2 Apply the configured retry limit for failed Compozy task steps.
-- [ ] 8.3 Mark failed-over-limit steps and advance to the next runnable task.
-- [ ] 8.4 Surface failed and skipped step counts in Runtime State.
-- [ ] 8.5 Add tests for retry, skip, and GitHub regression behavior.
+- [x] 8.1 Track task-step retry counts in Compozy task frontmatter.
+- [x] 8.2 Apply the configured retry limit for failed Compozy task steps.
+- [x] 8.3 Mark failed-over-limit steps and advance to the next runnable task.
+- [x] 8.4 Surface failed and skipped step counts in Runtime State.
+- [x] 8.5 Add tests for retry, skip, and GitHub regression behavior.
 
 ## Implementation Details
 Use TechSpec "Known Risks" and ADR-006 for final state visibility. Make failed/skipped states obvious because continuing after failures can otherwise hide broken work.
@@ -62,13 +62,13 @@ Use TechSpec "Known Risks" and ADR-006 for final state visibility. Make failed/s
 
 ## Tests
 - Unit tests:
-  - [ ] Failed Compozy task step increments `symphony_retry_count`.
-  - [ ] Retry count below limit relaunches the same task step.
-  - [ ] Retry count at limit marks the task failed or skipped.
-  - [ ] Failed-over-limit task advances to the next runnable task step.
-  - [ ] GitHub retry behavior remains unchanged.
+  - [x] Failed Compozy task step increments `symphony_retry_count`.
+  - [x] Retry count below limit relaunches the same task step.
+  - [x] Retry count at limit marks the task failed or skipped.
+  - [x] Failed-over-limit task advances to the next runnable task step.
+  - [x] GitHub retry behavior remains unchanged.
 - Integration tests:
-  - [ ] Two-step PRD run with first task failing over limit proceeds to second task and records failed/skipped count.
+  - [x] Two-step PRD run with first task failing over limit proceeds to second task and records failed/skipped count.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/compozy-tasks-run-integration/task_09.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/task_09.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: "Add Compozy progress to terminal and dashboard surfaces"
 type: frontend
 complexity: medium
@@ -31,11 +31,11 @@ Expose Compozy PRD-run progress in operator-facing Runtime State surfaces. This 
 </requirements>
 
 ## Subtasks
-- [ ] 9.1 Add optional Compozy progress fields to ReScript Runtime State parsing.
-- [ ] 9.2 Update dashboard labels to be tracker-neutral where appropriate.
-- [ ] 9.3 Render compact PRD-run progress when Compozy progress is present.
-- [ ] 9.4 Update terminal output for Compozy progress if backend console rendering requires it.
-- [ ] 9.5 Add frontend tests and run ReScript build.
+- [x] 9.1 Add optional Compozy progress fields to ReScript Runtime State parsing.
+- [x] 9.2 Update dashboard labels to be tracker-neutral where appropriate.
+- [x] 9.3 Render compact PRD-run progress when Compozy progress is present.
+- [x] 9.4 Update terminal output for Compozy progress if backend console rendering requires it.
+- [x] 9.5 Add frontend tests and run ReScript build.
 
 ## Implementation Details
 Reference TechSpec "Runtime State Projection" and "Monitoring and Observability". Keep UI changes compact and consistent with the existing operational dashboard.
@@ -64,14 +64,16 @@ Reference TechSpec "Runtime State Projection" and "Monitoring and Observability"
 
 ## Tests
 - Unit tests:
-  - [ ] Snapshot parsing succeeds when `tracker_kind` and `compozy_progress` are absent.
-  - [ ] Snapshot parsing captures Compozy current step and counts when present.
-  - [ ] Dashboard model exposes Compozy progress values.
+  - [x] Snapshot parsing succeeds when `tracker_kind` and `compozy_progress` are absent.
+  - [x] Snapshot parsing captures Compozy current step and counts when present.
+  - [x] Dashboard model exposes Compozy progress values.
 - Integration tests:
-  - [ ] `pnpm frontend:test` covers Compozy Runtime State rendering.
-  - [ ] `pnpm frontend:build` succeeds after ReScript changes.
+  - [x] `pnpm frontend:test` covers Compozy Runtime State rendering.
+  - [x] `pnpm frontend:build` succeeds after ReScript changes.
 - Test coverage target: >=80%
 - All tests must pass
+
+Coverage note: this repository has no configured frontend coverage command or coverage dependency. Task 09 verification uses focused live-state/model/render assertions plus the required frontend test and build gates.
 
 ## Success Criteria
 - All tests passing

--- a/.compozy/tasks/compozy-tasks-run-integration/task_10.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/task_10.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: "Support Compozy identifiers in queue and manual merge flows"
 type: backend
 complexity: high
@@ -31,11 +31,11 @@ Add `compozy:<task_name>` selector support to the operator flows needed for trac
 </requirements>
 
 ## Subtasks
-- [ ] 10.1 Extend Ordered Queue selector parsing to represent canonical identifiers.
-- [ ] 10.2 Validate Compozy queue identifiers against discovered PRD runs.
-- [ ] 10.3 Extend Manual Task Merge selector handling for Compozy PRD-run identifiers.
-- [ ] 10.4 Keep GitHub numeric selector behavior unchanged.
-- [ ] 10.5 Add queue and merge tests for Compozy and GitHub selectors.
+- [x] 10.1 Extend Ordered Queue selector parsing to represent canonical identifiers.
+- [x] 10.2 Validate Compozy queue identifiers against discovered PRD runs.
+- [x] 10.3 Extend Manual Task Merge selector handling for Compozy PRD-run identifiers.
+- [x] 10.4 Keep GitHub numeric selector behavior unchanged.
+- [x] 10.5 Add queue and merge tests for Compozy and GitHub selectors.
 
 ## Implementation Details
 Follow TechSpec "Impact Analysis" for queue and merge. Because ADR-003 chose a narrow path, avoid a broad selected-tracker refactor unless strictly needed for these flows.
@@ -65,15 +65,15 @@ Follow TechSpec "Impact Analysis" for queue and merge. Because ADR-003 chose a n
 
 ## Tests
 - Unit tests:
-  - [ ] Existing queue parse `"19,#22,31"` still returns GitHub identifiers.
-  - [ ] Queue parse accepts `compozy:example-feature`.
-  - [ ] Duplicate Compozy selectors are rejected.
-  - [ ] Malformed selectors such as `compozy:` and URLs return actionable errors.
-  - [ ] Manual Task Merge still accepts `20` and `#20`.
-  - [ ] Manual Task Merge accepts valid completed Compozy PRD-run identifiers when supported.
+  - [x] Existing queue parse `"19,#22,31"` still returns GitHub identifiers.
+  - [x] Queue parse accepts `compozy:example-feature`.
+  - [x] Duplicate Compozy selectors are rejected.
+  - [x] Malformed selectors such as `compozy:` and URLs return actionable errors.
+  - [x] Manual Task Merge still accepts `20` and `#20`.
+  - [x] Manual Task Merge accepts valid completed Compozy PRD-run identifiers when supported.
 - Integration tests:
-  - [ ] Compozy queue validation resolves an existing PRD-run fixture without GitHub Project membership.
-  - [ ] GitHub queue and Manual Task Merge tests continue to pass.
+  - [x] Compozy queue validation resolves an existing PRD-run fixture without GitHub Project membership.
+  - [x] GitHub queue and Manual Task Merge tests continue to pass.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/compozy-tasks-run-integration/task_11.md
+++ b/.compozy/tasks/compozy-tasks-run-integration/task_11.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: "Update tracker documentation and examples"
 type: docs
 complexity: medium
@@ -34,12 +34,12 @@ Document the Compozy-backed Local Issue Tracker workflow after the runtime behav
 </requirements>
 
 ## Subtasks
-- [ ] 11.1 Update README or tracker documentation with Compozy tracker setup.
-- [ ] 11.2 Add secret-free Runtime Settings examples.
-- [ ] 11.3 Document PRD-run versus task-step semantics.
-- [ ] 11.4 Document retry, failed/skipped, and progress visibility behavior.
-- [ ] 11.5 Review glossary usage and update `CONTEXT.md` only if new domain language is introduced.
-- [ ] 11.6 Add documentation verification checks.
+- [x] 11.1 Update README or tracker documentation with Compozy tracker setup.
+- [x] 11.2 Add secret-free Runtime Settings examples.
+- [x] 11.3 Document PRD-run versus task-step semantics.
+- [x] 11.4 Document retry, failed/skipped, and progress visibility behavior.
+- [x] 11.5 Review glossary usage and update `CONTEXT.md` only if new domain language is introduced.
+- [x] 11.6 Add documentation verification checks.
 
 ## Implementation Details
 Use TechSpec "Development Sequencing" and "Monitoring and Observability" as source material. If documentation introduces a new term beyond existing glossary terms, update `CONTEXT.md` per repository rules.
@@ -69,12 +69,12 @@ Use TechSpec "Development Sequencing" and "Monitoring and Observability" as sour
 
 ## Tests
 - Unit tests:
-  - [ ] Documentation examples include `tracker.kind = "compozy_tasks"` and no secret values.
-  - [ ] Documentation uses **Issue Tracker**, **GitHub Tracker**, **Local Issue Tracker**, and **Runtime Settings** consistently.
-  - [ ] No generated `.res.js` files are included by documentation-only changes.
+  - [x] Documentation examples include `tracker.kind = "compozy_tasks"` and no secret values.
+  - [x] Documentation uses **Issue Tracker**, **GitHub Tracker**, **Local Issue Tracker**, and **Runtime Settings** consistently.
+  - [x] No generated `.res.js` files are included by documentation-only changes.
 - Integration tests:
-  - [ ] `rg "WORKFLOW.md|WORKFLOW.example.md" README.md .github/project-tracking.md docs` does not introduce legacy tracker references.
-  - [ ] Focused documentation checks or link checks pass where available.
+  - [x] `rg "WORKFLOW.md|WORKFLOW.example.md" README.md .github/project-tracking.md docs` does not introduce legacy tracker references.
+  - [x] Focused documentation checks or link checks pass where available.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.github/project-tracking.md
+++ b/.github/project-tracking.md
@@ -65,6 +65,12 @@ For minibeads Local Issue Tracker setup, configure `tracker.kind = "minibeads"` 
 and follow the main README. minibeads does not use GitHub Issues, GitHub Projects, or GitHub tracker
 token settings for issue dispatch.
 
+For Compozy-backed Local Issue Tracker setup, configure `tracker.kind = "compozy_tasks"` in Runtime
+Settings and follow the main README. Symphony treats `.compozy/tasks/<task_name>/` as one Compozy PRD
+Run and uses `compozy:<task_name>` selectors where Compozy selector support is available. Compozy
+tracking does not use GitHub Issues, GitHub Projects, or GitHub tracker token settings for issue
+dispatch.
+
 ## Authentication
 
 Set `GITHUB_TOKEN` or `GH_TOKEN` for the backend process. The token needs permission to read issues

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -92,6 +92,14 @@ _Avoid_: synced GitHub issues, local notes
 A human-editable issue record stored by a Local Issue Tracker and used by Personal Symphony to render an Agent Prompt, select a Stage Agent, and update tracker status.
 _Avoid_: task markdown, PRD file, scratch note
 
+**Compozy PRD Run**:
+A Local Issue Tracker work item represented by one `.compozy/tasks/<task_name>/` directory in a Workspace Repository.
+_Avoid_: Compozy issue, task folder, PRD issue
+
+**Compozy Task Step**:
+One `task_NN.md` file inside a Compozy PRD Run that Symphony executes as an ordered step in the same Agent Worktree and Task Branch.
+_Avoid_: separate Symphony issue, GitHub issue, standalone task
+
 **Runtime Settings Invocation Override**:
 A command-line value on the default runtime command that replaces one loaded Runtime Settings field for the current Symphony process only, after Runtime Settings load and before orchestration uses the effective runtime config.
 _Avoid_: temporary config, settings rewrite, runtime patch
@@ -351,6 +359,7 @@ _Avoid_: reinitialize, reset
 - Runtime Settings select one **Issue Tracker** for orchestration.
 - The **GitHub Tracker** remains the default Issue Tracker.
 - A **Local Issue Tracker** stores issue records in **Local Issue Files** owned by the Workspace Repository.
+- A Compozy-backed **Local Issue Tracker** treats one **Compozy PRD Run** as the issue-level work item and the contained **Compozy Task Steps** as ordered progress within that work item.
 - A **Local Issue Tracker** must preserve Stage Agent dispatch, tracker status transitions, Agent Prompt rendering, Task Branch naming, retry, Stage Commit, Stage Push, and Task Branch Integration behavior.
 - A **Local Issue Tracker** must not require GitHub API access for issue fetches or tracker status updates.
 - Bootstrap must not overwrite existing **Local Issue Files**.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ its own repository-owned Runtime Contract under `.symphony/`.
   `GITHUB_TOKEN` or `GH_TOKEN`
 - For the minibeads Local Issue Tracker: the `mb` CLI and a local issue store in the Workspace
   Repository
+- For the Compozy-backed Local Issue Tracker: a Compozy PRD Run directory under
+  `.compozy/tasks/<task_name>/` in the Workspace Repository
 
 ## Install
 
@@ -91,6 +93,42 @@ Tracker users:
 `tracker.command` defaults to `mb`; set it only when the executable name or path differs in your
 environment. Symphony runs minibeads commands from the Workspace Repository root and treats Local
 Issue Files as repository-owned user data.
+
+Choose the Compozy-backed Local Issue Tracker when you want Symphony to run a Compozy PRD Run from
+`.compozy/tasks/<task_name>/` as one user-facing work item. This tracker is opt-in with
+`tracker.kind = "compozy_tasks"`; GitHub remains the default Issue Tracker when the field is omitted
+or set to `"github"`:
+
+```json
+{
+  "tracker": {
+    "kind": "compozy_tasks",
+    "compozy": {
+      "root": ".compozy/tasks",
+      "maxTaskStepRetries": 2
+    }
+  }
+}
+```
+
+`tracker.compozy.root` is resolved from the Workspace Repository root and defaults to
+`.compozy/tasks`. Each direct child directory, such as `.compozy/tasks/compozy-tasks-run-integration/`,
+is treated as one Compozy PRD Run. The `task_NN.md` files inside that directory are Compozy Task Steps
+in the same Agent Worktree and Task Branch; they are not separate Symphony issues. When
+present, `_prd.md` and `_techspec.md` are included in each task-step Agent Prompt.
+
+Symphony persists Compozy Task Step progress in task file frontmatter. During a run, task steps move
+through statuses such as `pending`, `in_progress`, `completed`, `failed`, and `skipped`, with retry
+metadata recorded alongside the status. `tracker.compozy.maxTaskStepRetries` controls how many times
+Symphony retries a failed task step before recording the failed or skipped state and advancing to the
+next runnable task step. Runtime State, the Terminal Console, and the Web Dashboard show the selected
+tracker kind, Compozy PRD Run identifier, current task step, completed count, failed count, skipped
+count, and total count when Compozy tracking is selected.
+
+Where selector-based flows support Compozy tracking, use the stable identifier form
+`compozy:<task_name>`. For example, `.compozy/tasks/compozy-tasks-run-integration/` is selected as
+`compozy:compozy-tasks-run-integration` in Ordered Queue and Manual Task Merge flows. GitHub numeric
+selectors such as `20` or `#20` remain GitHub Tracker identifiers.
 
 Define execution backends under `harnesses` and logical agent roles under `agents`. Harnesses own
 provider commands and loop capability. Logical agents select a Harness and may override model,
@@ -179,20 +217,26 @@ If setup is incomplete, the Terminal Console still starts and prints Readiness G
 steps. Dispatch remains disabled until those gaps are resolved.
 
 For the GitHub Tracker, readiness includes the configured owner, Workspace Repository name, GitHub
-Project number, status field, and token environment variable. For the minibeads Local Issue Tracker,
+Project number, status field, and token environment variable. For Local Issue Tracker runs,
 GitHub owner, repo, Project, and token settings are not required. The local tracker readiness checks
-include:
+include tracker-specific local files and commands:
 
 - `tracker.minibeads.command`: install minibeads or update `tracker.command` so Symphony can run the
   configured command.
 - `tracker.minibeads.store`: create the local issue store at `tracker.root` or update `tracker.root`
   to the existing minibeads store.
+- `tracker.compozy.root`: create the Compozy tasks root at `tracker.compozy.root` or update the
+  setting to the existing `.compozy/tasks` directory.
+- `tracker.compozy.tasks`: add at least one valid `.compozy/tasks/<task_name>/task_NN.md` file with
+  task-step frontmatter.
 
 ## Project Status Workflow
 
 Symphony moves the selected Issue Tracker status as work progresses. With the GitHub Tracker, this is
 the configured GitHub Projects `Status` field. With the minibeads Local Issue Tracker, Symphony maps
-the same Runtime Settings state names to minibeads statuses and writes them through `mb`:
+the same Runtime Settings state names to minibeads statuses and writes them through `mb`. With the
+Compozy-backed Local Issue Tracker, the Compozy PRD Run is the work item and Symphony records
+task-step status in each `task_NN.md` file's frontmatter:
 
 - `startStatus`: applied before launching an agent, default `In progress`.
 - `reviewStatus`: applied after the agent exits successfully, default `In review`.
@@ -314,7 +358,9 @@ duplicate skill identifiers are Readiness Gaps; Symphony checks all configured s
 dispatch, resolving Workspace Repository skills before Codex Home skills.
 
 Rendered Agent Prompts include issue comments as issue context when the selected Issue Tracker
-provides comments. minibeads Local Issue Tracker comments are not included in V1.
+provides comments. minibeads Local Issue Tracker comments are not included in V1. Compozy-backed
+Local Issue Tracker prompts include the current Compozy Task Step plus `_prd.md` and `_techspec.md`
+from the same Compozy PRD Run when those files exist.
 
 Set `goal.enabled` to `true` on a specific stage to allow Stage Goal Handoff for that stage only.
 The selected Harness decides whether a loop command is actually sent. The Bootstrap default Codex
@@ -562,9 +608,9 @@ opam exec -- dune exec symphony -- --web --port 8080
 ```
 
 If no GitHub token is configured for the GitHub Tracker, the runtime still starts, but readiness
-gaps report the missing token and live issue dispatch is disabled. For minibeads runs, dispatch does
-not require a GitHub token; unresolved `mb` command or local issue store gaps disable dispatch
-instead.
+gaps report the missing token and live issue dispatch is disabled. For Local Issue Tracker runs,
+dispatch does not require a GitHub token; unresolved minibeads command or local issue store gaps, or
+missing Compozy PRD Run task files, disable dispatch instead.
 
 ## Package Distribution
 

--- a/apps/backend/bin/main.ml
+++ b/apps/backend/bin/main.ml
@@ -104,6 +104,16 @@ let symphony_banner =
 
 let print_section title = Printf.printf "\n%s\n%!" (cyan title)
 
+let render_compozy_progress = function
+  | None -> ()
+  | Some (progress : Runtime_state.compozy_progress) ->
+      print_section "PRD Run Progress";
+      Printf.printf "  %s %s\n%!" (dim "Run") progress.run_id;
+      Printf.printf "  %s %s\n%!" (dim "Slug") progress.slug;
+      Printf.printf "  %s %s\n%!" (dim "Current step") (Option.value progress.current_step ~default:"none");
+      Printf.printf "  %s %d completed, %d failed, %d skipped, %d total\n%!" (dim "Steps") progress.completed
+        progress.failed progress.skipped progress.total
+
 let render_banner () =
   List.iter (fun line -> Printf.printf "%s\n%!" (blue line)) symphony_banner;
   Printf.printf "\n%!"
@@ -119,6 +129,7 @@ let render_terminal_console config state =
   Printf.printf "  %s %d running, %d retrying\n%!" (dim "Agents") (List.length state.Runtime_state.running)
     (List.length state.retrying);
   Printf.printf "  %s %d total\n%!" (dim "Tokens") state.usage_totals.total_tokens;
+  render_compozy_progress state.Runtime_state.compozy_progress;
   (match state.Runtime_state.ordered_queue with
   | None -> ()
   | Some queue ->

--- a/apps/backend/bin/main.ml
+++ b/apps/backend/bin/main.ml
@@ -3,72 +3,6 @@ let load_config workflow_path =
   let config = Config.from_workflow workflow in
   (workflow, config)
 
-let queue_parse_gaps = function
-  | [] -> []
-  | problems ->
-      problems
-      |> List.map (fun (problem : Ordered_queue.parse_problem) ->
-             {
-               Config.requirement = "orderedQueue." ^ (if problem.value = "" then "<empty>" else problem.value);
-               remediation = problem.reason;
-             })
-
-let queue_validation_gaps config queue =
-  let tracker = Issue_tracker.make config in
-  Ordered_queue.validation_gaps tracker queue
-  |> List.map (fun (gap : Ordered_queue.validation_gap) ->
-         { Config.requirement = gap.requirement; remediation = gap.remediation })
-
-let config_gap_of_runtime_gap (gap : Runtime_state.readiness_gap) =
-  { Config.requirement = gap.requirement; remediation = gap.remediation }
-
-let selected_tracker_readiness_gaps config =
-  try
-    let tracker = Issue_tracker.make config in
-    tracker.readiness_gaps () |> List.map config_gap_of_runtime_gap
-  with exn ->
-    [
-      {
-        Config.requirement = "tracker.adapter";
-        remediation = "Issue Tracker readiness failed: " ^ Printexc.to_string exn;
-      };
-    ]
-
-let readiness_state ?ordered_queue ?(queue_parse_problems = []) config =
-  let local_gaps = Config.readiness_gaps config in
-  let queue_gaps = queue_parse_gaps queue_parse_problems in
-  let gaps =
-    match local_gaps @ queue_gaps with
-    | [] -> (
-        let tracker_gaps = selected_tracker_readiness_gaps config in
-        match (tracker_gaps, ordered_queue) with
-        | [], Some queue -> (
-            try queue_validation_gaps config queue
-            with exn ->
-              [
-                {
-                  Config.requirement = "orderedQueue.validation";
-                  remediation = "Ordered Queue validation failed: " ^ Printexc.to_string exn;
-                };
-              ])
-        | gaps, _ -> gaps)
-    | gaps -> gaps
-  in
-  let last_error =
-    match gaps with
-    | [] -> None
-    | gap :: _ -> Some (gap.requirement ^ ": " ^ gap.remediation)
-  in
-  let readiness_gaps =
-    List.map
-      (fun (gap : Config.readiness_gap) ->
-        { Runtime_state.requirement = gap.requirement; remediation = gap.remediation })
-      gaps
-  in
-  Runtime_state.empty ?last_error ~tracker_kind:config.tracker.kind ~status_order:(Config.project_status_order config)
-    ?ordered_queue:(Option.map Orchestrator.ordered_queue_state ordered_queue)
-    ~readiness_gaps ()
-
 let colors_enabled () =
   Sys.getenv_opt "NO_COLOR" = None
 
@@ -138,12 +72,14 @@ let tracker_issue_source config =
   match config.Config.tracker.kind with
   | "github" -> Printf.sprintf "%s/%s" config.tracker.owner config.tracker.repo
   | "minibeads" -> config.tracker.minibeads_root
+  | "compozy_tasks" -> config.tracker.compozy_root
   | kind -> kind
 
 let tracker_status_source config =
   match config.Config.tracker.kind with
   | "github" -> Printf.sprintf "GitHub Project #%d" config.tracker.project_number
   | "minibeads" -> Printf.sprintf "Local Issue Files via %s" config.tracker.minibeads_command
+  | "compozy_tasks" -> "Compozy PRD-run task files"
   | kind -> kind
 
 let render_startup_completed ~mode ~config ~runtime_home =
@@ -214,7 +150,7 @@ let run_legacy workflow_path port once =
   in
   try
     let workflow, config = load_config workflow_path in
-    let state = readiness_state config in
+    let state = Runtime_readiness.state config in
     let example_issue = Issue.empty ~id:"local" ~identifier:"#0" ~title:"Local dry run" ~state:"Todo" in
     let _rendered =
       if workflow.prompt_template = "" then "You are working on an issue from GitHub."
@@ -294,7 +230,7 @@ let run_runtime port once web queue_arg merge_args overrides =
         render_startup_completed ~mode:(Cli_mode.to_string mode) ~config ~runtime_home:home.runtime_dir;
         if merge_args <> [] then run_manual_merge config merge_args
         else (
-          let state = readiness_state ?ordered_queue ~queue_parse_problems config in
+          let state = Runtime_readiness.state ?ordered_queue ~queue_parse_problems config in
           if mode = Cli_mode.Web_dashboard then render_banner ();
           if once then (
             if mode = Cli_mode.Terminal_console then render_terminal_console config state;

--- a/apps/backend/lib/compozy_tasks_tracker.ml
+++ b/apps/backend/lib/compozy_tasks_tracker.ml
@@ -373,6 +373,56 @@ let fetch_prd_runs (config : Config.t) =
 let issue_of_prd_run (run : prd_run) =
   Issue.empty ~id:run.id ~identifier:run.id ~title:run.title ~state:run.state
 
+let ensure_trailing_newline content =
+  if content = "" || content.[String.length content - 1] <> '\n' then content ^ "\n" else content
+
+let prompt_section title content =
+  Printf.sprintf "## %s\n\n%s" title (ensure_trailing_newline content)
+
+let prompt_optional_file run file title =
+  let path = Filename.concat run.path file in
+  if not (Sys.file_exists path) then Ok None
+  else
+    ok_or_error (fun () -> Util.read_file path)
+    |> Result.map (fun content -> Some (prompt_section title content))
+    |> Result.map_error (fun msg -> Printf.sprintf "could not read Compozy prompt context %s for %s: %s" file run.id msg)
+
+let current_prompt (run : prd_run) =
+  match run.current_step with
+  | None ->
+      let reason =
+        match run.not_runnable_reason with
+        | Some reason when Util.trim reason <> "" -> ": " ^ reason
+        | _ when run.state = "completed" -> ": PRD run is completed"
+        | _ when Util.trim run.state <> "" -> ": PRD run state is " ^ run.state
+        | _ -> ""
+      in
+      Error (Printf.sprintf "no runnable Compozy task step for %s%s" run.id reason)
+  | Some step -> (
+      let task_path = Filename.concat run.path step.file in
+      match ok_or_error (fun () -> Util.read_file task_path) with
+      | Error msg -> Error (Printf.sprintf "could not read Compozy task step %s for %s: %s" step.file run.id msg)
+      | Ok task_content -> (
+          match prompt_optional_file run "_prd.md" "PRD (`_prd.md`)" with
+          | Error _ as error -> error
+          | Ok prd_section -> (
+              match prompt_optional_file run "_techspec.md" "TechSpec (`_techspec.md`)" with
+              | Error _ as error -> error
+              | Ok techspec_section ->
+                  let header =
+                    Printf.sprintf
+                      "# Compozy Task Step\n\nRun: %s\nPRD directory: %s\nCurrent task file: %s\nCurrent task title: %s\n"
+                      run.id run.slug step.file step.title
+                  in
+                  let sections =
+                    [
+                      header;
+                      prompt_section (Printf.sprintf "Current Task (`%s`)" step.file) task_content;
+                    ]
+                    @ List.filter_map Fun.id [ prd_section; techspec_section ]
+                  in
+                  Ok (String.concat "\n" sections))))
+
 let yaml_line_value = function
   | `Status status -> status
   | `Retry_count count -> string_of_int count

--- a/apps/backend/lib/compozy_tasks_tracker.ml
+++ b/apps/backend/lib/compozy_tasks_tracker.ml
@@ -11,6 +11,29 @@ type task_file = {
   last_error : string option;
 }
 
+type task_step = { file : string; title : string; status : string; retry_count : int; index : int }
+
+type task_counts = {
+  total : int;
+  pending : int;
+  in_progress : int;
+  completed : int;
+  failed : int;
+  skipped : int;
+}
+
+type prd_run = {
+  id : string;
+  slug : string;
+  path : string;
+  title : string;
+  state : string;
+  current_step : task_step option;
+  steps : task_step list;
+  counts : task_counts;
+  not_runnable_reason : string option;
+}
+
 type frontmatter_update = {
   status : string option;
   retry_count : int option;
@@ -45,6 +68,10 @@ let task_index_of_filename file =
     let digits = String.sub file start len in
     if all_digits digits then int_of_string_opt digits else None
   else None
+
+let id_of_slug slug = "compozy:" ^ slug
+
+let title_of_slug slug = "Compozy PRD run: " ^ slug
 
 let canonical_existing kind path =
   ok_or_error (fun () -> Unix.realpath path)
@@ -203,15 +230,26 @@ let list_task_paths ~compozy_root prd_dir =
   | Ok prd_dir ->
       if not (Sys.is_directory prd_dir) then Error (Printf.sprintf "Compozy PRD path is not a directory: %s" prd_dir)
       else
-        Sys.readdir prd_dir |> Array.to_list
+        let entries =
+          Sys.readdir prd_dir |> Array.to_list
         |> List.filter_map (fun file ->
                match task_index_of_filename file with
                | Some index -> Some (index, file, Filename.concat prd_dir file)
                | None -> None)
         |> List.sort (fun (left_index, left_file, _) (right_index, right_file, _) ->
                match Int.compare left_index right_index with 0 -> String.compare left_file right_file | diff -> diff)
-        |> List.map (fun (_, _, path) -> path)
-        |> fun paths -> Ok paths
+        in
+        let rec duplicate_index = function
+          | (left_index, left_file, _) :: (right_index, right_file, _) :: _ when left_index = right_index ->
+              Some (left_index, left_file, right_file)
+          | _ :: rest -> duplicate_index rest
+          | [] -> None
+        in
+        match duplicate_index entries with
+        | Some (index, left_file, right_file) ->
+            Error
+              (Printf.sprintf "duplicate Compozy task index %d in %s: %s and %s" index prd_dir left_file right_file)
+        | None -> Ok (List.map (fun (_, _, path) -> path) entries)
 
 let list_task_files ~compozy_root prd_dir =
   match list_task_paths ~compozy_root prd_dir with
@@ -225,6 +263,115 @@ let list_task_files ~compozy_root prd_dir =
             | Error _ as error -> error)
       in
       parse [] paths
+
+let task_step_of_task_file (task : task_file) =
+  { file = task.file; title = task.title; status = task.status; retry_count = task.retry_count; index = task.index }
+
+let empty_counts = { total = 0; pending = 0; in_progress = 0; completed = 0; failed = 0; skipped = 0 }
+
+let counts_of_steps steps =
+  List.fold_left
+    (fun counts (step : task_step) ->
+      match String.lowercase_ascii step.status with
+      | "pending" -> { counts with total = counts.total + 1; pending = counts.pending + 1 }
+      | "in_progress" -> { counts with total = counts.total + 1; in_progress = counts.in_progress + 1 }
+      | "completed" -> { counts with total = counts.total + 1; completed = counts.completed + 1 }
+      | "failed" -> { counts with total = counts.total + 1; failed = counts.failed + 1 }
+      | "skipped" -> { counts with total = counts.total + 1; skipped = counts.skipped + 1 }
+      | _ -> { counts with total = counts.total + 1 })
+    empty_counts steps
+
+let current_step_of_steps steps =
+  match List.find_opt (fun (step : task_step) -> String.lowercase_ascii step.status = "in_progress") steps with
+  | Some _ as step -> step
+  | None -> List.find_opt (fun (step : task_step) -> String.lowercase_ascii step.status = "pending") steps
+
+let state_of_steps (counts : task_counts) (current_step : task_step option) =
+  match current_step with
+  | Some step -> step.status
+  | None when counts.total = 0 -> "not_runnable"
+  | None when counts.total = counts.completed -> "completed"
+  | None -> "not_runnable"
+
+let prd_run_of_directory ~compozy_root prd_dir =
+  match ensure_inside_root ~compozy_root prd_dir with
+  | Error _ as error -> error
+  | Ok prd_dir ->
+      let slug = Filename.basename prd_dir in
+      let not_runnable reason =
+        Ok
+          {
+            id = id_of_slug slug;
+            slug;
+            path = prd_dir;
+            title = title_of_slug slug;
+            state = "not_runnable";
+            current_step = None;
+            steps = [];
+            counts = empty_counts;
+            not_runnable_reason = Some reason;
+          }
+      in
+      if not (Sys.is_directory prd_dir) then Error (Printf.sprintf "Compozy PRD path is not a directory: %s" prd_dir)
+      else
+        match list_task_files ~compozy_root prd_dir with
+        | Error error -> not_runnable error
+        | Ok tasks ->
+            let steps = List.map task_step_of_task_file tasks in
+            let counts = counts_of_steps steps in
+            let current_step = current_step_of_steps steps in
+            let state = state_of_steps counts current_step in
+            let not_runnable_reason =
+              if counts.total = 0 then Some (Printf.sprintf "no Compozy task files found in %s" prd_dir)
+              else if state = "not_runnable" then Some "no pending or in-progress Compozy task step"
+              else None
+            in
+            Ok
+              {
+                id = id_of_slug slug;
+                slug;
+                path = prd_dir;
+                title = title_of_slug slug;
+                state;
+                current_step;
+                steps;
+                counts;
+                not_runnable_reason;
+              }
+
+let list_prd_run_paths ~compozy_root =
+  if not (Sys.file_exists compozy_root) then Ok []
+  else if not (Sys.is_directory compozy_root) then Error (Printf.sprintf "Compozy root is not a directory: %s" compozy_root)
+  else
+    Sys.readdir compozy_root |> Array.to_list
+    |> List.filter_map (fun name ->
+           let path = Filename.concat compozy_root name in
+           if Sys.file_exists path && Sys.is_directory path then Some (name, path) else None)
+    |> List.sort (fun (left_name, _) (right_name, _) -> String.compare left_name right_name)
+    |> List.map snd |> fun paths -> Ok paths
+
+let discover_prd_runs ~compozy_root =
+  match canonical_existing "root" compozy_root with
+  | Error _ when not (Sys.file_exists compozy_root) -> Ok []
+  | Error _ as error -> error
+  | Ok compozy_root -> (
+      match list_prd_run_paths ~compozy_root with
+      | Error _ as error -> error
+      | Ok paths ->
+          let rec build acc = function
+            | [] -> Ok (List.rev acc)
+            | path :: rest -> (
+                match prd_run_of_directory ~compozy_root path with
+                | Ok run -> build (run :: acc) rest
+                | Error _ as error -> error)
+          in
+          build [] paths)
+
+let fetch_prd_runs (config : Config.t) =
+  match discover_prd_runs ~compozy_root:config.tracker.compozy_root with Ok runs -> runs | Error _ -> []
+
+let issue_of_prd_run (run : prd_run) =
+  Issue.empty ~id:run.id ~identifier:run.id ~title:run.title ~state:run.state
 
 let yaml_line_value = function
   | `Status status -> status

--- a/apps/backend/lib/compozy_tasks_tracker.ml
+++ b/apps/backend/lib/compozy_tasks_tracker.ml
@@ -34,6 +34,8 @@ type prd_run = {
   not_runnable_reason : string option;
 }
 
+type readiness_gap = { requirement : string; remediation : string }
+
 type frontmatter_update = {
   status : string option;
   retry_count : int option;
@@ -369,6 +371,49 @@ let discover_prd_runs ~compozy_root =
 
 let fetch_prd_runs (config : Config.t) =
   match discover_prd_runs ~compozy_root:config.tracker.compozy_root with Ok runs -> runs | Error _ -> []
+
+let runnable_prd_run (run : prd_run) = Option.is_some run.current_step
+
+let readiness_gaps (config : Config.t) =
+  let root = config.tracker.compozy_root in
+  let gap requirement remediation = { requirement; remediation } in
+  if not (Sys.file_exists root) then
+    [
+      gap "tracker.compozy.root"
+        (Printf.sprintf
+           "Create the Compozy tracker root at %s or set tracker.compozy.root to an existing PRD tasks directory."
+           root);
+    ]
+  else if not (Sys.is_directory root) then
+    [
+      gap "tracker.compozy.root"
+        (Printf.sprintf "Set tracker.compozy.root to a directory; %s exists but is not a directory." root);
+    ]
+  else
+    match discover_prd_runs ~compozy_root:root with
+    | Error error -> [ gap "tracker.compozy.root" error ]
+    | Ok [] ->
+        [
+          gap "tracker.compozy.prdRuns"
+            (Printf.sprintf "Add at least one Compozy PRD-run directory under %s." root);
+        ]
+    | Ok runs ->
+        if List.exists runnable_prd_run runs then []
+        else
+          let reason =
+            runs
+            |> List.filter_map (fun (run : prd_run) ->
+                   Option.map (fun reason -> Printf.sprintf "%s: %s" run.id reason) run.not_runnable_reason)
+            |> function
+            | [] -> ""
+            | reasons -> " First issue: " ^ List.hd reasons
+          in
+          [
+            gap "tracker.compozy.runnablePrdRun"
+              (Printf.sprintf
+                 "Add at least one Compozy PRD-run directory with a pending or in_progress task_NN.md under %s.%s"
+                 root reason);
+          ]
 
 let issue_of_prd_run (run : prd_run) =
   Issue.empty ~id:run.id ~identifier:run.id ~title:run.title ~state:run.state

--- a/apps/backend/lib/compozy_tasks_tracker.ml
+++ b/apps/backend/lib/compozy_tasks_tracker.ml
@@ -293,6 +293,8 @@ let state_of_steps (counts : task_counts) (current_step : task_step option) =
   | Some step -> step.status
   | None when counts.total = 0 -> "not_runnable"
   | None when counts.total = counts.completed -> "completed"
+  | None when counts.total = counts.completed + counts.failed + counts.skipped && counts.failed > 0 -> "failed"
+  | None when counts.total = counts.completed + counts.failed + counts.skipped && counts.skipped > 0 -> "skipped"
   | None -> "not_runnable"
 
 let prd_run_of_directory ~compozy_root prd_dir =
@@ -548,6 +550,11 @@ let mark_step_started ~compozy_root run step =
 
 let mark_step_finished ~compozy_root run step =
   update_status ~compozy_root (task_step_path run step) "completed"
+
+let record_step_failure ~compozy_root run step ~retry_count ~last_error ~over_limit =
+  let status = if over_limit then "failed" else "in_progress" in
+  update_task_frontmatter ~compozy_root (task_step_path run step)
+    { status = Some status; retry_count = Some retry_count; last_error = Some last_error }
 
 let update_retry_count ~compozy_root path retry_count =
   if retry_count < 0 then Error (Printf.sprintf "invalid symphony_retry_count for %s: %d" (Filename.basename path) retry_count)

--- a/apps/backend/lib/compozy_tasks_tracker.ml
+++ b/apps/backend/lib/compozy_tasks_tracker.ml
@@ -1,0 +1,307 @@
+type task_file = {
+  path : string;
+  file : string;
+  index : int;
+  status : string;
+  title : string;
+  task_type : string;
+  complexity : string;
+  dependencies : string list;
+  retry_count : int;
+  last_error : string option;
+}
+
+type frontmatter_update = {
+  status : string option;
+  retry_count : int option;
+  last_error : string option;
+}
+
+let ok_or_error f =
+  try Ok (f ())
+  with
+  | Sys_error msg -> Error msg
+  | Unix.Unix_error (error, fn, arg) -> Error (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message error))
+
+let starts_with ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len && String.sub value 0 prefix_len = prefix
+
+let ends_with ~suffix value =
+  let suffix_len = String.length suffix in
+  let value_len = String.length value in
+  value_len >= suffix_len && String.sub value (value_len - suffix_len) suffix_len = suffix
+
+let all_digits value =
+  value <> ""
+  && String.for_all (fun c -> Char.code c >= Char.code '0' && Char.code c <= Char.code '9') value
+
+let task_index_of_filename file =
+  let prefix = "task_" in
+  let suffix = ".md" in
+  if starts_with ~prefix file && ends_with ~suffix file then
+    let start = String.length prefix in
+    let len = String.length file - start - String.length suffix in
+    let digits = String.sub file start len in
+    if all_digits digits then int_of_string_opt digits else None
+  else None
+
+let canonical_existing kind path =
+  ok_or_error (fun () -> Unix.realpath path)
+  |> Result.map_error (fun msg -> Printf.sprintf "invalid Compozy %s path %s: %s" kind path msg)
+
+let is_path_inside ~root path =
+  path = root || starts_with ~prefix:(root ^ "/") path
+
+let ensure_inside_root ~compozy_root path =
+  match (canonical_existing "root" compozy_root, canonical_existing "task" path) with
+  | Ok root, Ok path when is_path_inside ~root path -> Ok path
+  | Ok _, Ok _ -> Error (Printf.sprintf "path outside configured Compozy root: %s" path)
+  | Error error, _ | _, Error error -> Error error
+
+let first_line_end content =
+  match String.index_opt content '\n' with
+  | Some index -> Some (index + 1)
+  | None -> None
+
+let line_end content start =
+  match String.index_from_opt content start '\n' with
+  | Some index -> (index, index + 1)
+  | None -> (String.length content, String.length content)
+
+let line_without_cr content start stop =
+  let stop = if stop > start && content.[stop - 1] = '\r' then stop - 1 else stop in
+  String.sub content start (stop - start)
+
+let split_frontmatter ~file content =
+  match first_line_end content with
+  | None -> Error (Printf.sprintf "missing frontmatter in %s" file)
+  | Some first_end ->
+      let first = line_without_cr content 0 (first_end - 1) |> Util.trim in
+      if first <> "---" then Error (Printf.sprintf "missing frontmatter in %s" file)
+      else
+        let rec find_close start =
+          if start >= String.length content then Error (Printf.sprintf "malformed frontmatter in %s: missing closing ---" file)
+          else
+            let stop, next = line_end content start in
+            let line = line_without_cr content start stop |> Util.trim in
+            if line = "---" then
+              let frontmatter = String.sub content first_end (start - first_end) in
+              let body = String.sub content next (String.length content - next) in
+              Ok (frontmatter, body)
+            else find_close next
+        in
+        find_close first_end
+
+let strip_quotes value =
+  let value = Util.trim value in
+  let len = String.length value in
+  if len >= 2 && ((value.[0] = '"' && value.[len - 1] = '"') || (value.[0] = '\'' && value.[len - 1] = '\''))
+  then String.sub value 1 (len - 2)
+  else value
+
+let split_key_value ~file line =
+  match String.index_opt line ':' with
+  | None -> Error (Printf.sprintf "malformed frontmatter in %s: expected key:value line: %s" file line)
+  | Some index ->
+      let key = String.sub line 0 index |> Util.trim in
+      let value = String.sub line (index + 1) (String.length line - index - 1) |> Util.trim in
+      if key = "" then Error (Printf.sprintf "malformed frontmatter in %s: empty key" file) else Ok (key, value)
+
+let parse_inline_list value =
+  let value = Util.trim value in
+  let len = String.length value in
+  if len >= 2 && value.[0] = '[' && value.[len - 1] = ']' then
+    let inner = String.sub value 1 (len - 2) in
+    inner |> String.split_on_char ',' |> List.map (fun item -> strip_quotes (Util.trim item))
+    |> List.filter (fun item -> item <> "")
+  else [ strip_quotes value ]
+
+let parse_frontmatter ~file frontmatter =
+  let fields = Hashtbl.create 16 in
+  let dependency_block = ref false in
+  let dependencies = ref None in
+  let remember_dependency item =
+    let current = Option.value !dependencies ~default:[] in
+    dependencies := Some (current @ [ strip_quotes item ])
+  in
+  let parse_line raw_line =
+    let trimmed = Util.trim raw_line in
+    if trimmed = "" || starts_with ~prefix:"#" trimmed then Ok ()
+    else if raw_line <> "" && (raw_line.[0] = ' ' || raw_line.[0] = '\t') then
+      if !dependency_block && starts_with ~prefix:"- " trimmed then (
+        remember_dependency (String.sub trimmed 2 (String.length trimmed - 2) |> Util.trim);
+        Ok ())
+      else Error (Printf.sprintf "malformed frontmatter in %s: unsupported nested line: %s" file trimmed)
+    else
+      match split_key_value ~file trimmed with
+      | Error _ as error -> error
+      | Ok (key, value) ->
+          dependency_block := key = "dependencies" && value = "";
+          if key = "dependencies" then
+            dependencies := Some (if value = "" then [] else parse_inline_list value)
+          else Hashtbl.replace fields key (strip_quotes value);
+          Ok ()
+  in
+  let rec parse_lines = function
+    | [] -> Ok ()
+    | line :: rest -> (
+        match parse_line line with Ok () -> parse_lines rest | Error _ as error -> error)
+  in
+  match parse_lines (Util.split_lines frontmatter) with
+  | Error _ as error -> error
+  | Ok () ->
+      let required key =
+        match Hashtbl.find_opt fields key with
+        | Some value when value <> "" -> Ok value
+        | _ -> Error (Printf.sprintf "missing required frontmatter key %s in %s" key file)
+      in
+      let retry_count =
+        match Hashtbl.find_opt fields "symphony_retry_count" with
+        | None | Some "" -> Ok 0
+        | Some value -> (
+            match int_of_string_opt value with
+            | Some count when count >= 0 -> Ok count
+            | _ -> Error (Printf.sprintf "invalid symphony_retry_count in %s: %s" file value))
+      in
+      let last_error =
+        match Hashtbl.find_opt fields "symphony_last_error" with Some value when value <> "" -> Some value | _ -> None
+      in
+      (match (required "status", required "title", required "type", required "complexity", !dependencies, retry_count) with
+      | Ok status, Ok title, Ok task_type, Ok complexity, Some dependencies, Ok retry_count ->
+          Ok (status, title, task_type, complexity, dependencies, retry_count, last_error)
+      | Error error, _, _, _, _, _
+      | _, Error error, _, _, _, _
+      | _, _, Error error, _, _, _
+      | _, _, _, Error error, _, _
+      | _, _, _, _, _, Error error ->
+          Error error
+      | _, _, _, _, None, _ -> Error (Printf.sprintf "missing required frontmatter key dependencies in %s" file))
+
+let parse_task_file ~compozy_root path =
+  match ensure_inside_root ~compozy_root path with
+  | Error _ as error -> error
+  | Ok path -> (
+      let file = Filename.basename path in
+      match task_index_of_filename file with
+      | None -> Error (Printf.sprintf "not a Compozy task file: %s" file)
+      | Some index -> (
+          match ok_or_error (fun () -> Util.read_file path) with
+          | Error msg -> Error (Printf.sprintf "could not read %s: %s" file msg)
+          | Ok content -> (
+              match split_frontmatter ~file content with
+              | Error _ as error -> error
+              | Ok (frontmatter, _) -> (
+                  match parse_frontmatter ~file frontmatter with
+                  | Error _ as error -> error
+                  | Ok (status, title, task_type, complexity, dependencies, retry_count, last_error) ->
+                      Ok { path; file; index; status; title; task_type; complexity; dependencies; retry_count; last_error }))))
+
+let list_task_paths ~compozy_root prd_dir =
+  match ensure_inside_root ~compozy_root prd_dir with
+  | Error _ as error -> error
+  | Ok prd_dir ->
+      if not (Sys.is_directory prd_dir) then Error (Printf.sprintf "Compozy PRD path is not a directory: %s" prd_dir)
+      else
+        Sys.readdir prd_dir |> Array.to_list
+        |> List.filter_map (fun file ->
+               match task_index_of_filename file with
+               | Some index -> Some (index, file, Filename.concat prd_dir file)
+               | None -> None)
+        |> List.sort (fun (left_index, left_file, _) (right_index, right_file, _) ->
+               match Int.compare left_index right_index with 0 -> String.compare left_file right_file | diff -> diff)
+        |> List.map (fun (_, _, path) -> path)
+        |> fun paths -> Ok paths
+
+let list_task_files ~compozy_root prd_dir =
+  match list_task_paths ~compozy_root prd_dir with
+  | Error _ as error -> error
+  | Ok paths ->
+      let rec parse acc = function
+        | [] -> Ok (List.rev acc)
+        | path :: rest -> (
+            match parse_task_file ~compozy_root path with
+            | Ok task -> parse (task :: acc) rest
+            | Error _ as error -> error)
+      in
+      parse [] paths
+
+let yaml_line_value = function
+  | `Status status -> status
+  | `Retry_count count -> string_of_int count
+  | `Last_error error ->
+      let buffer = Buffer.create (String.length error + 8) in
+      Buffer.add_char buffer '"';
+      String.iter
+        (function
+          | '\\' -> Buffer.add_string buffer "\\\\"
+          | '"' -> Buffer.add_string buffer "\\\""
+          | '\n' | '\r' -> Buffer.add_char buffer ' '
+          | c -> Buffer.add_char buffer c)
+        error;
+      Buffer.add_char buffer '"';
+      Buffer.contents buffer
+
+let replace_or_append_line ~key ~value lines =
+  let replacement = key ^ ": " ^ value in
+  let replaced = ref false in
+  let lines =
+    List.map
+      (fun line ->
+        let trimmed = Util.trim line in
+        if (not !replaced) && line = trimmed && starts_with ~prefix:(key ^ ":") trimmed then (
+          replaced := true;
+          replacement)
+        else line)
+      lines
+  in
+  if !replaced then lines else lines @ [ replacement ]
+
+let update_frontmatter_text update frontmatter =
+  let lines = Util.split_lines frontmatter in
+  let lines =
+    match update.status with
+    | Some status -> replace_or_append_line ~key:"status" ~value:(yaml_line_value (`Status status)) lines
+    | None -> lines
+  in
+  let lines =
+    match update.retry_count with
+    | Some retry_count ->
+        replace_or_append_line ~key:"symphony_retry_count" ~value:(yaml_line_value (`Retry_count retry_count)) lines
+    | None -> lines
+  in
+  let lines =
+    match update.last_error with
+    | Some last_error ->
+        replace_or_append_line ~key:"symphony_last_error" ~value:(yaml_line_value (`Last_error last_error)) lines
+    | None -> lines
+  in
+  String.concat "\n" lines ^ "\n"
+
+let update_task_frontmatter ~compozy_root path update =
+  match ensure_inside_root ~compozy_root path with
+  | Error _ as error -> error
+  | Ok path -> (
+      let file = Filename.basename path in
+      match task_index_of_filename file with
+      | None -> Error (Printf.sprintf "not a Compozy task file: %s" file)
+      | Some _ -> (
+          match ok_or_error (fun () -> Util.read_file path) with
+          | Error msg -> Error (Printf.sprintf "could not read %s: %s" file msg)
+          | Ok content -> (
+              match split_frontmatter ~file content with
+              | Error _ as error -> error
+              | Ok (frontmatter, body) ->
+                  let updated = "---\n" ^ update_frontmatter_text update frontmatter ^ "---\n" ^ body in
+                  ok_or_error (fun () -> Util.write_file path updated)
+                  |> Result.map_error (fun msg -> Printf.sprintf "could not write %s: %s" file msg))))
+
+let update_status ~compozy_root path status =
+  update_task_frontmatter ~compozy_root path { status = Some status; retry_count = None; last_error = None }
+
+let update_retry_count ~compozy_root path retry_count =
+  if retry_count < 0 then Error (Printf.sprintf "invalid symphony_retry_count for %s: %d" (Filename.basename path) retry_count)
+  else update_task_frontmatter ~compozy_root path { status = None; retry_count = Some retry_count; last_error = None }
+
+let update_last_error ~compozy_root path last_error =
+  update_task_frontmatter ~compozy_root path { status = None; retry_count = None; last_error = Some last_error }

--- a/apps/backend/lib/compozy_tasks_tracker.ml
+++ b/apps/backend/lib/compozy_tasks_tracker.ml
@@ -541,6 +541,14 @@ let update_task_frontmatter ~compozy_root path update =
 let update_status ~compozy_root path status =
   update_task_frontmatter ~compozy_root path { status = Some status; retry_count = None; last_error = None }
 
+let task_step_path run (step : task_step) = Filename.concat run.path step.file
+
+let mark_step_started ~compozy_root run step =
+  update_status ~compozy_root (task_step_path run step) "in_progress"
+
+let mark_step_finished ~compozy_root run step =
+  update_status ~compozy_root (task_step_path run step) "completed"
+
 let update_retry_count ~compozy_root path retry_count =
   if retry_count < 0 then Error (Printf.sprintf "invalid symphony_retry_count for %s: %d" (Filename.basename path) retry_count)
   else update_task_frontmatter ~compozy_root path { status = None; retry_count = Some retry_count; last_error = None }

--- a/apps/backend/lib/config.ml
+++ b/apps/backend/lib/config.ml
@@ -7,6 +7,8 @@ type tracker = {
   api_key : string option;
   minibeads_root : string;
   minibeads_command : string;
+  compozy_root : string;
+  compozy_max_task_step_retries : int;
   active_states : string list;
   terminal_states : string list;
   project_status_field : string;
@@ -160,6 +162,8 @@ let default_pull_request_title = "Symphony batch from <head_branch>"
 let default_pull_request_body = "Opened automatically by Symphony after orchestration became idle."
 let default_minibeads_root = ".beads"
 let default_minibeads_command = "mb"
+let default_compozy_root = ".compozy/tasks"
+let default_compozy_max_task_step_retries = 2
 let default_protected_path_authorization = { issue_section = "Protected Path Authorization" }
 let default_protected_paths = { patterns = []; authorization = default_protected_path_authorization }
 let default_pull_request =
@@ -290,6 +294,27 @@ let expand_path ~base_dir path =
   Unix.realpath (if Sys.file_exists path then path else Filename.dirname path) |> fun real_parent ->
   if Sys.file_exists path then Unix.realpath path else Filename.concat real_parent (Filename.basename path)
 
+let expand_path_preserving_missing ~base_dir path =
+  let path =
+    match Util.drop_prefix ~prefix:"~/" path with
+    | Some suffix -> Filename.concat (Sys.getenv "HOME") suffix
+    | None -> (
+        match Util.drop_prefix ~prefix:"$" path with Some var -> Option.value (Util.getenv_nonempty var) ~default:path | None -> path)
+  in
+  let path = if Filename.is_relative path then Filename.concat base_dir path else path in
+  let rec existing_parent candidate missing =
+    if Sys.file_exists candidate then (Unix.realpath candidate, missing)
+    else
+      let parent = Filename.dirname candidate in
+      let name = Filename.basename candidate in
+      let missing = match missing with "" -> name | suffix -> Filename.concat name suffix in
+      if parent = candidate then (parent, missing) else existing_parent parent missing
+  in
+  if Sys.file_exists path then Unix.realpath path
+  else
+    let real_parent, missing = existing_parent (Filename.dirname path) (Filename.basename path) in
+    Filename.concat real_parent missing
+
 let positive name value =
   if value <= 0 then raise (Invalid_config (name ^ " must be positive"));
   value
@@ -300,11 +325,12 @@ let parse_tracker_kind raw =
   match Util.trim raw |> String.lowercase_ascii with
   | "github" -> "github"
   | "minibeads" -> "minibeads"
+  | "compozy_tasks" -> "compozy_tasks"
   | unsupported ->
       let shown = if unsupported = "" then "<empty>" else unsupported in
       raise
         (Invalid_config
-           (Printf.sprintf "Unsupported tracker.kind %s. Set tracker.kind to github or minibeads." shown))
+           (Printf.sprintf "Unsupported tracker.kind %s. Set tracker.kind to github, minibeads, or compozy_tasks." shown))
 
 let apply_runtime_invocation_overrides ~workspace_root config overrides =
   let polling =
@@ -403,6 +429,8 @@ let from_workflow workflow =
         api_key;
         minibeads_root = Filename.concat workflow.dir default_minibeads_root;
         minibeads_command = default_minibeads_command;
+        compozy_root = Filename.concat workflow.dir default_compozy_root;
+        compozy_max_task_step_retries = default_compozy_max_task_step_retries;
         active_states;
         terminal_states;
         project_status_field = Option.value (Simple_yaml.get_string "project_status_field" tracker_raw) ~default:"Status";
@@ -1262,6 +1290,7 @@ let from_settings_file ~workspace_root path =
     with Yojson.Json_error msg -> raise (Invalid_config ("settings.json parse error: " ^ msg))
   in
   let tracker_raw = member "tracker" root in
+  let compozy_raw = member "compozy" tracker_raw in
   let project_raw = member "project" root in
   let polling_raw = member "polling" root in
   let workspace_raw = member "workspace" root in
@@ -1317,6 +1346,12 @@ let from_settings_file ~workspace_root path =
         minibeads_root =
           json_string "root" tracker_raw ~default:default_minibeads_root |> expand_path ~base_dir:workspace_root;
         minibeads_command = json_string "command" tracker_raw ~default:default_minibeads_command;
+        compozy_root =
+          json_string "root" compozy_raw ~default:default_compozy_root
+          |> expand_path_preserving_missing ~base_dir:workspace_root;
+        compozy_max_task_step_retries =
+          positive "tracker.compozy.maxTaskStepRetries"
+            (json_int "maxTaskStepRetries" compozy_raw ~default:default_compozy_max_task_step_retries);
         active_states = json_string_list "activeStates" project_raw ~default:default_active_states;
         terminal_states;
         project_status_field = json_string "statusField" project_raw ~default:"Status";

--- a/apps/backend/lib/issue_tracker.ml
+++ b/apps/backend/lib/issue_tracker.ml
@@ -195,8 +195,87 @@ let minibeads ?(runner = Minibeads_tracker.default_runner) (config : Config.t) =
     is_terminal = Minibeads_tracker.is_terminal_status config.tracker;
   }
 
+let compozy_identifier raw =
+  let identifier = Util.trim raw in
+  match Util.drop_prefix ~prefix:"compozy:" identifier with
+  | Some slug when Util.trim slug <> "" && not (String.contains slug '/') -> Ok ("compozy:" ^ Util.trim slug)
+  | _ ->
+      Error
+        (Printf.sprintf
+           "invalid Compozy PRD-run identifier %S; expected an identifier like compozy:task-name"
+           raw)
+
+let string_equal_ci left right = String.lowercase_ascii left = String.lowercase_ascii right
+
+let status_in values status = List.exists (string_equal_ci status) values
+
+let compozy_status_is_active config status =
+  status_in [ "pending"; "in_progress" ] status || status_in config.Config.tracker.active_states status
+
+let compozy_status_is_terminal config status =
+  status_in [ "completed"; "failed"; "skipped" ] status || status_in config.Config.tracker.terminal_states status
+
+let compozy_lookup_result runs raw =
+  let identifier = match compozy_identifier raw with Ok identifier -> identifier | Error _ -> raw in
+  match List.find_opt (fun (run : Compozy_tasks_tracker.prd_run) -> run.id = identifier) runs with
+  | Some run -> { identifier; issue = Some (Compozy_tasks_tracker.issue_of_prd_run run); diagnostics = [] }
+  | None -> { identifier; issue = None; diagnostics = [ Missing_issue ] }
+
+let compozy config =
+  let fetch_runs () =
+    match Compozy_tasks_tracker.discover_prd_runs ~compozy_root:config.Config.tracker.compozy_root with
+    | Ok runs -> Ok runs
+    | Error message -> Error message
+  in
+  let fetch_candidates () =
+    match fetch_runs () with
+    | Error message -> Error (Failed message)
+    | Ok runs ->
+        Ok
+          (runs
+          |> List.filter Compozy_tasks_tracker.runnable_prd_run
+          |> List.map Compozy_tasks_tracker.issue_of_prd_run)
+  in
+  let fetch_by_identifiers_detailed identifiers =
+    let rec normalize acc = function
+      | [] -> Ok (List.rev acc)
+      | identifier :: rest -> (
+          match compozy_identifier identifier with
+          | Error _ as error -> error
+          | Ok identifier -> normalize (identifier :: acc) rest)
+    in
+    match normalize [] identifiers with
+    | Error _ as error -> error
+    | Ok identifiers -> (
+        match fetch_runs () with
+        | Error _ as error -> error
+        | Ok runs -> Ok (List.map (compozy_lookup_result runs) identifiers))
+  in
+  let fetch_by_identifiers identifiers =
+    fetch_by_identifiers_detailed identifiers
+    |> Result.map
+         (List.map (fun result ->
+              match result.diagnostics with [] -> result.issue | _ -> None))
+  in
+  {
+    kind = "compozy_tasks";
+    fetch_candidates;
+    fetch_by_identifiers;
+    fetch_by_identifiers_detailed;
+    update_status = (fun _ _ -> Ok ());
+    readiness_gaps =
+      (fun () ->
+        Compozy_tasks_tracker.readiness_gaps config
+        |> List.map (fun (gap : Compozy_tasks_tracker.readiness_gap) ->
+               { Runtime_state.requirement = gap.requirement; remediation = gap.remediation }));
+    normalize_identifier = compozy_identifier;
+    is_active = compozy_status_is_active config;
+    is_terminal = compozy_status_is_terminal config;
+  }
+
 let make (config : Config.t) =
   match config.tracker.kind with
   | "github" -> github config
   | "minibeads" -> minibeads config
+  | "compozy_tasks" -> compozy config
   | kind -> invalid_arg (Printf.sprintf "Issue tracker adapter is not implemented for tracker.kind=%S" kind)

--- a/apps/backend/lib/manual_merge.ml
+++ b/apps/backend/lib/manual_merge.ml
@@ -45,9 +45,31 @@ let normalize_minibeads_selector raw trimmed =
       Error
         (Printf.sprintf "invalid Manual Task Merge selector %S; expected a minibeads issue identifier like mb-20" raw)
 
+let normalize_compozy_selector raw trimmed =
+  match Util.drop_prefix ~prefix:"compozy:" trimmed with
+  | Some task_name ->
+      let task_name = Util.trim task_name in
+      if task_name = "" then
+        Error
+          (Printf.sprintf
+             "invalid Manual Task Merge selector %S; expected a Compozy PRD-run identifier like compozy:example-feature"
+             raw)
+      else if String.contains task_name '/' || String.contains task_name ':' then
+        Error
+          (Printf.sprintf
+             "invalid Manual Task Merge selector %S; expected a Compozy PRD-run identifier like compozy:example-feature without path separators"
+             raw)
+      else Ok { raw = trimmed; identifier = "compozy:" ^ task_name }
+  | None ->
+      Error
+        (Printf.sprintf
+           "invalid Manual Task Merge selector %S; expected a Compozy PRD-run identifier like compozy:example-feature"
+           raw)
+
 let normalize_one raw =
   let trimmed = Util.trim raw in
   if trimmed = "" then Error (Printf.sprintf "invalid Manual Task Merge selector %S" raw)
+  else if Util.starts_with ~prefix:"compozy:" trimmed then normalize_compozy_selector raw trimmed
   else if String.contains trimmed '/' || String.contains trimmed ':' then
     Error
       (Printf.sprintf
@@ -164,7 +186,10 @@ let preflight_one config (tracker : Issue_tracker.t) ~projected_tip (result : Is
                   with
                   | Error error -> Error (Printf.sprintf "%s %s" selector.identifier error)
                   | Ok () ->
-                      if terminal then
+                      let allow_terminal_merge =
+                        tracker.kind = "compozy_tasks" && String.lowercase_ascii issue.Issue.state = "completed"
+                      in
+                      if terminal && not allow_terminal_merge then
                         Error
                           (Printf.sprintf "%s is terminal in tracker state %S but %s is not on the Loop-Start Branch"
                              selector.identifier issue.state branch)

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -1406,6 +1406,18 @@ let compose_prompt_result ?stage ?previous_attempt_output config issue attempt b
 let compose_prompt ?stage ?previous_attempt_output config issue attempt base_prompt ~workspace ~loop_start_branch =
   (compose_prompt_result ?stage ?previous_attempt_output config issue attempt base_prompt ~workspace ~loop_start_branch).prompt
 
+let compose_compozy_task_step_prompt_result ?stage ?previous_attempt_output config run attempt ~workspace
+    ~loop_start_branch =
+  match Compozy_tasks_tracker.current_prompt run with
+  | Error _ as error -> error
+  | Ok base_prompt ->
+      let issue = Compozy_tasks_tracker.issue_of_prd_run run in
+      Ok (compose_prompt_result ?stage ?previous_attempt_output config issue attempt base_prompt ~workspace ~loop_start_branch)
+
+let compose_compozy_task_step_prompt ?stage ?previous_attempt_output config run attempt ~workspace ~loop_start_branch =
+  compose_compozy_task_step_prompt_result ?stage ?previous_attempt_output config run attempt ~workspace ~loop_start_branch
+  |> Result.map (fun composition -> composition.prompt)
+
 let context_command_diagnostic_to_yojson diagnostic =
   `Assoc
     [

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -1819,13 +1819,12 @@ let is_compozy_prd_run_child orchestrator issue =
 let compozy_workspace_root config (workspace : Workspace.t) =
   let repository_root = Unix.realpath config.Config.repository_root in
   let compozy_root = Unix.realpath config.Config.tracker.compozy_root in
-  let prefix = repository_root ^ Filename.dir_sep in
-  let relative =
+  if compozy_root = repository_root then workspace.path
+  else
+    let prefix = repository_root ^ Filename.dir_sep in
     match Util.drop_prefix ~prefix compozy_root with
-    | Some relative -> relative
-    | None -> Filename.basename compozy_root
-  in
-  Filename.concat workspace.path relative
+    | Some relative -> Filename.concat workspace.path relative
+    | None -> compozy_root
 
 let compozy_prd_run_for_workspace_issue config workspace issue =
   let compozy_root = compozy_workspace_root config workspace in
@@ -3070,7 +3069,7 @@ let mark_merge_attention orchestrator child error =
 
 type compozy_completion =
   | Not_compozy_child
-  | Compozy_final_step
+  | Compozy_final_step of Compozy_tasks_tracker.prd_run * Compozy_tasks_tracker.task_step
   | Compozy_next_step of Compozy_tasks_tracker.prd_run
 
 let complete_compozy_task_step orchestrator child =
@@ -3088,10 +3087,21 @@ let complete_compozy_task_step orchestrator child =
                 match compozy_prd_run_for_workspace_issue orchestrator.config child.workspace child.issue with
                 | Error _ as error -> error
                 | Ok updated_run ->
-                    update_compozy_progress orchestrator updated_run;
                     match updated_run.current_step with
-                    | Some _ -> Ok (Compozy_next_step updated_run)
-                    | None -> Ok Compozy_final_step)))
+                    | Some _ ->
+                        update_compozy_progress orchestrator updated_run;
+                        Ok (Compozy_next_step updated_run)
+                    | None -> Ok (Compozy_final_step (updated_run, step)))))
+
+let restore_compozy_final_step_for_retry orchestrator child run step =
+  match update_compozy_workspace_step_status orchestrator.config child.workspace run step "in_progress" with
+  | Error error -> Error error
+  | Ok () -> (
+      match compozy_prd_run_for_workspace_issue orchestrator.config child.workspace child.issue with
+      | Error _ as error -> error
+      | Ok restored_run ->
+          update_compozy_progress orchestrator restored_run;
+          Ok ())
 
 let mark_completed orchestrator child =
   let issue_id = child.issue_id in
@@ -3105,9 +3115,18 @@ let mark_completed orchestrator child =
       let next_issue = Compozy_tasks_tracker.issue_of_prd_run run in
       complete_child ~next_status:run.state orchestrator child;
       dispatch_issue orchestrator next_issue
-  | Ok (Not_compozy_child | Compozy_final_step) -> (
+  | Ok (Not_compozy_child | Compozy_final_step _) as completion -> (
       match orchestrator.commit_stage orchestrator.config child.workspace child.issue stage next_status with
       | Error error ->
+          let error =
+            match completion with
+            | Ok (Compozy_final_step (run, step)) -> (
+                match restore_compozy_final_step_for_retry orchestrator child run step with
+                | Ok () -> error
+                | Error restore_error ->
+                    Printf.sprintf "%s; could not restore final Compozy task step for retry: %s" error restore_error)
+            | _ -> error
+          in
           render_commit_failed child.issue_identifier error;
           if human_attention_completion_error error then mark_merge_attention orchestrator child error
           else if non_retryable_completion_error error then (
@@ -3115,6 +3134,9 @@ let mark_completed orchestrator child =
             mark_blocked orchestrator issue_id error)
           else mark_retrying orchestrator issue_id error
       | Ok () ->
+          (match completion with
+          | Ok (Compozy_final_step (run, _step)) -> update_compozy_progress orchestrator run
+          | _ -> ());
           let status_moved_before_merge =
             match next_status with
             | Some status when task_pull_request_before_auto_merge orchestrator status ->

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -2887,6 +2887,40 @@ let mark_retrying orchestrator issue_id error =
       render_dispatch_retrying row.issue.identifier next_attempt error;
       update_ordered_queue_entries orchestrator ~candidates:[ row.issue ] ()
 
+type compozy_failure =
+  | Not_compozy_failure
+  | Compozy_retry_step
+  | Compozy_next_after_failure of Compozy_tasks_tracker.prd_run
+  | Compozy_finished_after_failure of Compozy_tasks_tracker.prd_run
+
+let record_compozy_task_step_failure orchestrator child error =
+  if not (is_compozy_prd_run_child orchestrator child.issue) then Ok Not_compozy_failure
+  else
+    match compozy_prd_run_for_workspace_issue orchestrator.config child.workspace child.issue with
+    | Error _ as error -> error
+    | Ok run -> (
+        match run.current_step with
+        | None -> Error (Printf.sprintf "no runnable Compozy task step for %s" run.id)
+        | Some step ->
+            let retry_count = step.retry_count + 1 in
+            let over_limit = retry_count >= orchestrator.config.tracker.compozy_max_task_step_retries in
+            let compozy_root = compozy_workspace_root orchestrator.config child.workspace in
+            match
+              Compozy_tasks_tracker.record_step_failure ~compozy_root run step ~retry_count ~last_error:error
+                ~over_limit
+            with
+            | Error _ as error -> error
+            | Ok () -> (
+                match compozy_prd_run_for_workspace_issue orchestrator.config child.workspace child.issue with
+                | Error _ as error -> error
+                | Ok updated_run ->
+                    update_compozy_progress orchestrator updated_run;
+                    if not over_limit then Ok Compozy_retry_step
+                    else
+                      match updated_run.current_step with
+                      | Some _ -> Ok (Compozy_next_after_failure updated_run)
+                      | None -> Ok (Compozy_finished_after_failure updated_run)))
+
 let non_retryable_completion_error = function
   | "commit required but agent produced no code changes" | "commit required but no staged changes were found" -> true
   | _ -> false
@@ -2958,6 +2992,18 @@ let complete_child ?next_status orchestrator child =
     |> Runtime_state.clear_context_status issue_id);
   update_ordered_queue_entries orchestrator ?completed_identifier ?pending_identifier ~candidates:[ next_issue ] ();
   render_dispatch_completed child.issue_identifier child.issue_title
+
+let mark_child_failed orchestrator child error =
+  match record_compozy_task_step_failure orchestrator child error with
+  | Error failure_error ->
+      render_commit_failed child.issue_identifier failure_error;
+      mark_retrying orchestrator child.issue_id failure_error
+  | Ok Not_compozy_failure | Ok Compozy_retry_step -> mark_retrying orchestrator child.issue_id error
+  | Ok (Compozy_next_after_failure run) ->
+      let next_issue = Compozy_tasks_tracker.issue_of_prd_run run in
+      complete_child ~next_status:run.state orchestrator child;
+      dispatch_issue orchestrator next_issue
+  | Ok (Compozy_finished_after_failure run) -> complete_child ~next_status:run.state orchestrator child
 
 let cleanup_task_worktree orchestrator child =
   cleanup_task_worktree_for_issue orchestrator.config child.issue child.workspace.path
@@ -3172,7 +3218,7 @@ let reap_children orchestrator =
         then (
           refresh_child_output ~force:true orchestrator child;
           kill_child child;
-          mark_retrying orchestrator child.issue_id "agent timed out";
+          mark_child_failed orchestrator child "agent timed out";
           (child.issue_id :: finished, running))
         else
           match Unix.waitpid [ Unix.WNOHANG ] child.pid with
@@ -3183,11 +3229,11 @@ let reap_children orchestrator =
               (child.issue_id :: finished, running)
           | _, Unix.WEXITED code ->
               refresh_child_output ~force:true orchestrator child;
-              mark_retrying orchestrator child.issue_id (Printf.sprintf "agent exited with code %d" code);
+              mark_child_failed orchestrator child (Printf.sprintf "agent exited with code %d" code);
               (child.issue_id :: finished, running)
           | _, Unix.WSIGNALED signal ->
               refresh_child_output ~force:true orchestrator child;
-              mark_retrying orchestrator child.issue_id (Printf.sprintf "agent signaled %d" signal);
+              mark_child_failed orchestrator child (Printf.sprintf "agent signaled %d" signal);
               (child.issue_id :: finished, running)
           | _, Unix.WSTOPPED signal ->
               set_error orchestrator (Printf.sprintf "agent for %s stopped by signal %d" child.issue_id signal);

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -1784,6 +1784,7 @@ let make ?ordered_queue ?(launch : launch = shell_launch) ?(fetch = default_fetc
     state =
       Runtime_state.empty ~workspace_repository_name ~tracker_kind:tracker.kind ~status_order:(Config.project_status_order config)
         ?ordered_queue:(Option.map (load_ordered_queue_state config) ordered_queue)
+        ?compozy_progress:(Runtime_state.initial_compozy_progress config)
         ();
     children = [];
     retry_due = Hashtbl.create 16;

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -693,12 +693,14 @@ let worktree_branch path =
   else None
 
 let issue_branch_key issue =
-  let digits =
-    issue.Issue.identifier |> String.to_seq
-    |> Seq.filter (function '0' .. '9' -> true | _ -> false)
-    |> String.of_seq
-  in
-  if digits <> "" then digits else Workspace.sanitize issue.id
+  if Util.starts_with ~prefix:"compozy:" issue.Issue.identifier then Workspace.sanitize issue.Issue.identifier
+  else
+    let digits =
+      issue.Issue.identifier |> String.to_seq
+      |> Seq.filter (function '0' .. '9' -> true | _ -> false)
+      |> String.of_seq
+    in
+    if digits <> "" then digits else Workspace.sanitize issue.id
 
 let task_branch config issue = config.Config.git.task_branch_prefix ^ issue_branch_key issue
 

--- a/apps/backend/lib/orchestrator.ml
+++ b/apps/backend/lib/orchestrator.ml
@@ -1813,6 +1813,43 @@ let set_state orchestrator state =
 
 let update_state orchestrator f = set_state orchestrator (f orchestrator.state)
 
+let is_compozy_prd_run_child orchestrator issue =
+  orchestrator.tracker.kind = "compozy_tasks" && Util.starts_with ~prefix:"compozy:" issue.Issue.identifier
+
+let compozy_workspace_root config (workspace : Workspace.t) =
+  let repository_root = Unix.realpath config.Config.repository_root in
+  let compozy_root = Unix.realpath config.Config.tracker.compozy_root in
+  let prefix = repository_root ^ Filename.dir_sep in
+  let relative =
+    match Util.drop_prefix ~prefix compozy_root with
+    | Some relative -> relative
+    | None -> Filename.basename compozy_root
+  in
+  Filename.concat workspace.path relative
+
+let compozy_prd_run_for_workspace_issue config workspace issue =
+  let compozy_root = compozy_workspace_root config workspace in
+  match Compozy_tasks_tracker.discover_prd_runs ~compozy_root with
+  | Error error -> Error error
+  | Ok runs -> (
+      match List.find_opt (fun (run : Compozy_tasks_tracker.prd_run) -> run.id = issue.Issue.identifier) runs with
+      | Some run -> Ok run
+      | None -> Error (Printf.sprintf "Compozy PRD run not found for %s" issue.Issue.identifier))
+
+let update_compozy_workspace_step_status config workspace (run : Compozy_tasks_tracker.prd_run)
+    (step : Compozy_tasks_tracker.task_step) status =
+  let compozy_root = compozy_workspace_root config workspace in
+  match status with
+  | "in_progress" -> Compozy_tasks_tracker.mark_step_started ~compozy_root run step
+  | "completed" -> Compozy_tasks_tracker.mark_step_finished ~compozy_root run step
+  | status ->
+      let path = Filename.concat (Filename.concat compozy_root run.slug) step.file in
+      Compozy_tasks_tracker.update_status ~compozy_root path status
+
+let update_compozy_progress orchestrator run =
+  update_state orchestrator (fun state ->
+    { state with Runtime_state.compozy_progress = Some (Runtime_state.compozy_progress_of_prd_run run) })
+
 let update_ordered_queue_entries orchestrator ?completed_identifier ?pending_identifier ?skipped ?(skip_missing = false) ~candidates
     () =
   match orchestrator.state.Runtime_state.ordered_queue with
@@ -2693,91 +2730,115 @@ let dispatch_issue orchestrator issue =
         let attempt = Hashtbl.find_opt orchestrator.attempts issue.id in
         let rendered = Prompt.render ~issue ~attempt orchestrator.prompt_template in
         let previous_attempt_output = Hashtbl.find_opt orchestrator.previous_attempt_outputs issue.id in
-        let composition =
-          compose_prompt_result ?stage ?previous_attempt_output orchestrator.config issue attempt rendered ~workspace
-            ~loop_start_branch:(Some orchestrator.loop_start_branch)
+        let composition_result =
+          if is_compozy_prd_run_child orchestrator issue then
+            match compozy_prd_run_for_workspace_issue orchestrator.config workspace issue with
+            | Error _ as error -> error
+            | Ok run -> (
+                match run.current_step with
+                | None -> Error (Printf.sprintf "no runnable Compozy task step for %s" run.id)
+                | Some step -> (
+                    match update_compozy_workspace_step_status orchestrator.config workspace run step "in_progress" with
+                    | Error _ as error -> error
+                    | Ok () -> (
+                        match compozy_prd_run_for_workspace_issue orchestrator.config workspace issue with
+                        | Error _ as error -> error
+                        | Ok run ->
+                            update_compozy_progress orchestrator run;
+                            compose_compozy_task_step_prompt_result ?stage ?previous_attempt_output orchestrator.config run
+                              attempt ~workspace ~loop_start_branch:(Some orchestrator.loop_start_branch))))
+          else
+            Ok
+              (compose_prompt_result ?stage ?previous_attempt_output orchestrator.config issue attempt rendered ~workspace
+                 ~loop_start_branch:(Some orchestrator.loop_start_branch))
         in
-        let context_diagnostic_result =
-          match (composition.context_diagnostics, stage) with
-          | Some diagnostics, Some stage -> (
-              try Ok (Some (persist_context_generation_diagnostics orchestrator.config issue stage attempt diagnostics))
-              with exn -> Error ("Context Diagnostics persistence failed: " ^ Printexc.to_string exn))
-          | _ -> Ok None
-        in
-        let context_diagnostic_summary, context_diagnostic_error =
-          match context_diagnostic_result with Ok summary -> (summary, None) | Error error -> (None, Some error)
-        in
-        let context_status =
-          match context_diagnostic_summary with
-          | Some summary -> { composition.context_status with Runtime_state.diagnostics_path = Some summary.diagnostic_path }
-          | None -> composition.context_status
-        in
-        let prompt = composition.prompt in
-        let harness =
-          Option.value (Config.selected_agent_harness orchestrator.config stage)
-            ~default:(Config.default_agent_harness orchestrator.config)
-        in
-        let launched = orchestrator.launch ~stage ~config:orchestrator.config ~workspace ~prompt ~issue in
-        let now = Util.now_iso8601 () in
-        let stage_agent, stage_states = selected_stage_fields stage in
-        let row =
-          {
-            Runtime_state.issue;
-            stage_agent;
-            harness_name = Some harness.name;
-            harness_kind = Some harness.kind;
-            stage_states;
-            session_id = launched.session_id;
-            turn_count = 0;
-            last_event = Some launched.event;
-            last_message = None;
-            started_at = now;
-            last_event_at = Some now;
-            tokens = runtime_tokens;
-            goal_usage = None;
-          }
-        in
-        Hashtbl.remove orchestrator.retry_due issue.id;
-        Hashtbl.remove orchestrator.previous_attempt_outputs issue.id;
-        update_state orchestrator (fun state ->
-          {
-            state with
-            issues = List.map (fun candidate -> if candidate.Issue.id = issue.id then issue else candidate) state.issues;
-            running = row :: state.running;
-            retrying = List.filter (fun (retry : Runtime_state.retrying) -> retry.issue_id <> issue.id) state.retrying;
-            issue_errors =
-              List.filter (fun (issue_error : Runtime_state.issue_error) -> issue_error.issue_id <> issue.id) state.issue_errors;
-            context_diagnostics =
-              (match context_diagnostic_summary with
-              | Some summary -> append_context_diagnostic_summary state.context_diagnostics summary
-              | None -> state.context_diagnostics);
-            last_error = context_diagnostic_error;
-          }
-          |> Runtime_state.set_context_status issue.id context_status);
-        update_ordered_queue_entries orchestrator ~candidates:[ issue ] ();
-        (match launched.pid with
-        | Some pid ->
-            let now_float = Unix.time () in
-            orchestrator.children <-
+        match composition_result with
+        | Error error ->
+            set_error orchestrator error;
+            render_dispatch_retrying issue.identifier 0 error;
+            ignore (move_issue_status orchestrator issue orchestrator.config.git.merge_attention_status)
+        | Ok composition ->
+            let context_diagnostic_result =
+              match (composition.context_diagnostics, stage) with
+              | Some diagnostics, Some stage -> (
+                  try Ok (Some (persist_context_generation_diagnostics orchestrator.config issue stage attempt diagnostics))
+                  with exn -> Error ("Context Diagnostics persistence failed: " ^ Printexc.to_string exn))
+              | _ -> Ok None
+            in
+            let context_diagnostic_summary, context_diagnostic_error =
+              match context_diagnostic_result with Ok summary -> (summary, None) | Error error -> (None, Some error)
+            in
+            let context_status =
+              match context_diagnostic_summary with
+              | Some summary -> { composition.context_status with Runtime_state.diagnostics_path = Some summary.diagnostic_path }
+              | None -> composition.context_status
+            in
+            let prompt = composition.prompt in
+            let harness =
+              Option.value (Config.selected_agent_harness orchestrator.config stage)
+                ~default:(Config.default_agent_harness orchestrator.config)
+            in
+            let launched = orchestrator.launch ~stage ~config:orchestrator.config ~workspace ~prompt ~issue in
+            let now = Util.now_iso8601 () in
+            let stage_agent, stage_states = selected_stage_fields stage in
+            let row =
               {
-                pid;
-                issue;
-                stage;
-                harness;
-                issue_id = issue.id;
-                issue_identifier = issue.identifier;
-                issue_title = issue.title;
-                workspace;
-                started_at = now_float;
-                last_output_at = now_float;
-                stdout_path = launched.stdout_path;
-                stderr_path = launched.stderr_path;
-                stdout_size = file_size launched.stdout_path;
-                stderr_size = file_size launched.stderr_path;
+                Runtime_state.issue;
+                stage_agent;
+                harness_name = Some harness.name;
+                harness_kind = Some harness.kind;
+                stage_states;
+                session_id = launched.session_id;
+                turn_count = 0;
+                last_event = Some launched.event;
+                last_message = None;
+                started_at = now;
+                last_event_at = Some now;
+                tokens = runtime_tokens;
+                goal_usage = None;
               }
-              :: orchestrator.children
-        | None -> ());
-        render_dispatch_started issue)
+            in
+            Hashtbl.remove orchestrator.retry_due issue.id;
+            Hashtbl.remove orchestrator.previous_attempt_outputs issue.id;
+            update_state orchestrator (fun state ->
+              {
+                state with
+                issues = List.map (fun candidate -> if candidate.Issue.id = issue.id then issue else candidate) state.issues;
+                running = row :: state.running;
+                retrying = List.filter (fun (retry : Runtime_state.retrying) -> retry.issue_id <> issue.id) state.retrying;
+                issue_errors =
+                  List.filter (fun (issue_error : Runtime_state.issue_error) -> issue_error.issue_id <> issue.id) state.issue_errors;
+                context_diagnostics =
+                  (match context_diagnostic_summary with
+                  | Some summary -> append_context_diagnostic_summary state.context_diagnostics summary
+                  | None -> state.context_diagnostics);
+                last_error = context_diagnostic_error;
+              }
+              |> Runtime_state.set_context_status issue.id context_status);
+            update_ordered_queue_entries orchestrator ~candidates:[ issue ] ();
+            (match launched.pid with
+            | Some pid ->
+                let now_float = Unix.time () in
+                orchestrator.children <-
+                  {
+                    pid;
+                    issue;
+                    stage;
+                    harness;
+                    issue_id = issue.id;
+                    issue_identifier = issue.identifier;
+                    issue_title = issue.title;
+                    workspace;
+                    started_at = now_float;
+                    last_output_at = now_float;
+                    stdout_path = launched.stdout_path;
+                    stderr_path = launched.stderr_path;
+                    stdout_size = file_size launched.stdout_path;
+                    stderr_size = file_size launched.stderr_path;
+                  }
+                  :: orchestrator.children
+            | None -> ());
+            render_dispatch_started issue)
 
 let mark_retrying orchestrator issue_id error =
   match List.find_opt (fun (row : Runtime_state.running) -> row.issue.id = issue_id) orchestrator.state.running with
@@ -2961,45 +3022,79 @@ let mark_merge_attention orchestrator child error =
     |> Runtime_state.clear_context_status child.issue_id);
   update_ordered_queue_entries orchestrator ~skipped:(child.issue_identifier, error) ~candidates:[ child.issue ] ()
 
+type compozy_completion =
+  | Not_compozy_child
+  | Compozy_final_step
+  | Compozy_next_step of Compozy_tasks_tracker.prd_run
+
+let complete_compozy_task_step orchestrator child =
+  if not (is_compozy_prd_run_child orchestrator child.issue) then Ok Not_compozy_child
+  else
+    match compozy_prd_run_for_workspace_issue orchestrator.config child.workspace child.issue with
+    | Error _ as error -> error
+    | Ok run -> (
+        match run.current_step with
+        | None -> Error (Printf.sprintf "no runnable Compozy task step for %s" run.id)
+        | Some step -> (
+            match update_compozy_workspace_step_status orchestrator.config child.workspace run step "completed" with
+            | Error _ as error -> error
+            | Ok () -> (
+                match compozy_prd_run_for_workspace_issue orchestrator.config child.workspace child.issue with
+                | Error _ as error -> error
+                | Ok updated_run ->
+                    update_compozy_progress orchestrator updated_run;
+                    match updated_run.current_step with
+                    | Some _ -> Ok (Compozy_next_step updated_run)
+                    | None -> Ok Compozy_final_step)))
+
 let mark_completed orchestrator child =
   let issue_id = child.issue_id in
   let stage = match child.stage with Some _ -> child.stage | None -> stage_for_issue orchestrator.config child.issue in
   let next_status = success_status ?stage orchestrator child.issue in
-  match orchestrator.commit_stage orchestrator.config child.workspace child.issue stage next_status with
+  match complete_compozy_task_step orchestrator child with
   | Error error ->
       render_commit_failed child.issue_identifier error;
-      if human_attention_completion_error error then mark_merge_attention orchestrator child error
-      else if non_retryable_completion_error error then (
-        set_error orchestrator error;
-        mark_blocked orchestrator issue_id error)
-      else mark_retrying orchestrator issue_id error
-  | Ok () ->
-      let status_moved_before_merge =
-        match next_status with
-        | Some status when task_pull_request_before_auto_merge orchestrator status ->
-            if move_issue_status orchestrator child.issue status then (
-              attempt_task_pull_request orchestrator child.issue;
-              Some true)
-            else (
-              mark_retrying orchestrator issue_id (Printf.sprintf "could not move issue to %s" status);
-              None)
-        | _ -> Some false
-      in
-      (match status_moved_before_merge with
-      | None -> ()
-      | Some status_moved_before_merge -> (
-          match auto_merge_child orchestrator child with
-          | Error error -> mark_merge_attention orchestrator child error
-          | Ok () -> (
-              match next_status with
-              | None -> complete_child orchestrator child
-              | Some status ->
-                  if status_moved_before_merge then complete_child ~next_status:status orchestrator child
-                  else if not (move_issue_status orchestrator child.issue status) then
-                    mark_retrying orchestrator issue_id (Printf.sprintf "could not move issue to %s" status)
-                  else (
-                    maybe_open_review_pull_request orchestrator child.issue status;
-                    complete_child ~next_status:status orchestrator child))))
+      mark_retrying orchestrator issue_id error
+  | Ok (Compozy_next_step run) ->
+      let next_issue = Compozy_tasks_tracker.issue_of_prd_run run in
+      complete_child ~next_status:run.state orchestrator child;
+      dispatch_issue orchestrator next_issue
+  | Ok (Not_compozy_child | Compozy_final_step) -> (
+      match orchestrator.commit_stage orchestrator.config child.workspace child.issue stage next_status with
+      | Error error ->
+          render_commit_failed child.issue_identifier error;
+          if human_attention_completion_error error then mark_merge_attention orchestrator child error
+          else if non_retryable_completion_error error then (
+            set_error orchestrator error;
+            mark_blocked orchestrator issue_id error)
+          else mark_retrying orchestrator issue_id error
+      | Ok () ->
+          let status_moved_before_merge =
+            match next_status with
+            | Some status when task_pull_request_before_auto_merge orchestrator status ->
+                if move_issue_status orchestrator child.issue status then (
+                  attempt_task_pull_request orchestrator child.issue;
+                  Some true)
+                else (
+                  mark_retrying orchestrator issue_id (Printf.sprintf "could not move issue to %s" status);
+                  None)
+            | _ -> Some false
+          in
+          match status_moved_before_merge with
+          | None -> ()
+          | Some status_moved_before_merge -> (
+              match auto_merge_child orchestrator child with
+              | Error error -> mark_merge_attention orchestrator child error
+              | Ok () -> (
+                  match next_status with
+                  | None -> complete_child orchestrator child
+                  | Some status ->
+                      if status_moved_before_merge then complete_child ~next_status:status orchestrator child
+                      else if not (move_issue_status orchestrator child.issue status) then
+                        mark_retrying orchestrator issue_id (Printf.sprintf "could not move issue to %s" status)
+                      else (
+                        maybe_open_review_pull_request orchestrator child.issue status;
+                        complete_child ~next_status:status orchestrator child))))
 
 let signal_child child signal =
   try Unix.kill (-child.pid) signal

--- a/apps/backend/lib/ordered_queue.ml
+++ b/apps/backend/lib/ordered_queue.ml
@@ -11,9 +11,35 @@ let digits_only text =
          | _ -> false)
        text
 
+let normalize_compozy_entry value =
+  match Util.drop_prefix ~prefix:"compozy:" value with
+  | Some task_name ->
+      let task_name = Util.trim task_name in
+      if task_name = "" then
+        Error
+          {
+            value;
+            reason = "expected a Compozy PRD-run identifier like compozy:example-feature";
+          }
+      else if String.contains task_name '/' || String.contains task_name ':' then
+        Error
+          {
+            value;
+            reason =
+              "expected a Compozy PRD-run identifier like compozy:example-feature without path separators";
+          }
+      else Ok { issue_identifier = "compozy:" ^ task_name }
+  | None ->
+      Error
+        {
+          value;
+          reason = "expected a Compozy PRD-run identifier like compozy:example-feature";
+        }
+
 let normalize_entry raw =
   let value = Util.trim raw in
   if value = "" then Error { value; reason = "empty queue entry" }
+  else if Util.starts_with ~prefix:"compozy:" value then normalize_compozy_entry value
   else if String.contains value '/' || String.contains value ':' then
     Error { value; reason = "issue URLs and cross-repository references are not supported" }
   else
@@ -38,7 +64,8 @@ let normalize_entry raw =
             Error
               {
                 value;
-                reason = "expected a numeric issue identifier with optional # or a minibeads identifier like mb-20";
+                reason =
+                  "expected a numeric issue identifier with optional #, a minibeads identifier like mb-20, or a Compozy identifier like compozy:example-feature";
               }
 
 let parse text =

--- a/apps/backend/lib/runtime_readiness.ml
+++ b/apps/backend/lib/runtime_readiness.ml
@@ -1,0 +1,66 @@
+let queue_parse_gaps = function
+  | [] -> []
+  | problems ->
+      problems
+      |> List.map (fun (problem : Ordered_queue.parse_problem) ->
+             {
+               Config.requirement = "orderedQueue." ^ (if problem.value = "" then "<empty>" else problem.value);
+               remediation = problem.reason;
+             })
+
+let queue_validation_gaps config queue =
+  let tracker = Issue_tracker.make config in
+  Ordered_queue.validation_gaps tracker queue
+  |> List.map (fun (gap : Ordered_queue.validation_gap) ->
+         { Config.requirement = gap.requirement; remediation = gap.remediation })
+
+let config_gap_of_runtime_gap (gap : Runtime_state.readiness_gap) =
+  { Config.requirement = gap.requirement; remediation = gap.remediation }
+
+let selected_tracker_readiness_gaps config =
+  try
+    let tracker = Issue_tracker.make config in
+    tracker.readiness_gaps () |> List.map config_gap_of_runtime_gap
+  with exn ->
+    [
+      {
+        Config.requirement = "tracker.adapter";
+        remediation = "Issue Tracker readiness failed: " ^ Printexc.to_string exn;
+      };
+    ]
+
+let state ?ordered_queue ?(queue_parse_problems = []) config =
+  let local_gaps = Config.readiness_gaps config in
+  let queue_gaps = queue_parse_gaps queue_parse_problems in
+  let gaps =
+    match local_gaps @ queue_gaps with
+    | [] -> (
+        let tracker_gaps = selected_tracker_readiness_gaps config in
+        match (tracker_gaps, ordered_queue) with
+        | [], Some queue -> (
+            try queue_validation_gaps config queue
+            with exn ->
+              [
+                {
+                  Config.requirement = "orderedQueue.validation";
+                  remediation = "Ordered Queue validation failed: " ^ Printexc.to_string exn;
+                };
+              ])
+        | gaps, _ -> gaps)
+    | gaps -> gaps
+  in
+  let last_error =
+    match gaps with
+    | [] -> None
+    | gap :: _ -> Some (gap.requirement ^ ": " ^ gap.remediation)
+  in
+  let readiness_gaps =
+    List.map
+      (fun (gap : Config.readiness_gap) ->
+        { Runtime_state.requirement = gap.requirement; remediation = gap.remediation })
+      gaps
+  in
+  Runtime_state.empty ?last_error ~tracker_kind:config.tracker.kind ~status_order:(Config.project_status_order config)
+    ?ordered_queue:(Option.map Orchestrator.ordered_queue_state ordered_queue)
+    ?compozy_progress:(Runtime_state.initial_compozy_progress config)
+    ~readiness_gaps ()

--- a/apps/backend/lib/runtime_startup.ml
+++ b/apps/backend/lib/runtime_startup.ml
@@ -41,5 +41,6 @@ let startup_completed_event ~mode ~config ~runtime_home =
     (match config.tracker.kind with
     | "github" -> Printf.sprintf "%s/%s" config.tracker.owner config.tracker.repo
     | "minibeads" -> config.tracker.minibeads_root
+    | "compozy_tasks" -> config.tracker.compozy_root
     | kind -> kind)
     config.tracker.project_number runtime_home config.workspace.root

--- a/apps/backend/lib/runtime_state.ml
+++ b/apps/backend/lib/runtime_state.ml
@@ -35,6 +35,15 @@ type ordered_queue_entry = {
   skip_reason : string option;
 }
 type ordered_queue = { entries : ordered_queue_entry list }
+type compozy_progress = {
+  run_id : string;
+  slug : string;
+  current_step : string option;
+  completed : int;
+  failed : int;
+  skipped : int;
+  total : int;
+}
 type startup_reconciliation = {
   issue_id : string option;
   issue_identifier : string option;
@@ -96,6 +105,7 @@ type t = {
   pull_request : pull_request_handoff option;
   pull_requests : pull_request_handoff list;
   ordered_queue : ordered_queue option;
+  compozy_progress : compozy_progress option;
   startup_reconciliation : startup_reconciliation list;
   task_branch_integrations : task_branch_integration list;
   context_diagnostics : context_diagnostic list;
@@ -103,7 +113,7 @@ type t = {
 }
 
 let empty ?workspace_repository_name ?(tracker_kind = "github") ?(readiness_gaps = []) ?(status_order = []) ?ordered_queue
-    ?last_error () =
+    ?compozy_progress ?last_error () =
   {
     workspace_repository_name;
     tracker_kind;
@@ -120,6 +130,7 @@ let empty ?workspace_repository_name ?(tracker_kind = "github") ?(readiness_gaps
     pull_request = None;
     pull_requests = [];
     ordered_queue;
+    compozy_progress;
     startup_reconciliation = [];
     task_branch_integrations = [];
     context_diagnostics = [];
@@ -243,6 +254,30 @@ let ordered_queue_entry_to_yojson (row : ordered_queue_entry) =
 let ordered_queue_to_yojson (row : ordered_queue) =
   `Assoc [ ("entries", `List (List.map ordered_queue_entry_to_yojson row.entries)) ]
 
+let compozy_progress_of_prd_run (run : Compozy_tasks_tracker.prd_run) =
+  let counts = run.counts in
+  {
+    run_id = run.id;
+    slug = run.slug;
+    current_step = Option.map (fun (step : Compozy_tasks_tracker.task_step) -> step.file) run.current_step;
+    completed = counts.completed;
+    failed = counts.failed;
+    skipped = counts.skipped;
+    total = counts.total;
+  }
+
+let compozy_progress_to_yojson (row : compozy_progress) =
+  `Assoc
+    [
+      ("run_id", `String row.run_id);
+      ("slug", `String row.slug);
+      ("current_step", (match row.current_step with Some step -> `String step | None -> `Null));
+      ("completed", `Int row.completed);
+      ("failed", `Int row.failed);
+      ("skipped", `Int row.skipped);
+      ("total", `Int row.total);
+    ]
+
 let startup_reconciliation_to_yojson (row : startup_reconciliation) =
   `Assoc
     [
@@ -275,6 +310,9 @@ let json_member name = function
 let json_string_member name json =
   match json_member name json with Some (`String value) when Util.trim value <> "" -> Some value | _ -> None
 
+let json_int_member name json =
+  match json_member name json with Some (`Int value) -> Some value | _ -> None
+
 let ordered_queue_entry_of_yojson json =
   match json_string_member "issue_identifier" json with
   | None -> None
@@ -291,6 +329,27 @@ let ordered_queue_of_yojson json =
   match json_member "entries" json with
   | Some (`List entries) -> Some { entries = List.filter_map ordered_queue_entry_of_yojson entries }
   | _ -> None
+
+let compozy_progress_of_yojson json =
+  match (json_string_member "run_id" json, json_string_member "slug" json) with
+  | Some run_id, Some slug ->
+      Some
+        {
+          run_id;
+          slug;
+          current_step = json_string_member "current_step" json;
+          completed = Option.value (json_int_member "completed" json) ~default:0;
+          failed = Option.value (json_int_member "failed" json) ~default:0;
+          skipped = Option.value (json_int_member "skipped" json) ~default:0;
+          total = Option.value (json_int_member "total" json) ~default:0;
+        }
+  | _ -> None
+
+let compozy_progress_from_snapshot_yojson json =
+  match json_member "compozy_progress" json with Some (`Assoc _ as progress) -> compozy_progress_of_yojson progress | _ -> None
+
+let tracker_kind_from_snapshot_yojson json =
+  Option.value (json_string_member "tracker_kind" json) ~default:"github"
 
 let pull_request_handoff_to_yojson row =
   `Assoc
@@ -347,6 +406,7 @@ let to_yojson state =
       ("pull_request", (match state.pull_request with Some row -> pull_request_handoff_to_yojson row | None -> `Null));
       ("pull_requests", `List (List.map pull_request_handoff_to_yojson state.pull_requests));
       ("ordered_queue", (match state.ordered_queue with Some row -> ordered_queue_to_yojson row | None -> `Null));
+      ("compozy_progress", (match state.compozy_progress with Some row -> compozy_progress_to_yojson row | None -> `Null));
       ("startup_reconciliation", `List (List.map startup_reconciliation_to_yojson state.startup_reconciliation));
       ("task_branch_integrations", `List (List.map task_branch_integration_to_yojson state.task_branch_integrations));
       ("context_diagnostics", `List (List.map context_diagnostic_to_yojson state.context_diagnostics));

--- a/apps/backend/lib/runtime_state.ml
+++ b/apps/backend/lib/runtime_state.ml
@@ -266,6 +266,20 @@ let compozy_progress_of_prd_run (run : Compozy_tasks_tracker.prd_run) =
     total = counts.total;
   }
 
+let initial_compozy_progress (config : Config.t) =
+  if config.tracker.kind <> "compozy_tasks" then None
+  else
+    match Compozy_tasks_tracker.discover_prd_runs ~compozy_root:config.tracker.compozy_root with
+    | Error _ -> None
+    | Ok [] -> None
+    | Ok runs ->
+        let selected =
+          match List.find_opt Compozy_tasks_tracker.runnable_prd_run runs with
+          | Some run -> Some run
+          | None -> List.find_opt (fun (_ : Compozy_tasks_tracker.prd_run) -> true) runs
+        in
+        Option.map compozy_progress_of_prd_run selected
+
 let compozy_progress_to_yojson (row : compozy_progress) =
   `Assoc
     [

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -1508,6 +1508,8 @@ let require_error label = function
   | Ok _ -> Alcotest.fail (label ^ ": expected error")
   | Error error -> error
 
+let option_exists predicate = function Some value -> predicate value | None -> false
+
 let write_compozy_task ?(status = "pending") ?(title = "Example task") ?(task_type = "backend")
     ?(complexity = "medium") ?(dependencies = []) ?(body = "\n# Task Body\n\nUser-authored content.\n") path =
   let dependency_lines =
@@ -1614,6 +1616,110 @@ let test_compozy_task_directory_parse_and_update_integration () =
           Alcotest.(check int) "updated retry" 1 first.retry_count;
           Alcotest.(check (option string)) "updated last error" (Some "retry succeeded") first.last_error
       | [] -> Alcotest.fail "expected parsed tasks")
+
+let test_compozy_prd_run_maps_directory_to_canonical_issue () =
+  with_temp_dir "symphony-compozy-prd-run-" (fun root ->
+      let prd_dir = Filename.concat root "example-feature" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task ~title:"First step" (Filename.concat prd_dir "task_01.md");
+      let run =
+        Compozy_tasks_tracker.prd_run_of_directory ~compozy_root:root prd_dir |> require_ok "build PRD run"
+      in
+      Alcotest.(check string) "canonical id" "compozy:example-feature" run.id;
+      Alcotest.(check string) "slug" "example-feature" run.slug;
+      Alcotest.(check string) "current step" "task_01.md"
+        (match run.current_step with Some step -> step.file | None -> "");
+      Alcotest.(check int) "total steps" 1 run.counts.total;
+      let issue = Compozy_tasks_tracker.issue_of_prd_run run in
+      Alcotest.(check string) "issue id" "compozy:example-feature" issue.id;
+      Alcotest.(check string) "issue identifier" "compozy:example-feature" issue.identifier;
+      Alcotest.(check string) "issue title" "Compozy PRD run: example-feature" issue.title)
+
+let test_compozy_prd_run_task_files_are_not_separate_issues () =
+  with_temp_dir "symphony-compozy-prd-single-issue-" (fun root ->
+      let prd_dir = Filename.concat root "single-issue" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task ~title:"First" (Filename.concat prd_dir "task_01.md");
+      write_compozy_task ~title:"Second" ~dependencies:[ "task_01" ] (Filename.concat prd_dir "task_02.md");
+      let runs = Compozy_tasks_tracker.discover_prd_runs ~compozy_root:root |> require_ok "discover PRD runs" in
+      let issues = List.map Compozy_tasks_tracker.issue_of_prd_run runs in
+      Alcotest.(check int) "one PRD run" 1 (List.length runs);
+      Alcotest.(check int) "one issue" 1 (List.length issues);
+      let run = match runs with [ run ] -> run | _ -> Alcotest.fail "expected one run" in
+      Alcotest.(check (list string)) "step files" [ "task_01.md"; "task_02.md" ]
+        (List.map (fun (step : Compozy_tasks_tracker.task_step) -> step.file) run.steps);
+      Alcotest.(check int) "aggregate total" 2 run.counts.total)
+
+let test_compozy_issue_branch_key_uses_identifier_not_digits_only () =
+  let issue = Issue.empty ~id:"compozy:feature-123" ~identifier:"compozy:feature-123" ~title:"Feature" ~state:"pending" in
+  let first = Orchestrator.issue_branch_key issue in
+  let second = Orchestrator.issue_branch_key issue in
+  Alcotest.(check string) "stable key" first second;
+  Alcotest.(check bool) "non-empty" true (first <> "");
+  Alcotest.(check bool) "not numeric extraction" true (first <> "123");
+  Alcotest.(check string) "sanitized full identifier" "compozy_feature-123" first
+
+let test_compozy_empty_prd_run_is_not_runnable () =
+  with_temp_dir "symphony-compozy-empty-prd-" (fun root ->
+      let prd_dir = Filename.concat root "empty-feature" in
+      Util.mkdir_p prd_dir;
+      let run =
+        Compozy_tasks_tracker.prd_run_of_directory ~compozy_root:root prd_dir |> require_ok "build empty PRD run"
+      in
+      Alcotest.(check string) "state" "not_runnable" run.state;
+      Alcotest.(check int) "total" 0 run.counts.total;
+      Alcotest.(check bool) "no current step" true (Option.is_none run.current_step);
+      Alcotest.(check bool) "reason" true
+        (option_exists (fun reason -> contains_substring reason "no Compozy task files") run.not_runnable_reason))
+
+let test_compozy_two_workflow_directories_have_distinct_ids () =
+  with_temp_dir "symphony-compozy-distinct-prds-" (fun root ->
+      let first = Filename.concat root "first-feature" in
+      let second = Filename.concat root "second-feature" in
+      Util.mkdir_p first;
+      Util.mkdir_p second;
+      write_compozy_task (Filename.concat first "task_01.md");
+      write_compozy_task (Filename.concat second "task_01.md");
+      let runs = Compozy_tasks_tracker.discover_prd_runs ~compozy_root:root |> require_ok "discover PRD runs" in
+      Alcotest.(check (list string)) "distinct ids"
+        [ "compozy:first-feature"; "compozy:second-feature" ]
+        (List.map (fun (run : Compozy_tasks_tracker.prd_run) -> run.id) runs))
+
+let test_compozy_duplicate_task_indexes_are_not_runnable () =
+  with_temp_dir "symphony-compozy-duplicate-index-" (fun root ->
+      let prd_dir = Filename.concat root "duplicate-feature" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task (Filename.concat prd_dir "task_01.md");
+      write_compozy_task (Filename.concat prd_dir "task_1.md");
+      let run =
+        Compozy_tasks_tracker.prd_run_of_directory ~compozy_root:root prd_dir |> require_ok "build duplicate PRD run"
+      in
+      Alcotest.(check string) "state" "not_runnable" run.state;
+      Alcotest.(check bool) "duplicate reason" true
+        (option_exists (fun reason -> contains_substring reason "duplicate Compozy task index") run.not_runnable_reason))
+
+let test_compozy_missing_root_discovers_no_prd_runs () =
+  with_temp_dir "symphony-compozy-missing-root-" (fun root ->
+      let missing_root = Filename.concat root ".compozy/tasks" in
+      let runs =
+        Compozy_tasks_tracker.discover_prd_runs ~compozy_root:missing_root |> require_ok "discover missing root"
+      in
+      Alcotest.(check int) "no candidates" 0 (List.length runs))
+
+let test_compozy_prd_run_discovery_integration_yields_issue_candidates () =
+  with_temp_dir "symphony-compozy-prd-discovery-" (fun root ->
+      let first = Filename.concat root "alpha-run" in
+      let second = Filename.concat root "beta-run" in
+      Util.mkdir_p first;
+      Util.mkdir_p second;
+      write_compozy_task (Filename.concat first "task_01.md");
+      write_compozy_task (Filename.concat second "task_01.md");
+      Util.write_file (Filename.concat root "notes.md") "# Not a PRD run\n";
+      let runs = Compozy_tasks_tracker.discover_prd_runs ~compozy_root:root |> require_ok "discover runs" in
+      let issues = List.map Compozy_tasks_tracker.issue_of_prd_run runs in
+      Alcotest.(check (list string)) "issue candidates"
+        [ "compozy:alpha-run"; "compozy:beta-run" ]
+        (List.map (fun (issue : Issue.t) -> issue.identifier) issues))
 
 let test_invalid_tracker_kind () =
   with_temp_dir "symphony-settings-invalid-tracker-" (fun root ->
@@ -9910,6 +10016,22 @@ let () =
             test_compozy_task_rejects_paths_outside_root;
           Alcotest.test_case "parses and updates Compozy task directories" `Quick
             test_compozy_task_directory_parse_and_update_integration;
+          Alcotest.test_case "maps Compozy PRD run to canonical issue" `Quick
+            test_compozy_prd_run_maps_directory_to_canonical_issue;
+          Alcotest.test_case "keeps Compozy task files under one issue" `Quick
+            test_compozy_prd_run_task_files_are_not_separate_issues;
+          Alcotest.test_case "uses Compozy-safe branch keys" `Quick
+            test_compozy_issue_branch_key_uses_identifier_not_digits_only;
+          Alcotest.test_case "reports empty Compozy PRD run as not runnable" `Quick
+            test_compozy_empty_prd_run_is_not_runnable;
+          Alcotest.test_case "discovers distinct Compozy PRD directories" `Quick
+            test_compozy_two_workflow_directories_have_distinct_ids;
+          Alcotest.test_case "reports duplicate Compozy task indexes as not runnable" `Quick
+            test_compozy_duplicate_task_indexes_are_not_runnable;
+          Alcotest.test_case "handles missing Compozy root as no candidates" `Quick
+            test_compozy_missing_root_discovers_no_prd_runs;
+          Alcotest.test_case "discovers Compozy PRD issue candidates from fixtures" `Quick
+            test_compozy_prd_run_discovery_integration_yields_issue_candidates;
           Alcotest.test_case "rejects unsupported tracker kind" `Quick test_invalid_tracker_kind;
           Alcotest.test_case "keeps github readiness gaps" `Quick
             test_github_tracker_readiness_keeps_github_gaps;

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -7214,6 +7214,93 @@ let test_compozy_failed_step_retries_then_advances_to_next_step () =
       Alcotest.(check bool) "next prompt includes second task" true
         (contains_substring third_prompt "Second advance sentinel."))
 
+let test_compozy_dispatch_preserves_external_root_path () =
+  with_temp_dir "symphony-compozy-external-repo-" (fun root ->
+      with_temp_dir "symphony-compozy-external-root-" (fun external_root ->
+          init_repo root "feature/start";
+          let compozy_root = Filename.concat external_root "tasks" in
+          let prd_dir = Filename.concat compozy_root "external-feature" in
+          Util.mkdir_p prd_dir;
+          let task_01 = Filename.concat prd_dir "task_01.md" in
+          write_compozy_task ~title:"External step" ~body:"\n# External\n\nExternal root sentinel.\n" task_01;
+          let config = compozy_test_config root compozy_root in
+          let launches = ref [] in
+          let launch ~stage:_ ~config:_ ~(workspace : Workspace.t) ~prompt ~issue =
+            launches := (issue, workspace, prompt) :: !launches;
+            {
+              Orchestrator.pid = None;
+              session_id = Some (string_of_int (List.length !launches));
+              event = "test-launch";
+              stdout_path = None;
+              stderr_path = None;
+            }
+          in
+          let orchestrator =
+            Orchestrator.make ~launch ~config ~prompt_template:"Compozy {{ issue.identifier }}" ()
+          in
+          Orchestrator.poll_once orchestrator;
+          let _issue, workspace, prompt =
+            match List.rev !launches with
+            | [ launch ] -> launch
+            | _ -> Alcotest.fail "expected Compozy launch from external root"
+          in
+          Alcotest.(check bool) "prompt includes external task" true
+            (contains_substring prompt "External root sentinel.");
+          Alcotest.(check string) "external task started" "in_progress" (compozy_task_status compozy_root task_01);
+          let rewritten_root = Filename.concat workspace.Workspace.path (Filename.basename compozy_root) in
+          Alcotest.(check bool) "does not rewrite external root into worktree" false (Sys.file_exists rewritten_root)))
+
+let test_compozy_final_step_commit_failure_keeps_step_runnable () =
+  with_temp_dir "symphony-compozy-final-retry-" (fun root ->
+      init_repo root "feature/start";
+      let compozy_root = Filename.concat (Filename.concat root ".compozy") "tasks" in
+      let prd_dir = Filename.concat compozy_root "final-retry-feature" in
+      Util.mkdir_p prd_dir;
+      let task_01 = Filename.concat prd_dir "task_01.md" in
+      write_compozy_task ~title:"Final step" ~body:"\n# Final\n\nFinal retry sentinel.\n" task_01;
+      ignore (run_ok ~cwd:root "commit Compozy task" "git add .compozy && git commit -q -m compozy-task");
+      let base_config = compozy_test_config root compozy_root in
+      let config = { base_config with Config.agent = { base_config.agent with max_retry_backoff_ms = 0 } } in
+      let launches = ref [] in
+      let launch ~stage:_ ~config:_ ~(workspace : Workspace.t) ~prompt ~issue =
+        launches := (issue, workspace, prompt) :: !launches;
+        {
+          Orchestrator.pid = None;
+          session_id = Some (string_of_int (List.length !launches));
+          event = "test-launch";
+          stdout_path = None;
+          stderr_path = None;
+        }
+      in
+      let commit_calls = ref 0 in
+      let commit_stage _config _workspace _issue _stage _next_status =
+        incr commit_calls;
+        Error "stage push failed: transient remote error"
+      in
+      let orchestrator =
+        Orchestrator.make ~launch ~commit_stage ~config ~prompt_template:"Compozy {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      let first_issue, first_workspace, first_prompt =
+        match List.rev !launches with
+        | [ launch ] -> launch
+        | _ -> Alcotest.fail "expected initial Compozy launch"
+      in
+      let workspace_compozy_root = Filename.concat (Filename.concat first_workspace.path ".compozy") "tasks" in
+      let workspace_task_01 = Filename.concat (Filename.concat workspace_compozy_root "final-retry-feature") "task_01.md" in
+      Alcotest.(check bool) "prompt includes final task" true (contains_substring first_prompt "Final retry sentinel.");
+      Orchestrator.mark_completed orchestrator (compozy_child first_issue first_workspace);
+      Alcotest.(check int) "commit attempted" 1 !commit_calls;
+      Alcotest.(check string) "final task restored for retry" "in_progress"
+        (compozy_task_status workspace_compozy_root workspace_task_01);
+      let state = Orchestrator.get_state orchestrator in
+      Alcotest.(check int) "retry queued" 1 (List.length state.Runtime_state.retrying);
+      (match state.Runtime_state.compozy_progress with
+      | Some progress ->
+          Alcotest.(check (option string)) "runtime current step restored" (Some "task_01.md") progress.current_step;
+          Alcotest.(check int) "runtime completed count restored" 0 progress.completed
+      | None -> Alcotest.fail "expected Compozy progress after final commit failure"))
+
 let stage_context_command ?(cwd = "agentWorktree") ?(timeout_ms = 1000) ?(max_output_bytes = 4096) argv =
   { Config.argv; cwd; timeout_ms; max_output_bytes; validation_error = None }
 
@@ -11022,6 +11109,10 @@ let () =
             test_compozy_completion_relaunches_next_step_in_same_worktree;
           Alcotest.test_case "retries failed Compozy task step then advances" `Quick
             test_compozy_failed_step_retries_then_advances_to_next_step;
+          Alcotest.test_case "dispatch preserves external Compozy root path" `Quick
+            test_compozy_dispatch_preserves_external_root_path;
+          Alcotest.test_case "keeps final Compozy step runnable after commit failure" `Quick
+            test_compozy_final_step_commit_failure_keeps_step_runnable;
           Alcotest.test_case "skips stage goal handoff when disabled" `Quick test_orchestrator_skips_stage_goal_when_disabled;
           Alcotest.test_case "runs stage context command before launch" `Quick
             test_orchestrator_runs_stage_context_command_before_launch;

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -3410,7 +3410,54 @@ let test_runtime_state_exposes_tracker_kind () =
   let default_json = Runtime_state.empty () |> Runtime_state.to_yojson in
   Alcotest.(check string) "default tracker kind" "github" (default_json |> member "tracker_kind" |> to_string);
   let local_json = Runtime_state.empty ~tracker_kind:"minibeads" () |> Runtime_state.to_yojson in
-  Alcotest.(check string) "selected tracker kind" "minibeads" (local_json |> member "tracker_kind" |> to_string)
+  Alcotest.(check string) "selected tracker kind" "minibeads" (local_json |> member "tracker_kind" |> to_string);
+  let compozy_json = Runtime_state.empty ~tracker_kind:"compozy_tasks" () |> Runtime_state.to_yojson in
+  Alcotest.(check string) "Compozy tracker kind" "compozy_tasks" (compozy_json |> member "tracker_kind" |> to_string)
+
+let test_runtime_state_absent_compozy_progress_is_compatible () =
+  let open Yojson.Safe.Util in
+  let json = Runtime_state.empty () |> Runtime_state.to_yojson in
+  let progress_is_null = match json |> member "compozy_progress" with `Null -> true | _ -> false in
+  Alcotest.(check bool) "empty state has no progress payload" true progress_is_null;
+  let older_snapshot = `Assoc [ ("counts", `Assoc [ ("running", `Int 0); ("retrying", `Int 0) ]) ] in
+  Alcotest.(check string) "older snapshot tracker default" "github"
+    (Runtime_state.tracker_kind_from_snapshot_yojson older_snapshot);
+  Alcotest.(check bool) "older snapshot progress absent" true
+    (Option.is_none (Runtime_state.compozy_progress_from_snapshot_yojson older_snapshot))
+
+let test_runtime_state_exposes_compozy_progress () =
+  with_temp_dir "symphony-compozy-progress-" (fun root ->
+      let compozy_root = Filename.concat root ".compozy/tasks" in
+      let prd_dir = Filename.concat compozy_root "compozy-tasks-run-integration" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task ~status:"completed" ~title:"Done" (Filename.concat prd_dir "task_01.md");
+      write_compozy_task ~status:"in_progress" ~title:"Running" (Filename.concat prd_dir "task_02.md");
+      write_compozy_task ~status:"failed" ~title:"Failed" (Filename.concat prd_dir "task_03.md");
+      write_compozy_task ~status:"skipped" ~title:"Skipped" (Filename.concat prd_dir "task_04.md");
+      write_compozy_task ~status:"pending" ~title:"Pending" (Filename.concat prd_dir "task_05.md");
+      let run =
+        match Compozy_tasks_tracker.prd_run_of_directory ~compozy_root prd_dir with
+        | Ok run -> run
+        | Error error -> Alcotest.fail error
+      in
+      let progress = Runtime_state.compozy_progress_of_prd_run run in
+      let json = Runtime_state.empty ~tracker_kind:"compozy_tasks" ~compozy_progress:progress () |> Runtime_state.to_yojson in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "tracker kind" "compozy_tasks" (json |> member "tracker_kind" |> to_string);
+      let payload = json |> member "compozy_progress" in
+      Alcotest.(check string) "run id" "compozy:compozy-tasks-run-integration" (payload |> member "run_id" |> to_string);
+      Alcotest.(check string) "slug" "compozy-tasks-run-integration" (payload |> member "slug" |> to_string);
+      Alcotest.(check string) "current step" "task_02.md" (payload |> member "current_step" |> to_string);
+      Alcotest.(check int) "completed" 1 (payload |> member "completed" |> to_int);
+      Alcotest.(check int) "failed" 1 (payload |> member "failed" |> to_int);
+      Alcotest.(check int) "skipped" 1 (payload |> member "skipped" |> to_int);
+      Alcotest.(check int) "total" 5 (payload |> member "total" |> to_int);
+      match Runtime_state.compozy_progress_from_snapshot_yojson json with
+      | Some parsed ->
+          Alcotest.(check string) "parsed run id" progress.run_id parsed.Runtime_state.run_id;
+          Alcotest.(check (option string)) "parsed current step" (Some "task_02.md") parsed.current_step;
+          Alcotest.(check int) "parsed total" 5 parsed.total
+      | None -> Alcotest.fail "expected parsed Compozy progress")
 
 let test_ordered_queue_parses_cli_identifiers () =
   match Ordered_queue.parse "19,#22,mb-20" with
@@ -3877,6 +3924,33 @@ let test_websocket_readiness_snapshot_and_http_state () =
   let open Yojson.Safe.Util in
   let json = Yojson.Safe.from_string body in
   Alcotest.(check string) "http tracker kind" "minibeads" (json |> member "tracker_kind" |> to_string)
+
+let test_http_state_can_include_compozy_progress () =
+  let progress =
+    {
+      Runtime_state.run_id = "compozy:compozy-tasks-run-integration";
+      slug = "compozy-tasks-run-integration";
+      current_step = Some "task_02.md";
+      completed = 1;
+      failed = 0;
+      skipped = 0;
+      total = 8;
+    }
+  in
+  let state = Runtime_state.empty ~tracker_kind:"compozy_tasks" ~compozy_progress:progress () in
+  let http =
+    Server.handle_request (fun () -> state)
+      { Server.request_line = "GET /api/v1/state HTTP/1.1"; path = "/api/v1/state"; headers = [] }
+  in
+  let body = match List.rev (String.split_on_char '\n' http) with body :: _ -> body | [] -> "" in
+  let open Yojson.Safe.Util in
+  let json = Yojson.Safe.from_string body in
+  Alcotest.(check int) "running count required field" 0 (json |> member "counts" |> member "running" |> to_int);
+  Alcotest.(check string) "tracker kind" "compozy_tasks" (json |> member "tracker_kind" |> to_string);
+  let payload = json |> member "compozy_progress" in
+  Alcotest.(check string) "run id" progress.run_id (payload |> member "run_id" |> to_string);
+  Alcotest.(check string) "current step" "task_02.md" (payload |> member "current_step" |> to_string);
+  Alcotest.(check int) "total" 8 (payload |> member "total" |> to_int)
 
 let test_websocket_context_status_snapshot_and_http_state () =
   let issue = Issue.empty ~id:"I1" ~identifier:"#1" ~title:"Context status" ~state:"Todo" in
@@ -10223,6 +10297,9 @@ let () =
         [
           Alcotest.test_case "exposes running issue details" `Quick test_runtime_state_exposes_running_issue_details;
           Alcotest.test_case "exposes tracker kind" `Quick test_runtime_state_exposes_tracker_kind;
+          Alcotest.test_case "accepts absent Compozy progress" `Quick
+            test_runtime_state_absent_compozy_progress_is_compatible;
+          Alcotest.test_case "exposes Compozy progress" `Quick test_runtime_state_exposes_compozy_progress;
           Alcotest.test_case "parses ordered queue identifiers" `Quick test_ordered_queue_parses_cli_identifiers;
           Alcotest.test_case "validates ordered queue through selected tracker" `Quick
             test_ordered_queue_validation_uses_selected_tracker;
@@ -10236,6 +10313,7 @@ let () =
           Alcotest.test_case "handles websocket upgrade and initial snapshot" `Quick test_websocket_accept_and_initial_snapshot;
           Alcotest.test_case "broadcasts after state change" `Quick test_websocket_broadcast_after_state_change;
           Alcotest.test_case "serves readiness live snapshot and diagnostic state" `Quick test_websocket_readiness_snapshot_and_http_state;
+          Alcotest.test_case "serves Compozy progress in HTTP state" `Quick test_http_state_can_include_compozy_progress;
           Alcotest.test_case "serves context status live snapshot and HTTP state" `Quick
             test_websocket_context_status_snapshot_and_http_state;
         ] );

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -6819,6 +6819,156 @@ let test_orchestrator_wraps_compozy_task_step_prompt_without_github_prompt_chang
       Alcotest.(check bool) "GitHub prompt has no Compozy wrapper" false
         (contains_substring github_prompt "Compozy Task Step"))
 
+let compozy_task_status compozy_root path =
+  let task = Compozy_tasks_tracker.parse_task_file ~compozy_root path |> require_ok "parse Compozy task" in
+  task.status
+
+let compozy_test_config root compozy_root =
+  {
+    Config.workflow_path = "settings.json";
+    repository_root = root;
+    tracker =
+      {
+        kind = "compozy_tasks";
+        owner = "acme";
+        repo = "widgets";
+        project_number = 7;
+        api_key_env = "GITHUB_TOKEN";
+        api_key = Some "token";
+        minibeads_root = ".beads";
+        minibeads_command = "mb";
+        compozy_root;
+        compozy_max_task_step_retries = 2;
+        active_states = [ "pending"; "in_progress" ];
+        terminal_states = [ "completed"; "failed"; "skipped" ];
+        project_status_field = "Status";
+        project_status_on_dispatch = None;
+        project_status_on_success = Some "completed";
+        project_status_on_retry = Some "pending";
+        ensure_project_statuses = true;
+      };
+    polling = { interval_ms = 1000 };
+    workspace = { root = Filename.concat root ".symphony/workspaces" };
+    git = git_policy ();
+    agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
+    codex =
+      {
+        command = "true";
+        model = Config.default_model;
+        reasoning_effort = Config.default_reasoning_effort;
+        turn_timeout_ms = 1000;
+        read_timeout_ms = 100;
+        stall_timeout_ms = 1000;
+      };
+    agent_harnesses_explicit = false;
+    agent_harnesses = [];
+    logical_agents = [];
+    legacy_agent_harness_paths = [];
+    server = { port = None };
+    pull_request = Config.default_pull_request;
+    protected_paths = Config.default_protected_paths;
+    stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
+  }
+
+let test_compozy_completion_relaunches_next_step_in_same_worktree () =
+  with_temp_dir "symphony-compozy-sequential-" (fun root ->
+      init_repo root "feature/start";
+      let compozy_root = Filename.concat (Filename.concat root ".compozy") "tasks" in
+      let prd_dir = Filename.concat compozy_root "sequential-feature" in
+      Util.mkdir_p prd_dir;
+      let task_01 = Filename.concat prd_dir "task_01.md" in
+      let task_02 = Filename.concat prd_dir "task_02.md" in
+      write_compozy_task ~title:"First step" ~body:"\n# First\n\nFirst step sentinel.\n" task_01;
+      write_compozy_task ~title:"Second step" ~body:"\n# Second\n\nSecond step sentinel.\n" task_02;
+      ignore (run_ok ~cwd:root "commit Compozy tasks" "git add .compozy && git commit -q -m compozy-tasks");
+      let config = compozy_test_config root compozy_root in
+      let launches = ref [] in
+      let launch ~stage:_ ~config:_ ~(workspace : Workspace.t) ~prompt ~issue =
+        let branch = run_ok ~cwd:workspace.path "branch" "git branch --show-current" in
+        launches := (issue, workspace, prompt, branch) :: !launches;
+        {
+          Orchestrator.pid = None;
+          session_id = Some (string_of_int (List.length !launches));
+          event = "test-launch";
+          stdout_path = None;
+          stderr_path = None;
+        }
+      in
+      let commit_calls = ref [] in
+      let commit_stage _config (workspace : Workspace.t) issue _stage next_status =
+        commit_calls := (workspace.path, issue.Issue.identifier, next_status) :: !commit_calls;
+        Ok ()
+      in
+      let completed_compozy_child issue workspace =
+        {
+          Orchestrator.pid = 0;
+          issue;
+          stage = None;
+          harness = test_child_harness;
+          issue_id = issue.Issue.id;
+          issue_identifier = issue.identifier;
+          issue_title = issue.title;
+          workspace;
+          started_at = Unix.time ();
+          last_output_at = Unix.time ();
+          stdout_path = None;
+          stderr_path = None;
+          stdout_size = 0;
+          stderr_size = 0;
+        }
+      in
+      let orchestrator =
+        Orchestrator.make ~launch ~commit_stage ~config ~prompt_template:"Compozy {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      let first_issue, first_workspace, first_prompt, first_branch =
+        match List.rev !launches with
+        | [ launch ] -> launch
+        | _ -> Alcotest.fail "expected first Compozy launch"
+      in
+      let workspace_compozy_root = Filename.concat (Filename.concat first_workspace.path ".compozy") "tasks" in
+      let workspace_task_01 = Filename.concat (Filename.concat workspace_compozy_root "sequential-feature") "task_01.md" in
+      let workspace_task_02 = Filename.concat (Filename.concat workspace_compozy_root "sequential-feature") "task_02.md" in
+      Alcotest.(check string) "first task started" "in_progress"
+        (compozy_task_status workspace_compozy_root workspace_task_01);
+      Alcotest.(check bool) "first prompt includes first task" true (contains_substring first_prompt "First step sentinel.");
+      let first_child = completed_compozy_child first_issue first_workspace in
+      Orchestrator.mark_completed orchestrator first_child;
+      let first_progress =
+        match (Orchestrator.get_state orchestrator).Runtime_state.compozy_progress with
+        | Some progress -> progress
+        | None -> Alcotest.fail "expected Compozy progress after first completion"
+      in
+      Alcotest.(check int) "no intermediate stage commit" 0 (List.length !commit_calls);
+      Alcotest.(check string) "first task completed" "completed"
+        (compozy_task_status workspace_compozy_root workspace_task_01);
+      Alcotest.(check (option string)) "runtime current step" (Some "task_02.md") first_progress.current_step;
+      Alcotest.(check int) "runtime completed count" 1 first_progress.completed;
+      let second_issue, second_workspace, second_prompt, second_branch =
+        match List.rev !launches with
+        | [ _first; second ] -> second
+        | _ -> Alcotest.fail "expected relaunch for second Compozy task"
+      in
+      Alcotest.(check string) "second task started" "in_progress"
+        (compozy_task_status workspace_compozy_root workspace_task_02);
+      Alcotest.(check string) "same workspace" first_workspace.path second_workspace.path;
+      Alcotest.(check string) "same task branch" first_branch second_branch;
+      Alcotest.(check bool) "second prompt includes second task" true (contains_substring second_prompt "Second step sentinel.");
+      Alcotest.(check bool) "intermediate integration deferred" true
+        ((Orchestrator.get_state orchestrator).Runtime_state.task_branch_integrations = []);
+      let second_child = completed_compozy_child second_issue second_workspace in
+      Orchestrator.mark_completed orchestrator second_child;
+      let final_progress =
+        match (Orchestrator.get_state orchestrator).Runtime_state.compozy_progress with
+        | Some progress -> progress
+        | None -> Alcotest.fail "expected final Compozy progress"
+      in
+      Alcotest.(check int) "final stage commit" 1 (List.length !commit_calls);
+      Alcotest.(check string) "second task completed" "completed"
+        (compozy_task_status workspace_compozy_root workspace_task_02);
+      Alcotest.(check (option string)) "no current step after final completion" None final_progress.current_step;
+      Alcotest.(check int) "all steps completed" 2 final_progress.completed)
+
 let stage_context_command ?(cwd = "agentWorktree") ?(timeout_ms = 1000) ?(max_output_bytes = 4096) argv =
   { Config.argv; cwd; timeout_ms; max_output_bytes; validation_error = None }
 
@@ -10556,6 +10706,8 @@ let () =
           Alcotest.test_case "skips blank loop command" `Quick test_compose_prompt_skips_blank_loop_command;
           Alcotest.test_case "wraps Compozy task-step prompt without GitHub prompt changes" `Quick
             test_orchestrator_wraps_compozy_task_step_prompt_without_github_prompt_change;
+          Alcotest.test_case "relaunches Compozy task steps in one worktree" `Quick
+            test_compozy_completion_relaunches_next_step_in_same_worktree;
           Alcotest.test_case "skips stage goal handoff when disabled" `Quick test_orchestrator_skips_stage_goal_when_disabled;
           Alcotest.test_case "runs stage context command before launch" `Quick
             test_orchestrator_runs_stage_context_command_before_launch;

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -1721,6 +1721,69 @@ let test_compozy_prd_run_discovery_integration_yields_issue_candidates () =
         [ "compozy:alpha-run"; "compozy:beta-run" ]
         (List.map (fun (issue : Issue.t) -> issue.identifier) issues))
 
+let test_compozy_task_step_prompt_includes_current_task_file () =
+  with_temp_dir "symphony-compozy-prompt-task-" (fun root ->
+      let prd_dir = Filename.concat root "prompt-feature" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task ~title:"Build prompt context"
+        ~body:"\n# Task Body\n\nImplement prompt assembly sentinel.\n"
+        (Filename.concat prd_dir "task_04.md");
+      let run =
+        Compozy_tasks_tracker.prd_run_of_directory ~compozy_root:root prd_dir |> require_ok "build PRD run"
+      in
+      let prompt = Compozy_tasks_tracker.current_prompt run |> require_ok "current prompt" in
+      Alcotest.(check bool) "current file heading" true
+        (contains_substring prompt "## Current Task (`task_04.md`)");
+      Alcotest.(check bool) "current title included" true
+        (contains_substring prompt "Current task title: Build prompt context");
+      Alcotest.(check bool) "task body included" true
+        (contains_substring prompt "Implement prompt assembly sentinel."))
+
+let test_compozy_task_step_prompt_includes_prd_and_techspec () =
+  with_temp_dir "symphony-compozy-prompt-context-" (fun root ->
+      let prd_dir = Filename.concat root "context-feature" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task (Filename.concat prd_dir "task_01.md");
+      Util.write_file (Filename.concat prd_dir "_prd.md") "# Product Requirements\n\nPRD context sentinel.\n";
+      Util.write_file (Filename.concat prd_dir "_techspec.md") "# Technical Spec\n\nTechSpec context sentinel.\n";
+      let run =
+        Compozy_tasks_tracker.prd_run_of_directory ~compozy_root:root prd_dir |> require_ok "build PRD run"
+      in
+      let prompt = Compozy_tasks_tracker.current_prompt run |> require_ok "current prompt" in
+      Alcotest.(check bool) "PRD section" true (contains_substring prompt "## PRD (`_prd.md`)");
+      Alcotest.(check bool) "PRD content" true (contains_substring prompt "PRD context sentinel.");
+      Alcotest.(check bool) "TechSpec section" true (contains_substring prompt "## TechSpec (`_techspec.md`)");
+      Alcotest.(check bool) "TechSpec content" true (contains_substring prompt "TechSpec context sentinel."))
+
+let test_compozy_task_step_prompt_allows_missing_optional_context () =
+  with_temp_dir "symphony-compozy-prompt-no-context-" (fun root ->
+      let prd_dir = Filename.concat root "minimal-feature" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task ~body:"\n# Minimal Task\n\nNo optional context required.\n"
+        (Filename.concat prd_dir "task_01.md");
+      let run =
+        Compozy_tasks_tracker.prd_run_of_directory ~compozy_root:root prd_dir |> require_ok "build PRD run"
+      in
+      let prompt = Compozy_tasks_tracker.current_prompt run |> require_ok "current prompt" in
+      Alcotest.(check bool) "task content included" true
+        (contains_substring prompt "No optional context required.");
+      Alcotest.(check bool) "PRD section omitted" false (contains_substring prompt "## PRD (`_prd.md`)");
+      Alcotest.(check bool) "TechSpec section omitted" false
+        (contains_substring prompt "## TechSpec (`_techspec.md`)"))
+
+let test_compozy_task_step_prompt_errors_without_runnable_step () =
+  with_temp_dir "symphony-compozy-prompt-no-step-" (fun root ->
+      let prd_dir = Filename.concat root "finished-feature" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task ~status:"completed" (Filename.concat prd_dir "task_01.md");
+      let run =
+        Compozy_tasks_tracker.prd_run_of_directory ~compozy_root:root prd_dir |> require_ok "build PRD run"
+      in
+      let error = Compozy_tasks_tracker.current_prompt run |> require_error "current prompt" in
+      Alcotest.(check string) "deterministic error"
+        "no runnable Compozy task step for compozy:finished-feature: PRD run is completed"
+        error)
+
 let test_invalid_tracker_kind () =
   with_temp_dir "symphony-settings-invalid-tracker-" (fun root ->
       let settings = Filename.concat root "settings.json" in
@@ -6539,6 +6602,48 @@ let test_compose_prompt_skips_blank_loop_command () =
       Alcotest.(check bool) "no stage goal context" false (contains_substring prompt "Stage Goal Context");
       Alcotest.(check bool) "normal prompt included" true (contains_substring prompt "Normal #1"))
 
+let test_orchestrator_wraps_compozy_task_step_prompt_without_github_prompt_change () =
+  with_temp_dir "symphony-compozy-orchestrator-prompt-" (fun root ->
+      let prd_dir = Filename.concat root "wrapped-feature" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task ~title:"Wrapped task"
+        ~body:"\n# Wrapped Task\n\nCompozy task prompt sentinel.\n"
+        (Filename.concat prd_dir "task_01.md");
+      Util.write_file (Filename.concat prd_dir "_prd.md") "# PRD\n\nWrapped PRD sentinel.\n";
+      Util.write_file (Filename.concat prd_dir "_techspec.md") "# TechSpec\n\nWrapped TechSpec sentinel.\n";
+      let run =
+        Compozy_tasks_tracker.prd_run_of_directory ~compozy_root:root prd_dir |> require_ok "build PRD run"
+      in
+      let base_config = stage_context_test_config ~context_snapshot:false root in
+      let config =
+        { base_config with tracker = { base_config.tracker with kind = "compozy_tasks"; compozy_root = root } }
+      in
+      let workspace = Workspace.create_for_issue ~root:config.workspace.root run.id in
+      let composition =
+        Orchestrator.compose_compozy_task_step_prompt_result ~stage:(List.hd config.stage_agents.stages) config run
+          None ~workspace ~loop_start_branch:(Some "symphony/dogfood")
+        |> require_ok "compose Compozy prompt"
+      in
+      Alcotest.(check bool) "stage agent wrapper included" true
+        (contains_substring composition.prompt "Stage agent: engineer");
+      Alcotest.(check bool) "Compozy task content included" true
+        (contains_substring composition.prompt "Compozy task prompt sentinel.");
+      Alcotest.(check bool) "Compozy PRD included" true
+        (contains_substring composition.prompt "Wrapped PRD sentinel.");
+      Alcotest.(check bool) "Compozy TechSpec included" true
+        (contains_substring composition.prompt "Wrapped TechSpec sentinel.");
+      let github_issue = Issue.empty ~id:"I1" ~identifier:"#1" ~title:"One" ~state:"Todo" in
+      let github_workspace = Workspace.create_for_issue ~root:config.workspace.root github_issue.identifier in
+      let github_prompt =
+        Orchestrator.compose_prompt ~stage:(List.hd config.stage_agents.stages) config github_issue None "Normal #1"
+          ~workspace:github_workspace ~loop_start_branch:(Some "symphony/dogfood")
+      in
+      Alcotest.(check string) "GitHub base prompt unchanged"
+        "Engineer stage instructions\n\n---\n\nStage agent: engineer\n\nNormal #1\n"
+        github_prompt;
+      Alcotest.(check bool) "GitHub prompt has no Compozy wrapper" false
+        (contains_substring github_prompt "Compozy Task Step"))
+
 let stage_context_command ?(cwd = "agentWorktree") ?(timeout_ms = 1000) ?(max_output_bytes = 4096) argv =
   { Config.argv; cwd; timeout_ms; max_output_bytes; validation_error = None }
 
@@ -10032,6 +10137,14 @@ let () =
             test_compozy_missing_root_discovers_no_prd_runs;
           Alcotest.test_case "discovers Compozy PRD issue candidates from fixtures" `Quick
             test_compozy_prd_run_discovery_integration_yields_issue_candidates;
+          Alcotest.test_case "builds Compozy prompt from current task file" `Quick
+            test_compozy_task_step_prompt_includes_current_task_file;
+          Alcotest.test_case "adds Compozy PRD and TechSpec prompt context" `Quick
+            test_compozy_task_step_prompt_includes_prd_and_techspec;
+          Alcotest.test_case "allows missing Compozy prompt context files" `Quick
+            test_compozy_task_step_prompt_allows_missing_optional_context;
+          Alcotest.test_case "reports missing runnable Compozy prompt step" `Quick
+            test_compozy_task_step_prompt_errors_without_runnable_step;
           Alcotest.test_case "rejects unsupported tracker kind" `Quick test_invalid_tracker_kind;
           Alcotest.test_case "keeps github readiness gaps" `Quick
             test_github_tracker_readiness_keeps_github_gaps;
@@ -10252,6 +10365,8 @@ let () =
           Alcotest.test_case "dispatch exposes Claude harness identity" `Quick
             test_orchestrator_dispatch_exposes_claude_harness_identity;
           Alcotest.test_case "skips blank loop command" `Quick test_compose_prompt_skips_blank_loop_command;
+          Alcotest.test_case "wraps Compozy task-step prompt without GitHub prompt changes" `Quick
+            test_orchestrator_wraps_compozy_task_step_prompt_without_github_prompt_change;
           Alcotest.test_case "skips stage goal handoff when disabled" `Quick test_orchestrator_skips_stage_goal_when_disabled;
           Alcotest.test_case "runs stage context command before launch" `Quick
             test_orchestrator_runs_stage_context_command_before_launch;

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -57,6 +57,11 @@ let contains_substring text substring =
   in
   loop 0
 
+let ends_with ~suffix text =
+  let text_len = String.length text in
+  let suffix_len = String.length suffix in
+  text_len >= suffix_len && String.sub text (text_len - suffix_len) suffix_len = suffix
+
 let rec find_repo_root dir =
   if Sys.file_exists (Filename.concat dir "package.json") && Sys.file_exists (Filename.concat dir "CONTEXT.md") then dir
   else
@@ -1496,6 +1501,119 @@ let test_config_parses_compozy_tracker_settings () =
         (Filename.concat (Filename.concat (Unix.realpath root) ".local") "compozy-tasks")
         config.tracker.compozy_root;
       Alcotest.(check int) "custom max task step retries" 5 config.tracker.compozy_max_task_step_retries)
+
+let require_ok label = function Ok value -> value | Error error -> Alcotest.fail (label ^ ": " ^ error)
+
+let require_error label = function
+  | Ok _ -> Alcotest.fail (label ^ ": expected error")
+  | Error error -> error
+
+let write_compozy_task ?(status = "pending") ?(title = "Example task") ?(task_type = "backend")
+    ?(complexity = "medium") ?(dependencies = []) ?(body = "\n# Task Body\n\nUser-authored content.\n") path =
+  let dependency_lines =
+    match dependencies with
+    | [] -> "dependencies: []\n"
+    | dependencies ->
+        "dependencies:\n"
+        ^ (dependencies |> List.map (fun dependency -> "  - " ^ dependency ^ "\n") |> String.concat "")
+  in
+  Util.write_file path
+    (Printf.sprintf "---\nstatus: %s\ntitle: \"%s\"\ntype: %s\ncomplexity: %s\n%s---\n%s" status title task_type
+       complexity dependency_lines body)
+
+let test_compozy_task_files_sort_numeric_order () =
+  with_temp_dir "symphony-compozy-sort-" (fun root ->
+      let prd_dir = Filename.concat root "run" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task (Filename.concat prd_dir "task_10.md");
+      write_compozy_task (Filename.concat prd_dir "task_02.md");
+      write_compozy_task (Filename.concat prd_dir "task_01.md");
+      let tasks = Compozy_tasks_tracker.list_task_files ~compozy_root:root prd_dir |> require_ok "list tasks" in
+      Alcotest.(check (list string)) "numeric order" [ "task_01.md"; "task_02.md"; "task_10.md" ]
+        (List.map (fun (task : Compozy_tasks_tracker.task_file) -> task.file) tasks))
+
+let test_compozy_task_files_ignore_non_task_files () =
+  with_temp_dir "symphony-compozy-ignore-" (fun root ->
+      let prd_dir = Filename.concat root "run" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task (Filename.concat prd_dir "task_01.md");
+      Util.write_file (Filename.concat prd_dir "_prd.md") "# PRD\n";
+      Util.write_file (Filename.concat prd_dir "notes.md") "# Notes\n";
+      Util.write_file (Filename.concat prd_dir "task_alpha.md") "# Invalid task\n";
+      let tasks = Compozy_tasks_tracker.list_task_files ~compozy_root:root prd_dir |> require_ok "list tasks" in
+      Alcotest.(check (list string)) "task files only" [ "task_01.md" ]
+        (List.map (fun (task : Compozy_tasks_tracker.task_file) -> task.file) tasks))
+
+let test_compozy_task_frontmatter_parses_metadata () =
+  with_temp_dir "symphony-compozy-parse-" (fun root ->
+      let path = Filename.concat root "task_02.md" in
+      write_compozy_task ~status:"in_progress" ~title:"Add parser" ~task_type:"backend" ~complexity:"high"
+        ~dependencies:[ "task_01"; "task_00" ] path;
+      let task = Compozy_tasks_tracker.parse_task_file ~compozy_root:root path |> require_ok "parse task" in
+      Alcotest.(check int) "index" 2 task.index;
+      Alcotest.(check string) "status" "in_progress" task.status;
+      Alcotest.(check string) "title" "Add parser" task.title;
+      Alcotest.(check string) "type" "backend" task.task_type;
+      Alcotest.(check string) "complexity" "high" task.complexity;
+      Alcotest.(check (list string)) "dependencies" [ "task_01"; "task_00" ] task.dependencies;
+      Alcotest.(check int) "retry default" 0 task.retry_count;
+      Alcotest.(check bool) "last error absent" true (Option.is_none task.last_error))
+
+let test_compozy_task_missing_frontmatter_error () =
+  with_temp_dir "symphony-compozy-missing-frontmatter-" (fun root ->
+      let path = Filename.concat root "task_01.md" in
+      Util.write_file path "# Missing frontmatter\n";
+      let error = Compozy_tasks_tracker.parse_task_file ~compozy_root:root path |> require_error "parse task" in
+      Alcotest.(check string) "deterministic error" "missing frontmatter in task_01.md" error)
+
+let test_compozy_task_frontmatter_updates_preserve_body () =
+  with_temp_dir "symphony-compozy-update-" (fun root ->
+      let path = Filename.concat root "task_01.md" in
+      let body = "\n# Task Body\n\nUser-authored **Markdown** stays here.\n" in
+      write_compozy_task ~body path;
+      Compozy_tasks_tracker.update_task_frontmatter ~compozy_root:root path
+        { status = Some "completed"; retry_count = Some 2; last_error = Some "agent exited with code 1" }
+      |> require_ok "update task";
+      let content = Util.read_file path in
+      Alcotest.(check bool) "status updated" true (contains_substring content "status: completed\n");
+      Alcotest.(check bool) "retry updated" true (contains_substring content "symphony_retry_count: 2\n");
+      Alcotest.(check bool) "last error updated" true
+        (contains_substring content "symphony_last_error: \"agent exited with code 1\"\n");
+      Alcotest.(check bool) "body preserved" true (ends_with ~suffix:body content))
+
+let test_compozy_task_rejects_paths_outside_root () =
+  with_temp_dir "symphony-compozy-paths-" (fun root ->
+      let compozy_root = Filename.concat root "tasks" in
+      let outside_root = Filename.concat root "outside" in
+      Util.mkdir_p compozy_root;
+      Util.mkdir_p outside_root;
+      let path = Filename.concat outside_root "task_01.md" in
+      write_compozy_task path;
+      let error = Compozy_tasks_tracker.parse_task_file ~compozy_root path |> require_error "parse outside task" in
+      Alcotest.(check bool) "outside root error" true
+        (contains_substring error "path outside configured Compozy root"))
+
+let test_compozy_task_directory_parse_and_update_integration () =
+  with_temp_dir "symphony-compozy-integration-" (fun root ->
+      let prd_dir = Filename.concat root "compozy-tasks-run-integration" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task ~title:"Second" ~dependencies:[ "task_01" ] (Filename.concat prd_dir "task_02.md");
+      write_compozy_task ~title:"First" (Filename.concat prd_dir "task_01.md");
+      let before = Compozy_tasks_tracker.list_task_files ~compozy_root:root prd_dir |> require_ok "list before" in
+      Alcotest.(check (list string)) "initial order" [ "First"; "Second" ]
+        (List.map (fun (task : Compozy_tasks_tracker.task_file) -> task.title) before);
+      let first_path = Filename.concat prd_dir "task_01.md" in
+      Compozy_tasks_tracker.update_status ~compozy_root:root first_path "completed" |> require_ok "update status";
+      Compozy_tasks_tracker.update_retry_count ~compozy_root:root first_path 1 |> require_ok "update retry";
+      Compozy_tasks_tracker.update_last_error ~compozy_root:root first_path "retry succeeded"
+      |> require_ok "update last error";
+      let after = Compozy_tasks_tracker.list_task_files ~compozy_root:root prd_dir |> require_ok "list after" in
+      match after with
+      | first :: _ ->
+          Alcotest.(check string) "updated status" "completed" first.status;
+          Alcotest.(check int) "updated retry" 1 first.retry_count;
+          Alcotest.(check (option string)) "updated last error" (Some "retry succeeded") first.last_error
+      | [] -> Alcotest.fail "expected parsed tasks")
 
 let test_invalid_tracker_kind () =
   with_temp_dir "symphony-settings-invalid-tracker-" (fun root ->
@@ -9778,6 +9896,20 @@ let () =
             test_config_parses_compozy_tracker_defaults;
           Alcotest.test_case "parses Compozy tracker settings" `Quick
             test_config_parses_compozy_tracker_settings;
+          Alcotest.test_case "sorts Compozy task files numerically" `Quick
+            test_compozy_task_files_sort_numeric_order;
+          Alcotest.test_case "ignores non-task Compozy files" `Quick
+            test_compozy_task_files_ignore_non_task_files;
+          Alcotest.test_case "parses Compozy task metadata" `Quick
+            test_compozy_task_frontmatter_parses_metadata;
+          Alcotest.test_case "rejects missing Compozy task frontmatter" `Quick
+            test_compozy_task_missing_frontmatter_error;
+          Alcotest.test_case "updates Compozy task frontmatter body-safe" `Quick
+            test_compozy_task_frontmatter_updates_preserve_body;
+          Alcotest.test_case "rejects Compozy task paths outside root" `Quick
+            test_compozy_task_rejects_paths_outside_root;
+          Alcotest.test_case "parses and updates Compozy task directories" `Quick
+            test_compozy_task_directory_parse_and_update_integration;
           Alcotest.test_case "rejects unsupported tracker kind" `Quick test_invalid_tracker_kind;
           Alcotest.test_case "keeps github readiness gaps" `Quick
             test_github_tracker_readiness_keeps_github_gaps;

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -3541,10 +3541,12 @@ let test_runtime_state_exposes_compozy_progress () =
       | None -> Alcotest.fail "expected parsed Compozy progress")
 
 let test_ordered_queue_parses_cli_identifiers () =
-  match Ordered_queue.parse "19,#22,mb-20" with
+  match Ordered_queue.parse "19,#22,31,mb-20,compozy:example-feature" with
   | Error _ -> Alcotest.fail "expected ordered queue parse success"
   | Ok queue ->
-      Alcotest.(check (list string)) "identifiers" [ "#19"; "#22"; "mb-20" ] (Ordered_queue.identifiers queue);
+      Alcotest.(check (list string)) "identifiers"
+        [ "#19"; "#22"; "#31"; "mb-20"; "compozy:example-feature" ]
+        (Ordered_queue.identifiers queue);
       (match Ordered_queue.parse "20,#20" with
       | Ok _ -> Alcotest.fail "expected duplicate canonical GitHub selector"
       | Error problems ->
@@ -3555,6 +3557,19 @@ let test_ordered_queue_parses_cli_identifiers () =
       | Error problems ->
           Alcotest.(check string) "duplicate minibeads" "duplicate issue identifier"
             (List.hd problems).Ordered_queue.reason);
+      (match Ordered_queue.parse "compozy:example-feature, compozy:example-feature" with
+      | Ok _ -> Alcotest.fail "expected duplicate canonical Compozy selector"
+      | Error problems ->
+          Alcotest.(check string) "duplicate Compozy" "duplicate issue identifier"
+            (List.hd problems).Ordered_queue.reason);
+      (match Ordered_queue.parse "compozy:,compozy:feature/child" with
+      | Ok _ -> Alcotest.fail "expected malformed Compozy selectors"
+      | Error problems ->
+          Alcotest.(check int) "Compozy problem count" 2 (List.length problems);
+          Alcotest.(check bool) "empty Compozy selector diagnostic" true
+            (contains_substring (List.hd problems).Ordered_queue.reason "Compozy PRD-run identifier");
+          Alcotest.(check bool) "path Compozy selector diagnostic" true
+            (contains_substring (List.nth problems 1).Ordered_queue.reason "without path separators"));
       (match Ordered_queue.parse "owner/repo#20,https://github.com/acme/widgets/issues/20,,mb-,mb-zero,MB-20" with
       | Ok _ -> Alcotest.fail "expected ordered queue parse problems"
       | Error problems ->
@@ -3597,6 +3612,21 @@ let test_ordered_queue_validation_uses_selected_tracker () =
     (List.map (fun (gap : Ordered_queue.validation_gap) -> gap.requirement) gaps);
   Alcotest.(check string) "terminal remediation" "Issue is terminal in tracker state \"closed\"."
     (List.hd gaps).Ordered_queue.remediation
+
+let test_ordered_queue_validation_resolves_compozy_prd_run_without_github_project () =
+  with_temp_dir "symphony-compozy-queue-validation-" (fun root ->
+      let config = write_compozy_settings root in
+      let prd_dir = Filename.concat config.Config.tracker.compozy_root "example-feature" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task ~title:"Queued Compozy run" (Filename.concat prd_dir "task_01.md");
+      let queue =
+        match Ordered_queue.parse "compozy:example-feature" with
+        | Ok queue -> queue
+        | Error _ -> Alcotest.fail "queue parse failed"
+      in
+      let tracker = Issue_tracker.compozy config in
+      let gaps = Ordered_queue.validation_gaps tracker queue in
+      Alcotest.(check (list string)) "no validation gaps" [] (List.map (fun gap -> gap.Ordered_queue.requirement) gaps))
 
 let test_runtime_state_exposes_ordered_queue () =
   let queue =
@@ -10340,6 +10370,39 @@ let run_manual_merge_minibeads_test config ~runner selectors =
   let tracker = Issue_tracker.minibeads ~runner config in
   Manual_merge.run ~tracker config selectors
 
+let manual_merge_compozy_config root compozy_root =
+  let config = manual_merge_config root in
+  let stage_agents =
+    {
+      config.Config.stage_agents with
+      stages =
+        List.map
+          (fun (stage : Config.stage_agent) -> { stage with states = [ "completed" ]; success_status = None })
+          config.stage_agents.stages;
+    }
+  in
+  {
+    config with
+    Config.tracker =
+      {
+        config.tracker with
+        kind = "compozy_tasks";
+        owner = "";
+        repo = "";
+        project_number = 0;
+        api_key = None;
+        active_states = [ "pending"; "in_progress" ];
+        terminal_states = [ "completed"; "failed"; "skipped" ];
+        compozy_root;
+        compozy_max_task_step_retries = 2;
+      };
+    stage_agents;
+  }
+
+let run_manual_merge_compozy_test config selectors =
+  let tracker = Issue_tracker.compozy config in
+  Manual_merge.run ~tracker config selectors
+
 let test_manual_merge_accepts_minibeads_selector_and_rejects_canonical_duplicates () =
   with_temp_dir "symphony-manual-merge-minibeads-selectors-" (fun root ->
       init_repo root "feature/start";
@@ -10436,6 +10499,34 @@ let test_manual_merge_minibeads_fast_forward_updates_selected_tracker () =
       Alcotest.(check (list (pair string string))) "selected tracker commands"
         [ (root, show_command); (root, update_command) ]
         (List.rev !calls))
+
+let test_manual_merge_accepts_completed_compozy_prd_run () =
+  with_temp_dir "symphony-manual-merge-compozy-" (fun root ->
+      init_repo root "feature/start";
+      let compozy_root = Filename.concat (Filename.concat root ".compozy") "tasks" in
+      let prd_dir = Filename.concat compozy_root "example-feature" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task ~status:"completed" ~title:"Completed Compozy run"
+        (Filename.concat prd_dir "task_01.md");
+      ignore (run_ok ~cwd:root "commit Compozy tracker files" "git add .compozy && git commit -q -m compozy-tasks");
+      let config = manual_merge_compozy_config root compozy_root in
+      let run =
+        Compozy_tasks_tracker.prd_run_of_directory ~compozy_root prd_dir |> require_ok "build Compozy PRD run"
+      in
+      let issue = Compozy_tasks_tracker.issue_of_prd_run run in
+      let workspace =
+        match Orchestrator.shell_prepare_workspace config ~loop_start_branch:"feature/start" issue with
+        | Ok workspace -> workspace
+        | Error error -> Alcotest.fail error
+      in
+      Util.write_file (Filename.concat workspace.path "compozy-merge.txt") "compozy\n";
+      ignore (run_ok ~cwd:workspace.path "task commit" "git add compozy-merge.txt && git commit -q -m task");
+      let result = run_manual_merge_compozy_test config [ "compozy:example-feature" ] in
+      let report = match result with Ok report -> report | Error errors -> Alcotest.fail (String.concat "; " errors) in
+      Alcotest.(check int) "merged" 1 report.merged;
+      Alcotest.(check int) "already integrated" 0 report.already_integrated;
+      Alcotest.(check bool) "merged file present" true (Sys.file_exists (Filename.concat root "compozy-merge.txt"));
+      Alcotest.(check bool) "worktree removed" false (Sys.file_exists workspace.path))
 
 let test_manual_merge_rejects_invalid_and_duplicate_selectors () =
   with_temp_dir "symphony-manual-merge-selectors-" (fun root ->
@@ -10779,6 +10870,8 @@ let () =
           Alcotest.test_case "parses ordered queue identifiers" `Quick test_ordered_queue_parses_cli_identifiers;
           Alcotest.test_case "validates ordered queue through selected tracker" `Quick
             test_ordered_queue_validation_uses_selected_tracker;
+          Alcotest.test_case "validates Compozy ordered queue without GitHub Project membership" `Quick
+            test_ordered_queue_validation_resolves_compozy_prd_run_without_github_project;
           Alcotest.test_case "exposes ordered queue" `Quick test_runtime_state_exposes_ordered_queue;
           Alcotest.test_case "resumes same ordered queue state" `Quick test_orchestrator_resumes_same_ordered_queue_state;
           Alcotest.test_case "exposes goal usage when available" `Quick test_runtime_state_exposes_goal_usage_when_available;
@@ -11075,6 +11168,8 @@ let () =
             test_manual_merge_fast_forwards_protected_trunk_and_updates_review_status;
           Alcotest.test_case "fast-forwards minibeads task and updates selected tracker" `Quick
             test_manual_merge_minibeads_fast_forward_updates_selected_tracker;
+          Alcotest.test_case "fast-forwards completed Compozy PRD-run task" `Quick
+            test_manual_merge_accepts_completed_compozy_prd_run;
           Alcotest.test_case "blocks unauthorized protected paths" `Quick
             test_manual_merge_blocks_unauthorized_protected_path_change;
           Alcotest.test_case "preflight is all or nothing" `Quick test_manual_merge_preflight_is_all_or_nothing;

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -1138,6 +1138,8 @@ let test_shell_launch_runs_agent_in_agent_worktree () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -1224,6 +1226,8 @@ let test_shell_launch_selects_pi_harness_for_stage_agent () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -1337,6 +1341,8 @@ let test_dispatch_selects_pi_harness_before_start_status_update () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo"; "In progress" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -1460,12 +1466,44 @@ let test_config_parses_minibeads_tracker_settings () =
         (Filename.concat (Filename.concat (Unix.realpath root) ".local") "issues")
         config.tracker.minibeads_root)
 
+let test_config_parses_compozy_tracker_defaults () =
+  with_temp_dir "symphony-settings-compozy-defaults-" (fun root ->
+      Util.mkdir_p (Filename.concat root ".symphony");
+      let settings = Filename.concat root "settings.json" in
+      Util.write_file settings {|{"tracker": {"kind": "compozy_tasks"}}|};
+      let config = Config.from_settings_file ~workspace_root:root settings in
+      Alcotest.(check string) "tracker kind" "compozy_tasks" config.tracker.kind;
+      Alcotest.(check string) "default root"
+        (Filename.concat (Filename.concat (Unix.realpath root) ".compozy") "tasks")
+        config.tracker.compozy_root;
+      Alcotest.(check int) "default max task step retries" 2 config.tracker.compozy_max_task_step_retries)
+
+let test_config_parses_compozy_tracker_settings () =
+  with_temp_dir "symphony-settings-compozy-explicit-" (fun root ->
+      Util.mkdir_p (Filename.concat root ".symphony");
+      Util.mkdir_p (Filename.concat root ".local");
+      let settings = Filename.concat root "settings.json" in
+      Util.write_file settings
+        {|{
+  "tracker": {
+    "kind": "compozy_tasks",
+    "compozy": {"root": ".local/compozy-tasks", "maxTaskStepRetries": 5}
+  }
+}|};
+      let config = Config.from_settings_file ~workspace_root:root settings in
+      Alcotest.(check string) "tracker kind" "compozy_tasks" config.tracker.kind;
+      Alcotest.(check string) "custom root"
+        (Filename.concat (Filename.concat (Unix.realpath root) ".local") "compozy-tasks")
+        config.tracker.compozy_root;
+      Alcotest.(check int) "custom max task step retries" 5 config.tracker.compozy_max_task_step_retries)
+
 let test_invalid_tracker_kind () =
   with_temp_dir "symphony-settings-invalid-tracker-" (fun root ->
       let settings = Filename.concat root "settings.json" in
       Util.write_file settings {|{"tracker": {"kind": "linear"}}|};
       Alcotest.check_raises "linear rejected"
-        (Config.Invalid_config "Unsupported tracker.kind linear. Set tracker.kind to github or minibeads.")
+        (Config.Invalid_config
+           "Unsupported tracker.kind linear. Set tracker.kind to github, minibeads, or compozy_tasks.")
         (fun () -> ignore (Config.from_settings_file ~workspace_root:root settings)))
 
 let test_github_tracker_readiness_keeps_github_gaps () =
@@ -1489,6 +1527,18 @@ let test_minibeads_tracker_readiness_skips_github_gaps () =
           Util.mkdir_p (Filename.concat root ".symphony");
           let settings = Filename.concat root "settings.json" in
           Util.write_file settings {|{"tracker": {"kind": "minibeads"}}|};
+          let gaps = Config.from_settings_file ~workspace_root:root settings |> Config.readiness_gaps in
+          Alcotest.(check bool) "owner gap skipped" false (has_readiness_requirement "tracker.owner" gaps);
+          Alcotest.(check bool) "repo gap skipped" false (has_readiness_requirement "tracker.repo" gaps);
+          Alcotest.(check bool) "project gap skipped" false (has_readiness_requirement "tracker.projectNumber" gaps);
+          Alcotest.(check bool) "token gap skipped" false (has_readiness_requirement "environment.GITHUB_TOKEN" gaps)))
+
+let test_compozy_tracker_readiness_skips_github_gaps () =
+  with_env [ ("GITHUB_TOKEN", ""); ("GH_TOKEN", "") ] (fun () ->
+      with_temp_dir "symphony-settings-compozy-gaps-" (fun root ->
+          Util.mkdir_p (Filename.concat root ".symphony");
+          let settings = Filename.concat root "settings.json" in
+          Util.write_file settings {|{"tracker": {"kind": "compozy_tasks"}}|};
           let gaps = Config.from_settings_file ~workspace_root:root settings |> Config.readiness_gaps in
           Alcotest.(check bool) "owner gap skipped" false (has_readiness_requirement "tracker.owner" gaps);
           Alcotest.(check bool) "repo gap skipped" false (has_readiness_requirement "tracker.repo" gaps);
@@ -1527,6 +1577,27 @@ let test_minibeads_settings_load_without_github_token () =
           let config = Config.from_settings_file ~workspace_root:root settings in
           let gaps = Config.readiness_gaps config in
           Alcotest.(check string) "tracker kind" "minibeads" config.tracker.kind;
+          Alcotest.(check bool) "github token not required" false
+            (has_readiness_requirement "environment.GITHUB_TOKEN" gaps)))
+
+let test_compozy_settings_load_without_github_token () =
+  with_env [ ("GITHUB_TOKEN", ""); ("GH_TOKEN", "") ] (fun () ->
+      with_temp_dir "symphony-runtime-compozy-" (fun root ->
+          let runtime_home = Filename.concat root ".symphony" in
+          Util.mkdir_p runtime_home;
+          let settings = Filename.concat runtime_home "settings.json" in
+          Util.write_file settings
+            {|{
+  "tracker": {"kind": "compozy_tasks"},
+  "project": {"activeStates": ["pending"], "terminalStates": ["completed"], "startStatus": "in_progress", "reviewStatus": "completed", "retryStatus": "pending"}
+}|};
+          let config = Config.from_settings_file ~workspace_root:root settings in
+          let gaps = Config.readiness_gaps config in
+          Alcotest.(check string) "tracker kind" "compozy_tasks" config.tracker.kind;
+          Alcotest.(check string) "default root"
+            (Filename.concat (Filename.concat (Unix.realpath root) ".compozy") "tasks")
+            config.tracker.compozy_root;
+          Alcotest.(check int) "default max task step retries" 2 config.tracker.compozy_max_task_step_retries;
           Alcotest.(check bool) "github token not required" false
             (has_readiness_requirement "environment.GITHUB_TOKEN" gaps)))
 
@@ -2261,6 +2332,8 @@ let test_project_status_order_uses_transition_flow () =
       api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
       active_states = [ "Backlog"; "Todo"; "To-Do"; "In progress"; "In Progress"; "In review" ];
       terminal_states = [ "Done"; "Closed"; "Cancelled" ];
       project_status_field = "Status";
@@ -3149,6 +3222,8 @@ let test_orchestrator_resumes_same_ordered_queue_state () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -3591,6 +3666,8 @@ let test_orchestrator_notifies_each_state_mutation () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -3641,6 +3718,8 @@ let test_orchestrator_parses_final_output_when_size_was_already_seen () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -3755,6 +3834,8 @@ let test_orchestrator_parses_final_output_before_timeout_retry () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -3877,6 +3958,8 @@ let test_orchestrator_uses_workspace_changes_as_agent_activity () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -3992,6 +4075,8 @@ let test_orchestrator_preserves_goal_usage_on_blocked_issue_error () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -4513,6 +4598,8 @@ let test_github_project_field_parsing () =
       api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
       active_states = [ "Todo"; "In Progress" ];
       terminal_states = [ "Done" ];
       project_status_field = "Status";
@@ -4575,6 +4662,8 @@ let test_github_active_state_filtering () =
       api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
       active_states = [ "Todo" ];
       terminal_states = [ "Done" ];
       project_status_field = "Status";
@@ -4628,6 +4717,8 @@ let test_github_empty_project_field_values_are_ignored () =
       api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
       active_states = [ "To-Do" ];
       terminal_states = [ "Done" ];
       project_status_field = "Status";
@@ -4668,6 +4759,8 @@ let test_github_status_metadata_parsing () =
       api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
       active_states = [ "Todo" ];
       terminal_states = [ "Done" ];
       project_status_field = "Status";
@@ -4749,6 +4842,8 @@ let stage_capacity_config root ~global_cap =
         api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
         active_states = [ "Backlog"; "Todo"; "In progress"; "In review" ];
         terminal_states = [ "Done"; "Human attention" ];
         project_status_field = "Status";
@@ -4846,6 +4941,8 @@ let test_orchestrator_dispatch_limits () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -5059,6 +5156,8 @@ let test_orchestrator_stage_capacity_skips_full_ordered_stage () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo"; "In progress"; "In review" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -5179,6 +5278,8 @@ let test_orchestrator_dispatches_ordered_queue_only_in_order () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -5304,6 +5405,8 @@ let test_orchestrator_pauses_tracker_after_rate_limit () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -5444,6 +5547,8 @@ let test_orchestrator_does_not_dispatch_terminal_issues () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -5502,6 +5607,8 @@ let test_orchestrator_retries_failed_agent () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -5557,6 +5664,8 @@ let test_orchestrator_timeout_kills_agent_process_group () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -5628,6 +5737,8 @@ let test_orchestrator_moves_status_to_review_on_success () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo"; "In progress" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -5693,6 +5804,8 @@ let test_orchestrator_uses_stage_agent_prompt_and_status () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "In review" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -5797,6 +5910,8 @@ let test_orchestrator_prepends_stage_goal_handoff () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -5931,6 +6046,8 @@ let test_orchestrator_skips_stage_goal_when_disabled () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -6008,6 +6125,8 @@ let stage_context_test_config ?(goal_enabled = false) ?(max_output_bytes = 12000
         api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
         active_states = [ "Todo" ];
         terminal_states = [ "Done" ];
         project_status_field = "Status";
@@ -6733,6 +6852,8 @@ let test_orchestrator_truncates_agent_context_snapshot () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "Todo" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -7017,6 +7138,8 @@ let test_orchestrator_commits_stage_before_success_status () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "In progress" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -7167,6 +7290,8 @@ let test_orchestrator_retries_when_success_status_move_fails () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "In review" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -7240,6 +7365,8 @@ let test_orchestrator_retries_push_failure_before_success_status () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "In progress" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -7340,6 +7467,8 @@ let test_stage_commit_requires_code_changes () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "In progress" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -7402,6 +7531,8 @@ let test_orchestrator_does_not_retry_empty_commit () =
               api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
               active_states = [ "In progress" ];
               terminal_states = [ "Done" ];
               project_status_field = "Status";
@@ -7502,6 +7633,8 @@ let base_orchestrator_config root git =
         api_key = Some "token";
         minibeads_root = ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
         active_states = [ "Todo"; "In progress" ];
         terminal_states = [ "Done" ];
         project_status_field = "Status";
@@ -9328,6 +9461,8 @@ let manual_merge_minibeads_config root =
         terminal_states = [ "closed" ];
         minibeads_root = Filename.concat root ".beads";
         minibeads_command = "mb";
+        compozy_root = ".compozy/tasks";
+        compozy_max_task_step_retries = 2;
       };
     stage_agents;
   }
@@ -9639,15 +9774,23 @@ let () =
             test_config_parses_minibeads_tracker_defaults;
           Alcotest.test_case "parses minibeads tracker settings" `Quick
             test_config_parses_minibeads_tracker_settings;
+          Alcotest.test_case "parses Compozy tracker defaults" `Quick
+            test_config_parses_compozy_tracker_defaults;
+          Alcotest.test_case "parses Compozy tracker settings" `Quick
+            test_config_parses_compozy_tracker_settings;
           Alcotest.test_case "rejects unsupported tracker kind" `Quick test_invalid_tracker_kind;
           Alcotest.test_case "keeps github readiness gaps" `Quick
             test_github_tracker_readiness_keeps_github_gaps;
           Alcotest.test_case "skips github readiness gaps for minibeads" `Quick
             test_minibeads_tracker_readiness_skips_github_gaps;
+          Alcotest.test_case "skips github readiness gaps for Compozy" `Quick
+            test_compozy_tracker_readiness_skips_github_gaps;
           Alcotest.test_case "skips github tracker gaps for minibeads pull requests" `Quick
             test_minibeads_pull_request_readiness_skips_github_tracker_gaps;
           Alcotest.test_case "loads minibeads settings without github token" `Quick
             test_minibeads_settings_load_without_github_token;
+          Alcotest.test_case "loads Compozy settings without github token" `Quick
+            test_compozy_settings_load_without_github_token;
           Alcotest.test_case "normalizes legacy codex app-server command" `Quick test_legacy_codex_app_server_command_normalizes_to_exec;
           Alcotest.test_case "parses agent harnesses" `Quick
             test_config_parses_agent_harnesses_and_legacy_codex_precedence;

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -6110,6 +6110,105 @@ let test_orchestrator_retries_failed_agent () =
           Alcotest.(check int) "retry attempt" 1 retry.attempt
       | [] -> Alcotest.fail "expected retry row")
 
+let test_github_child_failure_retry_behavior_unchanged () =
+  with_temp_dir "symphony-github-child-retry-regression-" (fun root ->
+      let config =
+        {
+          Config.workflow_path = "settings.json";
+          repository_root = root;
+          tracker =
+            {
+              kind = "github";
+              owner = "acme";
+              repo = "widgets";
+              project_number = 7;
+              api_key_env = "GITHUB_TOKEN";
+              api_key = Some "token";
+              minibeads_root = ".beads";
+              minibeads_command = "mb";
+              compozy_root = ".compozy/tasks";
+              compozy_max_task_step_retries = 1;
+              active_states = [ "Todo"; "In progress" ];
+              terminal_states = [ "Done" ];
+              project_status_field = "Status";
+              project_status_on_dispatch = Some "In progress";
+              project_status_on_success = Some "In review";
+              project_status_on_retry = Some "Todo";
+              ensure_project_statuses = true;
+            };
+          polling = { interval_ms = 1000 };
+          workspace = { root = Filename.concat root "workspaces" };
+          git = Config.default_git;
+          agent = { max_concurrent_agents = 1; max_turns = 10; max_retry_backoff_ms = 1000 };
+          codex =
+            {
+              command = "cat";
+              model = Config.default_model;
+              reasoning_effort = Config.default_reasoning_effort;
+              turn_timeout_ms = 1000;
+              read_timeout_ms = 100;
+              stall_timeout_ms = 1000;
+            };
+          agent_harnesses_explicit = false;
+          agent_harnesses = [];
+          logical_agents = [];
+          legacy_agent_harness_paths = [];
+          server = { port = None };
+          pull_request = Config.default_pull_request;
+          protected_paths = Config.default_protected_paths;
+          stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
+        }
+      in
+      let issue = Issue.empty ~id:"I1" ~identifier:"#1" ~title:"One" ~state:"Todo" in
+      let launched = ref None in
+      let launch ~stage:_ ~config:_ ~(workspace : Workspace.t) ~prompt:_ ~issue =
+        launched := Some (issue, workspace);
+        { Orchestrator.pid = None; session_id = Some issue.Issue.id; event = "test-launch"; stdout_path = None; stderr_path = None }
+      in
+      let statuses = ref [] in
+      let set_status _ issue status =
+        statuses := (issue.Issue.identifier, status) :: !statuses;
+        Ok ()
+      in
+      let orchestrator =
+        Orchestrator.make ~launch ~fetch:(fun _ -> Ok [ issue ]) ~set_status ~config
+          ~prompt_template:"Issue {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      let launched_issue, workspace =
+        match !launched with Some launched -> launched | None -> Alcotest.fail "expected GitHub issue launch"
+      in
+      let child =
+        {
+          Orchestrator.pid = 0;
+          issue = launched_issue;
+          stage = None;
+          harness = test_child_harness;
+          issue_id = launched_issue.Issue.id;
+          issue_identifier = launched_issue.identifier;
+          issue_title = launched_issue.title;
+          workspace;
+          started_at = Unix.time ();
+          last_output_at = Unix.time ();
+          stdout_path = None;
+          stderr_path = None;
+          stdout_size = 0;
+          stderr_size = 0;
+        }
+      in
+      Orchestrator.mark_child_failed orchestrator child "agent exited with code 1";
+      let state = Orchestrator.get_state orchestrator in
+      Alcotest.(check int) "no longer running" 0 (List.length state.Runtime_state.running);
+      Alcotest.(check int) "generic retry queued" 1 (List.length state.Runtime_state.retrying);
+      Alcotest.(check (list (pair string string))) "dispatch and retry statuses"
+        [ ("#1", "In progress"); ("#1", "Todo") ]
+        (List.rev !statuses);
+      match state.Runtime_state.retrying with
+      | retry :: _ ->
+          Alcotest.(check string) "retry issue" "I1" retry.issue_id;
+          Alcotest.(check int) "retry attempt" 1 retry.attempt
+      | [] -> Alcotest.fail "expected retry row")
+
 let test_orchestrator_timeout_kills_agent_process_group () =
   with_temp_dir "symphony-orchestrator-timeout-group-" (fun root ->
       let config =
@@ -6819,8 +6918,11 @@ let test_orchestrator_wraps_compozy_task_step_prompt_without_github_prompt_chang
       Alcotest.(check bool) "GitHub prompt has no Compozy wrapper" false
         (contains_substring github_prompt "Compozy Task Step"))
 
+let compozy_task_file compozy_root path =
+  Compozy_tasks_tracker.parse_task_file ~compozy_root path |> require_ok "parse Compozy task"
+
 let compozy_task_status compozy_root path =
-  let task = Compozy_tasks_tracker.parse_task_file ~compozy_root path |> require_ok "parse Compozy task" in
+  let task = compozy_task_file compozy_root path in
   task.status
 
 let compozy_test_config root compozy_root =
@@ -6869,6 +6971,35 @@ let compozy_test_config root compozy_root =
     protected_paths = Config.default_protected_paths;
     stage_agents = { enabled = false; root = Filename.concat root "agents"; default_agent = None; stages = [] };
   }
+
+let compozy_child issue workspace =
+  {
+    Orchestrator.pid = 0;
+    issue;
+    stage = None;
+    harness = test_child_harness;
+    issue_id = issue.Issue.id;
+    issue_identifier = issue.identifier;
+    issue_title = issue.title;
+    workspace;
+    started_at = Unix.time ();
+    last_output_at = Unix.time ();
+    stdout_path = None;
+    stderr_path = None;
+    stdout_size = 0;
+    stderr_size = 0;
+  }
+
+let test_compozy_prd_run_failed_terminal_state_is_visible () =
+  with_temp_dir "symphony-compozy-failed-state-" (fun root ->
+      let prd_dir = Filename.concat root "failed-feature" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task ~status:"completed" ~title:"Done" (Filename.concat prd_dir "task_01.md");
+      write_compozy_task ~status:"failed" ~title:"Failed" (Filename.concat prd_dir "task_02.md");
+      let run = Compozy_tasks_tracker.prd_run_of_directory ~compozy_root:root prd_dir |> require_ok "build PRD run" in
+      Alcotest.(check string) "run state" "failed" run.state;
+      Alcotest.(check int) "failed count" 1 run.counts.failed;
+      Alcotest.(check bool) "no runnable current step" true (Option.is_none run.current_step))
 
 let test_compozy_completion_relaunches_next_step_in_same_worktree () =
   with_temp_dir "symphony-compozy-sequential-" (fun root ->
@@ -6968,6 +7099,90 @@ let test_compozy_completion_relaunches_next_step_in_same_worktree () =
         (compozy_task_status workspace_compozy_root workspace_task_02);
       Alcotest.(check (option string)) "no current step after final completion" None final_progress.current_step;
       Alcotest.(check int) "all steps completed" 2 final_progress.completed)
+
+let test_compozy_failed_step_retries_then_advances_to_next_step () =
+  with_temp_dir "symphony-compozy-retry-advance-" (fun root ->
+      init_repo root "feature/start";
+      let compozy_root = Filename.concat (Filename.concat root ".compozy") "tasks" in
+      let prd_dir = Filename.concat compozy_root "retry-feature" in
+      Util.mkdir_p prd_dir;
+      let task_01 = Filename.concat prd_dir "task_01.md" in
+      let task_02 = Filename.concat prd_dir "task_02.md" in
+      write_compozy_task ~title:"First step" ~body:"\n# First\n\nFirst retry sentinel.\n" task_01;
+      write_compozy_task ~title:"Second step" ~body:"\n# Second\n\nSecond advance sentinel.\n" task_02;
+      ignore (run_ok ~cwd:root "commit Compozy tasks" "git add .compozy && git commit -q -m compozy-tasks");
+      let base_config = compozy_test_config root compozy_root in
+      let config = { base_config with Config.agent = { base_config.agent with max_retry_backoff_ms = 0 } } in
+      let launches = ref [] in
+      let launch ~stage:_ ~config:_ ~(workspace : Workspace.t) ~prompt ~issue =
+        launches := (issue, workspace, prompt) :: !launches;
+        {
+          Orchestrator.pid = None;
+          session_id = Some (string_of_int (List.length !launches));
+          event = "test-launch";
+          stdout_path = None;
+          stderr_path = None;
+        }
+      in
+      let commit_calls = ref 0 in
+      let commit_stage _config _workspace _issue _stage _next_status =
+        incr commit_calls;
+        Ok ()
+      in
+      let orchestrator =
+        Orchestrator.make ~launch ~commit_stage ~config ~prompt_template:"Compozy {{ issue.identifier }}" ()
+      in
+      Orchestrator.poll_once orchestrator;
+      let first_issue, first_workspace, first_prompt =
+        match List.rev !launches with
+        | [ launch ] -> launch
+        | _ -> Alcotest.fail "expected initial Compozy launch"
+      in
+      let workspace_compozy_root = Filename.concat (Filename.concat first_workspace.path ".compozy") "tasks" in
+      let workspace_task_01 = Filename.concat (Filename.concat workspace_compozy_root "retry-feature") "task_01.md" in
+      let workspace_task_02 = Filename.concat (Filename.concat workspace_compozy_root "retry-feature") "task_02.md" in
+      Alcotest.(check bool) "first prompt includes first task" true (contains_substring first_prompt "First retry sentinel.");
+      Orchestrator.mark_child_failed orchestrator (compozy_child first_issue first_workspace) "agent exited with code 1";
+      let first_task_after_failure = compozy_task_file workspace_compozy_root workspace_task_01 in
+      Alcotest.(check string) "first task still current" "in_progress" first_task_after_failure.status;
+      Alcotest.(check int) "retry count incremented" 1 first_task_after_failure.retry_count;
+      Alcotest.(check (option string)) "last error recorded" (Some "agent exited with code 1")
+        first_task_after_failure.last_error;
+      let retry_state = Orchestrator.get_state orchestrator in
+      Alcotest.(check int) "retry queued below limit" 1 (List.length retry_state.Runtime_state.retrying);
+      Orchestrator.poll_once orchestrator;
+      let second_issue, second_workspace, second_prompt =
+        match List.rev !launches with
+        | [ _first; second ] -> second
+        | _ -> Alcotest.fail "expected retry launch for same Compozy task"
+      in
+      Alcotest.(check string) "same workspace on retry" first_workspace.path second_workspace.path;
+      Alcotest.(check bool) "retry prompt still includes first task" true
+        (contains_substring second_prompt "First retry sentinel.");
+      Orchestrator.mark_child_failed orchestrator (compozy_child second_issue second_workspace) "agent exited with code 1";
+      let failed_task = compozy_task_file workspace_compozy_root workspace_task_01 in
+      let advanced_task = compozy_task_file workspace_compozy_root workspace_task_02 in
+      Alcotest.(check string) "failed over limit" "failed" failed_task.status;
+      Alcotest.(check int) "retry count at limit" 2 failed_task.retry_count;
+      Alcotest.(check (option string)) "over-limit error recorded" (Some "agent exited with code 1") failed_task.last_error;
+      Alcotest.(check string) "next task started" "in_progress" advanced_task.status;
+      let final_state = Orchestrator.get_state orchestrator in
+      Alcotest.(check int) "no generic retry after limit" 0 (List.length final_state.Runtime_state.retrying);
+      Alcotest.(check int) "no intermediate stage commit" 0 !commit_calls;
+      (match final_state.Runtime_state.compozy_progress with
+      | Some progress ->
+          Alcotest.(check (option string)) "runtime current step" (Some "task_02.md") progress.current_step;
+          Alcotest.(check int) "runtime failed count" 1 progress.failed;
+          Alcotest.(check int) "runtime skipped count" 0 progress.skipped
+      | None -> Alcotest.fail "expected Compozy progress after failed-over-limit advancement");
+      let _third_issue, third_workspace, third_prompt =
+        match List.rev !launches with
+        | [ _first; _retry; third ] -> third
+        | _ -> Alcotest.fail "expected launch for next Compozy task"
+      in
+      Alcotest.(check string) "same workspace for next task" first_workspace.path third_workspace.path;
+      Alcotest.(check bool) "next prompt includes second task" true
+        (contains_substring third_prompt "Second advance sentinel."))
 
 let stage_context_command ?(cwd = "agentWorktree") ?(timeout_ms = 1000) ?(max_output_bytes = 4096) argv =
   { Config.argv; cwd; timeout_ms; max_output_bytes; validation_error = None }
@@ -10454,6 +10669,8 @@ let () =
             test_compozy_issue_branch_key_uses_identifier_not_digits_only;
           Alcotest.test_case "reports empty Compozy PRD run as not runnable" `Quick
             test_compozy_empty_prd_run_is_not_runnable;
+          Alcotest.test_case "reports failed Compozy PRD run state visibly" `Quick
+            test_compozy_prd_run_failed_terminal_state_is_visible;
           Alcotest.test_case "discovers distinct Compozy PRD directories" `Quick
             test_compozy_two_workflow_directories_have_distinct_ids;
           Alcotest.test_case "reports duplicate Compozy task indexes as not runnable" `Quick
@@ -10689,6 +10906,8 @@ let () =
             test_orchestrator_minibeads_stub_dispatch_without_github_settings;
           Alcotest.test_case "does not dispatch terminal issues" `Quick test_orchestrator_does_not_dispatch_terminal_issues;
           Alcotest.test_case "retries failed agents" `Quick test_orchestrator_retries_failed_agent;
+          Alcotest.test_case "keeps GitHub child retry behavior unchanged" `Quick
+            test_github_child_failure_retry_behavior_unchanged;
           Alcotest.test_case "timeout kills agent process group" `Quick
             test_orchestrator_timeout_kills_agent_process_group;
           Alcotest.test_case "moves status to review on success" `Quick test_orchestrator_moves_status_to_review_on_success;
@@ -10708,6 +10927,8 @@ let () =
             test_orchestrator_wraps_compozy_task_step_prompt_without_github_prompt_change;
           Alcotest.test_case "relaunches Compozy task steps in one worktree" `Quick
             test_compozy_completion_relaunches_next_step_in_same_worktree;
+          Alcotest.test_case "retries failed Compozy task step then advances" `Quick
+            test_compozy_failed_step_retries_then_advances_to_next_step;
           Alcotest.test_case "skips stage goal handoff when disabled" `Quick test_orchestrator_skips_stage_goal_when_disabled;
           Alcotest.test_case "runs stage context command before launch" `Quick
             test_orchestrator_runs_stage_context_command_before_launch;

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -1429,6 +1429,12 @@ let test_dispatch_selects_pi_harness_before_start_status_update () =
 let has_readiness_requirement requirement gaps =
   List.exists (fun (gap : Config.readiness_gap) -> gap.requirement = requirement) gaps
 
+let runtime_requirements gaps =
+  List.map (fun (gap : Runtime_state.readiness_gap) -> gap.requirement) gaps
+
+let has_runtime_readiness_requirement requirement gaps =
+  List.exists (fun (gap : Runtime_state.readiness_gap) -> gap.requirement = requirement) gaps
+
 let test_config_defaults_to_github_tracker_kind () =
   with_temp_dir "symphony-settings-default-tracker-" (fun root ->
       Util.mkdir_p (Filename.concat root ".symphony");
@@ -1887,6 +1893,81 @@ let test_compozy_settings_load_without_github_token () =
           Alcotest.(check int) "default max task step retries" 2 config.tracker.compozy_max_task_step_retries;
           Alcotest.(check bool) "github token not required" false
             (has_readiness_requirement "environment.GITHUB_TOKEN" gaps)))
+
+let write_compozy_settings ?(extra = "") root =
+  Util.mkdir_p (Filename.concat root ".symphony");
+  let settings = Filename.concat root ".symphony/settings.json" in
+  Util.write_file settings
+    (Printf.sprintf
+       {|{
+  "tracker": {"kind": "compozy_tasks"},
+  "stageAgents": {"enabled": false}%s
+}|}
+       extra);
+  Config.from_settings_file ~workspace_root:root settings
+
+let test_compozy_readiness_missing_root_gap () =
+  with_env [ ("GITHUB_TOKEN", ""); ("GH_TOKEN", "") ] (fun () ->
+      with_temp_dir "symphony-compozy-readiness-missing-root-" (fun root ->
+          let config = write_compozy_settings root in
+          let tracker = Issue_tracker.make config in
+          let gaps = tracker.readiness_gaps () in
+          Alcotest.(check bool) "root gap" true (has_runtime_readiness_requirement "tracker.compozy.root" gaps);
+          Alcotest.(check bool) "owner gap omitted" false (has_runtime_readiness_requirement "tracker.owner" gaps);
+          Alcotest.(check bool) "repo gap omitted" false (has_runtime_readiness_requirement "tracker.repo" gaps);
+          Alcotest.(check bool) "project gap omitted" false
+            (has_runtime_readiness_requirement "tracker.projectNumber" gaps);
+          Alcotest.(check bool) "token gap omitted" false
+            (has_runtime_readiness_requirement "environment.GITHUB_TOKEN" gaps)))
+
+let test_compozy_readiness_no_runnable_prd_run_gap () =
+  with_temp_dir "symphony-compozy-readiness-no-runnable-" (fun root ->
+      let config = write_compozy_settings root in
+      Util.mkdir_p (Filename.concat config.Config.tracker.compozy_root "empty-run");
+      let gaps = (Issue_tracker.make config).readiness_gaps () in
+      Alcotest.(check bool) "runnable gap" true
+        (has_runtime_readiness_requirement "tracker.compozy.runnablePrdRun" gaps);
+      Alcotest.(check bool) "github token omitted" false
+        (has_runtime_readiness_requirement "environment.GITHUB_TOKEN" gaps))
+
+let test_compozy_runtime_readiness_valid_fixture_omits_github_gaps () =
+  with_env [ ("GITHUB_TOKEN", ""); ("GH_TOKEN", "") ] (fun () ->
+      with_temp_dir "symphony-compozy-runtime-readiness-valid-" (fun root ->
+          let config = write_compozy_settings root in
+          let prd_dir = Filename.concat config.Config.tracker.compozy_root "valid-run" in
+          Util.mkdir_p prd_dir;
+          write_compozy_task ~title:"Runnable" (Filename.concat prd_dir "task_01.md");
+          let state = Runtime_readiness.state config in
+          let requirements = runtime_requirements state.Runtime_state.readiness_gaps in
+          Alcotest.(check string) "tracker kind" "compozy_tasks" state.tracker_kind;
+          Alcotest.(check (list string)) "no readiness gaps" [] requirements;
+          Alcotest.(check bool) "no github token gap" false
+            (List.exists (( = ) "environment.GITHUB_TOKEN") requirements);
+          match state.compozy_progress with
+          | Some progress ->
+              Alcotest.(check string) "run id" "compozy:valid-run" progress.run_id;
+              Alcotest.(check (option string)) "current step" (Some "task_01.md") progress.current_step;
+              Alcotest.(check int) "total" 1 progress.total
+          | None -> Alcotest.fail "expected initial Compozy progress"))
+
+let test_github_runtime_readiness_still_reports_github_gaps () =
+  with_env [ ("GITHUB_TOKEN", ""); ("GH_TOKEN", "") ] (fun () ->
+      with_temp_dir "symphony-github-runtime-readiness-gaps-" (fun root ->
+          Util.mkdir_p (Filename.concat root ".symphony");
+          let settings = Filename.concat root ".symphony/settings.json" in
+          Util.write_file settings
+            {|{
+  "tracker": {"kind": "github", "owner": "your-org", "repo": "your-repo", "projectNumber": 0},
+  "stageAgents": {"enabled": false}
+}|};
+          let state = Config.from_settings_file ~workspace_root:root settings |> Runtime_readiness.state in
+          let requirements = runtime_requirements state.Runtime_state.readiness_gaps in
+          Alcotest.(check bool) "owner gap" true (List.exists (( = ) "tracker.owner") requirements);
+          Alcotest.(check bool) "repo gap" true (List.exists (( = ) "tracker.repo") requirements);
+          Alcotest.(check bool) "project gap" true
+            (List.exists (( = ) "tracker.projectNumber") requirements);
+          Alcotest.(check bool) "token gap" true
+            (List.exists (( = ) "environment.GITHUB_TOKEN") requirements)))
 
 let test_legacy_codex_app_server_command_normalizes_to_exec () =
   let content =
@@ -4691,9 +4772,6 @@ let test_issue_tracker_github_lookup_preserves_diagnostics () =
                 [ None; None; Some "#3" ]
                 (List.map (Option.map (fun issue -> issue.Issue.identifier)) issues)))
 
-let runtime_requirements gaps =
-  List.map (fun (gap : Runtime_state.readiness_gap) -> gap.requirement) gaps
-
 let test_minibeads_readiness_missing_command_gap () =
   with_temp_dir "symphony-minibeads-command-gap-" (fun root ->
       Util.mkdir_p (Filename.concat root ".beads");
@@ -4947,6 +5025,29 @@ let test_minibeads_runtime_readiness_omits_github_gaps () =
             (List.exists (( = ) "tracker.minibeads.command") requirements);
           Alcotest.(check bool) "minibeads store gap included" true
             (List.exists (( = ) "tracker.minibeads.store") requirements)))
+
+let test_issue_tracker_selects_compozy_adapter () =
+  with_temp_dir "symphony-compozy-adapter-" (fun root ->
+      let config = write_compozy_settings root in
+      let prd_dir = Filename.concat config.Config.tracker.compozy_root "adapter-run" in
+      Util.mkdir_p prd_dir;
+      write_compozy_task ~title:"Adapter run" (Filename.concat prd_dir "task_01.md");
+      let tracker = Issue_tracker.make config in
+      Alcotest.(check string) "kind" "compozy_tasks" tracker.kind;
+      Alcotest.(check bool) "pending active" true (tracker.is_active "pending");
+      Alcotest.(check bool) "completed terminal" true (tracker.is_terminal "completed");
+      Alcotest.(check (list string)) "requirements" [] (runtime_requirements (tracker.readiness_gaps ()));
+      (match tracker.fetch_candidates () with
+      | Ok [ issue ] ->
+          Alcotest.(check string) "identifier" "compozy:adapter-run" issue.Issue.identifier;
+          Alcotest.(check string) "state" "pending" issue.state
+      | Ok issues -> Alcotest.fail (Printf.sprintf "expected one candidate, got %d" (List.length issues))
+      | Error (Issue_tracker.Failed message) -> Alcotest.fail message
+      | Error (Issue_tracker.Rate_limited _) -> Alcotest.fail "Compozy tracker should not rate-limit");
+      match tracker.fetch_by_identifiers [ "compozy:adapter-run" ] with
+      | Ok [ Some issue ] -> Alcotest.(check string) "lookup hit" "compozy:adapter-run" issue.Issue.identifier
+      | Ok _ -> Alcotest.fail "expected lookup hit"
+      | Error message -> Alcotest.fail message)
 
 let test_github_project_field_parsing () =
   let config =
@@ -10232,6 +10333,14 @@ let () =
             test_minibeads_settings_load_without_github_token;
           Alcotest.test_case "loads Compozy settings without github token" `Quick
             test_compozy_settings_load_without_github_token;
+          Alcotest.test_case "reports missing Compozy root readiness" `Quick
+            test_compozy_readiness_missing_root_gap;
+          Alcotest.test_case "reports no runnable Compozy PRD run readiness" `Quick
+            test_compozy_readiness_no_runnable_prd_run_gap;
+          Alcotest.test_case "serves Compozy runtime readiness without GitHub gaps" `Quick
+            test_compozy_runtime_readiness_valid_fixture_omits_github_gaps;
+          Alcotest.test_case "keeps GitHub runtime readiness gaps" `Quick
+            test_github_runtime_readiness_still_reports_github_gaps;
           Alcotest.test_case "normalizes legacy codex app-server command" `Quick test_legacy_codex_app_server_command_normalizes_to_exec;
           Alcotest.test_case "parses agent harnesses" `Quick
             test_config_parses_agent_harnesses_and_legacy_codex_precedence;
@@ -10354,6 +10463,8 @@ let () =
           Alcotest.test_case "selects GitHub issue tracker adapter" `Quick test_issue_tracker_selects_github_adapter;
           Alcotest.test_case "selects minibeads issue tracker adapter" `Quick
             test_issue_tracker_selects_minibeads_adapter;
+          Alcotest.test_case "selects Compozy issue tracker adapter" `Quick
+            test_issue_tracker_selects_compozy_adapter;
           Alcotest.test_case "preserves active and terminal state semantics" `Quick
             test_issue_tracker_github_state_semantics_match_existing;
           Alcotest.test_case "maps GitHub rate limits to poll errors" `Quick

--- a/apps/frontend/src/Pages/Dashboard.res
+++ b/apps/frontend/src/Pages/Dashboard.res
@@ -17,6 +17,16 @@ type queueEntry = {
   skipReason: string,
 }
 
+type compozyProgress = {
+  runId: string,
+  slug: string,
+  currentStep: string,
+  completed: string,
+  failed: string,
+  skipped: string,
+  total: string,
+}
+
 type snapshot = {
   workspaceRepositoryName: string,
   trackerKind: string,
@@ -30,6 +40,7 @@ type snapshot = {
   statusOrder: array<string>,
   issues: array<issueItem>,
   orderedQueue: array<queueEntry>,
+  compozyProgress: option<compozyProgress>,
 }
 
 @send external arrayPush: (array<'a>, 'a) => int = "push"
@@ -258,7 +269,7 @@ let queueEntryRow = (entry: queueEntry) =>
       <div className="mt-1 truncate text-sm text-neutral-100">
         {React.string(
           if entry.title == "" {
-            "Pending issue details"
+            "Pending work item details"
           } else {
             entry.title
           },
@@ -311,6 +322,82 @@ let orderedQueuePanel = entries =>
         </HeroUI.AccordionPanel>
       </HeroUI.AccordionItem>
     </HeroUI.AccordionRoot>
+  }
+
+let isCompozyTracker = trackerKind => sameState(trackerKind, "compozy_tasks")
+
+let trackedWorkLabel = trackerKind =>
+  if isCompozyTracker(trackerKind) {
+    "PRD runs"
+  } else {
+    "issues"
+  }
+
+let emptyTrackedWorkMessage = trackerKind =>
+  if isCompozyTracker(trackerKind) {
+    "No PRD runs were returned by the latest snapshot."
+  } else {
+    "No tracked issues were returned by the latest snapshot."
+  }
+
+let columnDescription = trackerKind =>
+  if isCompozyTracker(trackerKind) {
+    "Columns follow Runtime State status order and work item states."
+  } else {
+    "Columns follow Runtime State status order and issue states."
+  }
+
+let metricTile = (label, value, tone) =>
+  <div className="rounded border border-neutral-800 bg-[#1d1d1d] px-3 py-3">
+    <div className="text-[11px] font-semibold uppercase tracking-normal text-neutral-500">
+      {React.string(label)}
+    </div>
+    <div className={"mt-2 text-2xl font-semibold leading-none " ++ tone}>
+      {React.string(value)}
+    </div>
+  </div>
+
+let compozyProgressPanel = (progress: option<compozyProgress>) =>
+  switch progress {
+  | None => React.null
+  | Some(progress) =>
+    <HeroUI.Card className="rounded border border-neutral-800 bg-neutral-950">
+      <HeroUI.CardHeader
+        className="flex flex-col gap-3 border-b border-neutral-800 px-4 py-4 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <div className="min-w-0">
+          <div className="text-sm font-semibold text-neutral-100">
+            {React.string("PRD run progress")}
+          </div>
+          <div className="mt-1 truncate font-mono text-xs text-neutral-500">
+            {React.string(progress.runId)}
+          </div>
+        </div>
+        <HeroUI.Chip
+          size="sm"
+          variant="flat"
+          className="self-start rounded border border-teal-800 bg-teal-950/70 px-3 text-teal-100 sm:self-auto"
+        >
+          {React.string(progress.slug)}
+        </HeroUI.Chip>
+      </HeroUI.CardHeader>
+      <HeroUI.CardContent className="p-4">
+        <div className="grid gap-3 md:grid-cols-[minmax(0,1.5fr)_repeat(4,minmax(5rem,1fr))]">
+          <div className="rounded border border-neutral-800 bg-[#1d1d1d] px-3 py-3">
+            <div className="text-[11px] font-semibold uppercase tracking-normal text-neutral-500">
+              {React.string("Current step")}
+            </div>
+            <div className="mt-2 truncate font-mono text-sm text-neutral-100">
+              {React.string(progress.currentStep)}
+            </div>
+          </div>
+          {metricTile("Completed", progress.completed, "text-emerald-200")}
+          {metricTile("Failed", progress.failed, "text-red-200")}
+          {metricTile("Skipped", progress.skipped, "text-amber-200")}
+          {metricTile("Total", progress.total, "text-neutral-100")}
+        </div>
+      </HeroUI.CardContent>
+    </HeroUI.Card>
   }
 
 let emptyOrchestrator = error => <>
@@ -394,15 +481,16 @@ let make = (~snapshot: option<snapshot>, ~error: option<string>) =>
         {renderBanner("warning", "Startup Reconciliation", data.startupReconciliation)}
         {renderBanner("error", "Runtime State Error", data.lastError)}
         {orderedQueuePanel(data.orderedQueue)}
+        {compozyProgressPanel(data.compozyProgress)}
         <HeroUI.Card className="rounded border border-neutral-800 bg-neutral-950">
         <HeroUI.CardHeader
             className="flex flex-col items-center justify-center border-b border-neutral-800 px-4 py-4 text-center"
           >
             <div className="mb-2 text-sm font-semibold text-neutral-100">
-              {React.string("Issue tracker")}
+              {React.string("Work tracker")}
             </div>
             <div className="mb-3 text-xs text-neutral-500">
-              {React.string("Columns follow Runtime State status order and issue states.")}
+              {React.string(columnDescription(data.trackerKind))}
             </div>
             <div className="flex flex-wrap items-center justify-center gap-2">
               <HeroUI.Chip
@@ -410,7 +498,9 @@ let make = (~snapshot: option<snapshot>, ~error: option<string>) =>
                 variant="flat"
                 className="rounded border border-teal-800 bg-teal-950/70 px-3 text-teal-100"
               >
-                {React.string(Array.length(data.issues)->Int.toString ++ " tracked")}
+                {React.string(
+                  Array.length(data.issues)->Int.toString ++ " tracked " ++ trackedWorkLabel(data.trackerKind),
+                )}
               </HeroUI.Chip>
               <HeroUI.Chip
                 size="sm"
@@ -424,7 +514,7 @@ let make = (~snapshot: option<snapshot>, ~error: option<string>) =>
           {switch Array.length(data.issues) == 0 && Array.length(data.statusOrder) == 0 {
           | true =>
             <HeroUI.CardContent className="p-4 text-sm text-neutral-400">
-              {React.string("No tracked issues were returned by the latest snapshot.")}
+              {React.string(emptyTrackedWorkMessage(data.trackerKind))}
             </HeroUI.CardContent>
           | false =>
             <HeroUI.CardContent className="overflow-x-auto p-4">

--- a/apps/frontend/src/RuntimeStateSnapshot.res
+++ b/apps/frontend/src/RuntimeStateSnapshot.res
@@ -92,6 +92,16 @@ type orderedQueueEntry = {
 
 type orderedQueue = {entries: array<orderedQueueEntry>}
 
+type compozyProgress = {
+  run_id: string,
+  slug: string,
+  current_step: option<string>,
+  completed: int,
+  failed: int,
+  skipped: int,
+  total: int,
+}
+
 type startupReconciliation = {
   issue_identifier: option<string>,
   task_branch: option<string>,
@@ -127,6 +137,7 @@ type runtimeState = {
   issue_errors: array<blockedTaskError>,
   status_order: array<string>,
   ordered_queue: option<orderedQueue>,
+  compozy_progress: option<compozyProgress>,
 }
 
 @val external shortDescription: string => string = "shortDescription"
@@ -218,6 +229,21 @@ let orderedQueueEntries = state =>
   | None => []
   }
 
+let compozyProgressForDashboard = state =>
+  switch state.compozy_progress {
+  | Some(progress) =>
+    Some({
+      Dashboard.runId: progress.run_id,
+      slug: progress.slug,
+      currentStep: stringOrFallback(progress.current_step, "No active step"),
+      completed: progress.completed->Int.toString,
+      failed: progress.failed->Int.toString,
+      skipped: progress.skipped->Int.toString,
+      total: progress.total->Int.toString,
+    })
+  | None => None
+  }
+
 let snapshotFromState = state => {
   Dashboard.workspaceRepositoryName: stringOrEmpty(state.workspace_repository_name),
   trackerKind: RuntimeState.trackerKindOrDefault(state.tracker_kind),
@@ -230,6 +256,7 @@ let snapshotFromState = state => {
   lastError: stringOrEmpty(state.last_error),
   statusOrder: arrayOrEmpty(state.status_order),
   orderedQueue: orderedQueueEntries(state),
+  compozyProgress: compozyProgressForDashboard(state),
   issues: arrayOrEmpty(state.issues)->Array.map(issue => {
     {
       Dashboard.identifier: issue.issue_identifier,

--- a/apps/frontend/test/liveState.test.mjs
+++ b/apps/frontend/test/liveState.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { make as Dashboard } from "../src/Pages/Dashboard.res.js";
 import { createLiveStateConnection } from "../src/LiveState.res.js";
 import { trackerKindOrDefault } from "../src/RuntimeState.res.js";
 import { snapshotFromState } from "../src/RuntimeStateSnapshot.res.js";
@@ -46,7 +49,7 @@ assert.equal(sockets[0].url, "ws://127.0.0.1:8080/api/v1/state/live");
 sockets[0].onmessage({
   data: JSON.stringify({
     counts: { running: 1, retrying: 1 },
-    tracker_kind: "minibeads",
+    tracker_kind: "compozy_tasks",
     usage_totals: { total_tokens: 42 },
     generated_at: "2026-05-04T00:00:00Z",
     issues: [
@@ -85,22 +88,88 @@ sockets[0].onmessage({
         },
       },
     ],
+    compozy_progress: {
+      run_id: "compozy:compozy-tasks-run-integration",
+      slug: "compozy-tasks-run-integration",
+      current_step: "task_02.md",
+      completed: 1,
+      failed: 0,
+      skipped: 0,
+      total: 8,
+    },
   }),
 });
 assert.equal(snapshots.length, 1);
 assert.equal(snapshots[0].counts.running, 1);
-assert.equal(trackerKindOrDefault(snapshots[0].tracker_kind), "minibeads");
+assert.equal(trackerKindOrDefault(snapshots[0].tracker_kind), "compozy_tasks");
 assert.equal(snapshots[0][`codex_${"totals"}`], undefined);
 assert.equal(snapshots[0].usage_totals.total_tokens, 42);
 assert.equal(snapshots[0].running[0].context_status.state, "succeeded");
 assert.equal(snapshots[0].running[0].harness_name, "engineer");
 assert.equal(snapshots[0].running[0].harness_kind, "claude");
 assert.equal(snapshots[0].retrying[0].context_status.state, "timed_out");
+assert.equal(snapshots[0].compozy_progress.current_step, "task_02.md");
+assert.equal(snapshots[0].compozy_progress.completed, 1);
+assert.equal(snapshots[0].compozy_progress.failed, 0);
+assert.equal(snapshots[0].compozy_progress.skipped, 0);
+assert.equal(snapshots[0].compozy_progress.total, 8);
 
 const dashboardSnapshot = snapshotFromState(snapshots[0]);
-assert.equal(dashboardSnapshot.trackerKind, "minibeads");
+assert.equal(dashboardSnapshot.trackerKind, "compozy_tasks");
 assert.equal(dashboardSnapshot.tokens, "42");
 assert.equal(dashboardSnapshot.issues[0].harnessIdentity, "engineer (claude)");
+assert.equal(dashboardSnapshot.compozyProgress.runId, "compozy:compozy-tasks-run-integration");
+assert.equal(dashboardSnapshot.compozyProgress.currentStep, "task_02.md");
+assert.equal(dashboardSnapshot.compozyProgress.completed, "1");
+assert.equal(dashboardSnapshot.compozyProgress.failed, "0");
+assert.equal(dashboardSnapshot.compozyProgress.skipped, "0");
+assert.equal(dashboardSnapshot.compozyProgress.total, "8");
+
+const compozyDashboardSnapshot = snapshotFromState({
+  tracker_kind: "compozy_tasks",
+  counts: { running: 1, retrying: 0 },
+  usage_totals: { total_tokens: 11 },
+  generated_at: "2026-05-04T00:03:00Z",
+  status_order: ["In Progress"],
+  issues: [
+    {
+      issue_id: "compozy:compozy-tasks-run-integration",
+      issue_identifier: "compozy:compozy-tasks-run-integration",
+      title: "Compozy Tasks Run Integration",
+      state: "In Progress",
+      description: "Run task files as one PRD run.",
+    },
+  ],
+  running: [],
+  retrying: [],
+  issue_errors: [],
+  compozy_progress: {
+    run_id: "compozy:compozy-tasks-run-integration",
+    slug: "compozy-tasks-run-integration",
+    current_step: "task_02.md",
+    completed: 1,
+    failed: 0,
+    skipped: 1,
+    total: 8,
+  },
+});
+
+assert.equal(compozyDashboardSnapshot.trackerKind, "compozy_tasks");
+assert.equal(compozyDashboardSnapshot.compozyProgress.currentStep, "task_02.md");
+assert.equal(compozyDashboardSnapshot.compozyProgress.completed, "1");
+assert.equal(compozyDashboardSnapshot.compozyProgress.failed, "0");
+assert.equal(compozyDashboardSnapshot.compozyProgress.skipped, "1");
+assert.equal(compozyDashboardSnapshot.compozyProgress.total, "8");
+
+const compozyMarkup = renderToStaticMarkup(
+  React.createElement(Dashboard, { snapshot: compozyDashboardSnapshot, error: undefined }),
+);
+assert.match(compozyMarkup, /PRD run progress/);
+assert.match(compozyMarkup, /task_02\.md/);
+assert.match(compozyMarkup, /Completed/);
+assert.match(compozyMarkup, /Skipped/);
+assert.match(compozyMarkup, /1 tracked PRD runs/);
+assert.match(compozyMarkup, /work item states/);
 
 const richDashboardSnapshot = snapshotFromState({
   workspace_repository_name: "workspace-repo",
@@ -256,6 +325,8 @@ sockets[0].onmessage({
 });
 assert.equal(snapshots.length, 2);
 assert.equal(trackerKindOrDefault(snapshots[1].tracker_kind), "github");
+assert.equal(snapshots[1].compozy_progress, undefined);
+assert.equal(snapshotFromState(snapshots[1]).compozyProgress, undefined);
 assert.equal(snapshots[1].running[0].context_status, undefined);
 assert.equal(snapshots[1].running[0].harness_name, undefined);
 

--- a/scripts/validate-docs-examples.js
+++ b/scripts/validate-docs-examples.js
@@ -2,6 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const { execFileSync } = require("child_process");
 
 const root = path.resolve(__dirname, "..");
 const docs = [
@@ -57,7 +58,7 @@ function parseJsonBlock(block) {
 }
 
 function assertTrackerExamples(blocks) {
-  const allowedKinds = new Set(["github", "minibeads"]);
+  const allowedKinds = new Set(["github", "minibeads", "compozy_tasks"]);
   const seenKinds = new Set();
 
   for (const block of blocks) {
@@ -68,7 +69,7 @@ function assertTrackerExamples(blocks) {
 
     const kind = parsed.tracker.kind;
     if (!allowedKinds.has(kind)) {
-      fail(`${block.relativePath} json block ${block.index} must use tracker.kind "github" or "minibeads"`);
+      fail(`${block.relativePath} json block ${block.index} must use a documented tracker.kind`);
       continue;
     }
 
@@ -80,6 +81,15 @@ function assertTrackerExamples(blocks) {
       }
       if (parsed.tracker.root !== ".beads") {
         fail(`${block.relativePath} json block ${block.index} must document tracker.root for minibeads`);
+      }
+    }
+
+    if (kind === "compozy_tasks") {
+      if (!parsed.tracker.compozy || parsed.tracker.compozy.root !== ".compozy/tasks") {
+        fail(`${block.relativePath} json block ${block.index} must document tracker.compozy.root`);
+      }
+      if (parsed.tracker.compozy.maxTaskStepRetries !== 2) {
+        fail(`${block.relativePath} json block ${block.index} must document tracker.compozy.maxTaskStepRetries`);
       }
     }
   }
@@ -97,6 +107,8 @@ function assertGlossaryTerms() {
     "GitHub Tracker",
     "Local Issue Tracker",
     "Local Issue File",
+    "Compozy PRD Run",
+    "Compozy Task Step",
     "Runtime Settings",
     "Readiness Gap",
   ];
@@ -132,16 +144,101 @@ function assertReadinessGuidance(readme) {
   }
 }
 
+function assertCompozyGuidance(readme) {
+  const required = [
+    'tracker.kind = "compozy_tasks"',
+    "GitHub remains the default Issue Tracker",
+    ".compozy/tasks/<task_name>/",
+    "Compozy PRD Run",
+    "Compozy Task Steps",
+    "tracker.compozy.root",
+    "tracker.compozy.maxTaskStepRetries",
+    "pending",
+    "in_progress",
+    "completed",
+    "failed",
+    "skipped",
+    "Runtime State",
+    "Terminal Console",
+    "Web Dashboard",
+    "compozy:<task_name>",
+    "Ordered Queue",
+    "Manual Task Merge",
+  ];
+
+  for (const phrase of required) {
+    if (!readme.includes(phrase)) {
+      fail(`README.md is missing Compozy tracker guidance for ${phrase}`);
+    }
+  }
+}
+
 function assertGitHubScope(projectTracking) {
   const required = [
     'tracker.kind` is `"github"`',
     "GitHub Tracker",
     "For minibeads Local Issue Tracker setup",
+    "For Compozy-backed Local Issue Tracker setup",
   ];
 
   for (const phrase of required) {
     if (!projectTracking.includes(phrase)) {
       fail(`.github/project-tracking.md is missing scoped GitHub Tracker wording: ${phrase}`);
+    }
+  }
+}
+
+function collectMarkdownFiles(relativeDir) {
+  const absoluteDir = path.join(root, relativeDir);
+  const entries = fs.readdirSync(absoluteDir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const childRelative = path.join(relativeDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectMarkdownFiles(childRelative));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(childRelative);
+    }
+  }
+
+  return files;
+}
+
+function assertLegacyWorkflowReferencesAreScoped() {
+  const filesToScan = [...docs];
+  filesToScan.push(...collectMarkdownFiles("docs"));
+
+  const allowedContext = /\blegacy\b|\bfixture\b|\bcompatibility\b|\bearlier root workflow\b|\bnot the active Runtime Contract\b/i;
+  for (const relativePath of filesToScan) {
+    const text = readDoc(relativePath);
+    const lines = text.split(/\r?\n/);
+    lines.forEach((line, index) => {
+      const contextWindow = [
+        lines[index - 2] || "",
+        lines[index - 1] || "",
+        line,
+        lines[index + 1] || "",
+        lines[index + 2] || "",
+      ].join(" ");
+      if (/WORKFLOW\.md|WORKFLOW\.example\.md/.test(line) && !allowedContext.test(contextWindow)) {
+        fail(`${relativePath}:${index + 1} contains an unscoped legacy WORKFLOW reference`);
+      }
+    });
+  }
+}
+
+function assertNoGeneratedResJsDiff() {
+  const changedFrontendFiles = execFileSync("git", ["diff", "--name-only", "--", "apps/frontend/src"], {
+    cwd: root,
+    encoding: "utf8",
+  })
+    .split(/\r?\n/)
+    .filter(Boolean);
+
+  for (const changedFile of changedFrontendFiles) {
+    if (changedFile.endsWith(".res.js")) {
+      fail(`generated ReScript output changed in documentation-only task: ${changedFile}`);
     }
   }
 }
@@ -157,7 +254,10 @@ for (const [relativePath, markdown] of markdownByPath.entries()) {
 assertTrackerExamples(jsonBlocks);
 assertGlossaryTerms();
 assertReadinessGuidance(markdownByPath.get("README.md"));
+assertCompozyGuidance(markdownByPath.get("README.md"));
 assertGitHubScope(markdownByPath.get(".github/project-tracking.md"));
+assertLegacyWorkflowReferencesAreScoped();
+assertNoGeneratedResJsDiff();
 
 if (failures.length > 0) {
   console.error("Documentation validation failed:");


### PR DESCRIPTION
## Summary
- add Compozy tracker runtime settings, task parsing, PRD-run mapping, readiness, orchestration, retry, queue, and manual merge support
- surface Compozy progress through backend runtime state and the frontend dashboard
- document the Compozy tracker workflow and mark the Compozy task plan complete

## Tests
- Verification evidence is recorded across the completed Compozy task files in `.compozy/tasks/compozy-tasks-run-integration/`.