### PR TITLE
document TUI usage and examples

### DIFF
--- a/apps/tui/README.md
+++ b/apps/tui/README.md
@@ -8,8 +8,10 @@ The library is intentionally framework-free. The layout engine uses `toffee`, an
 
 - Buffered cell surface with plain snapshots, ANSI rendering, and diff rendering.
 - Semantic styling primitives: colors, attributes, themes, borders, padding, margins, and flex properties.
-- Components: `Text`, `Box`, `Input`, `Select`, `Scroll_box`, `Progress_bar`, `Sparkline`, and footer helper.
-- Dashboard/workspace helpers: `Components.app_shell`, `header`, `panel`, `rule_panel`, `wordmark`, `badge`, `tab_bar`, `metric_card`, `key_value`, `table`, `log_feed`, `message`, `timeline`, `composer`, `command_block`, `model_status`, `hint_bar`, `tip`, `split`, `row`, and `column`.
+- Components: `text`, `box`, `input`, `select`, `scroll_box`, `progress_bar`, `sparkline`, `panel`, `badge`, `tab_bar`, `key_value`, `table`, `split`, `row`, and `column`.
+- Themed component design contexts with `Components.make_design` and `?design` arguments for reusable widgets and patterns.
+- Application patterns: `Patterns.app_shell`, `header`, `rule_panel`, `metric_card`, `log_feed`, `message`, `timeline`, `composer`, `command_bar`, `footer`, and `modal`.
+- Example presets: `Presets.Open_code.wordmark`, `model_status`, `command_block`, `hint_bar`, and `tip`.
 - Keyboard parsing for common terminal sequences plus focus routing and basic widget key handling.
 - Keymap engine with single-key and multi-stroke bindings.
 - Terminal helpers for alternate screen, raw mode, viewport detection, color capability, and a small render loop.

--- a/apps/tui/README.md
+++ b/apps/tui/README.md
@@ -51,6 +51,7 @@ Use the lower layers when you need control, and the higher layers when you want 
 - Presets: `Presets.Open_code.wordmark`, `model_status`, `command_block`, `hint_bar`, and `tip`.
 
 `Components` are the stable building blocks. `Patterns` are opinionated application layouts. `Presets` are example-shaped helpers and should not be treated as neutral primitives.
+Existing callers can still reach moved pattern and preset helpers through `Components`; prefer the canonical `Patterns` and `Presets` modules for new code.
 
 ## Layout Usage
 

--- a/apps/tui/README.md
+++ b/apps/tui/README.md
@@ -1,32 +1,32 @@
 # Symphony TUI
 
-Symphony TUI is a modern terminal UI library for OCaml. It follows the same core shape as OpenTUI: a renderer-owned root tree, composable components, a buffered cell surface, flexbox-style layout, structured keyboard events, and practical widgets.
+Symphony TUI is an OCaml terminal UI toolkit. It provides a renderer-owned component tree, buffered cell surfaces, ANSI and plain-text rendering, Toffee-backed flexbox layout, keyboard parsing, keymaps, viewport helpers, and reusable terminal UI widgets.
 
-The library is intentionally framework-free. The layout engine uses `toffee`, an OCaml port of Taffy, so panels, rows, columns, padding, borders, growth, and fixed sizes behave like a terminal-focused subset of CSS flexbox.
+The package is intentionally framework-free. You build a tree of `Tui.Node.t` values, render it with `Tui.Renderer`, and decide whether your program prints a static snapshot or runs an interactive terminal loop.
 
-## Current Features
+Unless noted otherwise, commands in this README run from `apps/tui`.
 
-- Buffered cell surface with plain snapshots, ANSI rendering, and diff rendering.
-- Semantic styling primitives: colors, attributes, themes, borders, padding, margins, and flex properties.
-- Components: `text`, `box`, `input`, `select`, `scroll_box`, `progress_bar`, `sparkline`, `panel`, `badge`, `tab_bar`, `key_value`, `table`, `split`, `row`, and `column`.
-- Themed component design contexts with `Components.make_design` and `?design` arguments for reusable widgets and patterns.
-- Application patterns: `Patterns.app_shell`, `header`, `rule_panel`, `metric_card`, `log_feed`, `message`, `timeline`, `composer`, `command_bar`, `footer`, and `modal`.
-- Example presets: `Presets.Open_code.wordmark`, `model_status`, `command_block`, `hint_bar`, and `tip`.
-- Keyboard parsing for common terminal sequences plus focus routing and basic widget key handling.
-- Keymap engine with single-key and multi-stroke bindings.
-- Terminal helpers for alternate screen, raw mode, viewport detection, color capability, and a small render loop.
+## Quick Start
 
-## Example
+Add the `tui` library to a Dune executable:
+
+```lisp
+(executable
+ (name my_console)
+ (libraries tui))
+```
+
+Create a root node and render it:
 
 ```ocaml
 open Tui
 
 let root =
   box
-    ~style:Style.(make ~border:Rounded ~title:"Demo" ~padding:(spacing_all 1) ())
+    ~style:Style.(make ~border:Rounded ~title:"Build" ~padding:(spacing_all 1) ())
     [
       text "Hello from OCaml";
-      progress_bar ~label:"build" 0.72;
+      progress_bar ~label:"compile" 0.72;
       input ~placeholder:"type here" ();
     ]
 
@@ -35,85 +35,158 @@ let () =
   print_endline (Renderer.render_to_string renderer)
 ```
 
-Run the included demo:
+Run one of the bundled examples:
 
 ```bash
-dune exec examples/demo.exe
+opam exec -- dune exec examples/demo.exe
 ```
 
-## Responsive Layouts
+## Public API Layers
 
-Consumers can read the terminal viewport and branch their layout without reaching into renderer internals:
+Use the lower layers when you need control, and the higher layers when you want common application shapes.
+
+- Core: `Geometry`, `Color`, `Theme`, `Style`, `Surface`, `Node`, `Layout`, `Renderer`, `Terminal`, `Viewport`, `Key`, and `Keymap`.
+- Components: `text`, `rich_text`, `box`, `input`, `select`, `scroll_box`, `progress_bar`, `sparkline`, `panel`, `badge`, `tab_bar`, `key_value`, `table`, `split`, `row`, and `column`.
+- Patterns: `Patterns.app_shell`, `header`, `rule_panel`, `metric_card`, `log_feed`, `message`, `timeline`, `composer`, `command_bar`, `footer`, and `modal`.
+- Presets: `Presets.Open_code.wordmark`, `model_status`, `command_block`, `hint_bar`, and `tip`.
+
+`Components` are the stable building blocks. `Patterns` are opinionated application layouts. `Presets` are example-shaped helpers and should not be treated as neutral primitives.
+
+## Layout Usage
+
+Most layout is configured through `Style.make`. The toolkit supports terminal-focused flexbox concepts:
+
+- `width`, `height`, `min_width`, and `min_height`
+- `flex_direction`, `flex_grow`, and `flex_shrink`
+- `justify_content` and `align_items`
+- `padding`, `margin`, `gap`, and borders
+- absolute positioning for overlays such as modals
+
+Example:
 
 ```ocaml
 open Tui
 
-let root viewport =
-  match Viewport.breakpoint viewport with
-  | Tiny | Compact -> box [ text "Compact view" ]
-  | Regular | Wide -> box [ text "Full view" ]
+let root =
+  Components.row
+    ~style:Style.(make ~width:(Percent 1.) ~height:(Percent 1.) ~gap:1 ())
+    [
+      Components.panel
+        ~style:Style.(make ~width:(Cells 28) ())
+        "Navigator"
+        [ text "Queue"; text "Runs"; text "Logs" ];
+      Components.panel
+        ~style:Style.(make ~flex_grow:1. ())
+        "Detail"
+        [ text "Selected item" ];
+    ]
+```
+
+## Rendering Modes
+
+For a fixed snapshot, construct a renderer with an explicit size:
+
+```ocaml
+let renderer = Renderer.create ~width:96 ~height:24 root
+let plain = Renderer.render_to_string renderer
+let ansi = Renderer.render_to_string ~ansi:true renderer
+```
+
+For a terminal-sized view, read the current viewport:
+
+```ocaml
+let viewport = Terminal.viewport () in
+let renderer =
+  Renderer.create ~width:viewport.width ~height:viewport.height (root viewport)
+```
+
+For full-screen previews, enter the alternate screen, render, and restore the terminal when the program exits. The OpenCode-inspired examples show this pattern.
+
+## Theming
+
+Components and patterns accept an optional `?design` value. A design combines a theme with tone mapping:
+
+```ocaml
+open Tui
+
+let design = Components.make_design ~theme:Theme.light ()
+
+let root =
+  Components.panel ~design ~tone:Components.Success "Status"
+    [
+      Components.badge ~design ~tone:Components.Success "ready";
+      Patterns.log_feed ~design [ ("12:00", "OK", "started") ];
+    ]
+```
+
+`Theme.dark` is the default. Use `Theme.light` or a custom `Theme.t` when an application needs its own palette.
+
+## Keyboard Usage
+
+Inputs, selects, and scroll boxes handle common keys through `Renderer.dispatch_key`. For application-level shortcuts, use `Keymap`:
+
+```ocaml
+let keymap = Keymap.create ()
+let quit = ref false
 
 let () =
-  let viewport = Terminal.viewport () in
-  let renderer =
-    Renderer.create ~width:viewport.width ~height:viewport.height (root viewport)
-  in
-  print_string (Renderer.render_to_string ~ansi:true renderer)
+  Keymap.register keymap ~key:"q" ~name:"quit" ~run:(fun () -> quit := true)
 ```
 
-Useful public helpers:
+The renderer also supports focus routing for focusable nodes such as `input`, `select`, and `scroll_box`.
 
-- `Terminal.viewport ()`, `Terminal.size ()`, `Terminal.columns ()`, and `Terminal.rows ()`
-- `Viewport.breakpoint`, `Viewport.fits`, `Viewport.choose`, and `Viewport.orientation`
-- `Renderer.viewport`, `Renderer.size`, `Renderer.resize`, `Renderer.resize_to_viewport`, and `Renderer.resize_to_terminal`
+## Examples
 
-Run the screenshot-style operations console example:
+Example documentation lives in [examples/README.md](examples/README.md).
 
-```bash
-dune exec examples/operations_dashboard.exe
-```
+| Example | Purpose | Run |
+| --- | --- | --- |
+| `demo` | Minimal component composition and fixed snapshot rendering. | `opam exec -- dune exec examples/demo.exe` |
+| `operations_dashboard` | Wide dashboard using panels, metrics, tables, logs, and app shell patterns. | `opam exec -- dune exec examples/operations_dashboard.exe` |
+| `agent_workspace` | Message-first agent workspace with navigator, transcript, composer, and run state. | `opam exec -- dune exec examples/agent_workspace.exe` |
+| `opencode_splash` | Responsive full-screen splash using OpenCode-inspired presets. | `opam exec -- dune exec examples/opencode_splash.exe` |
+| `opencode_session` | Responsive session view with conversation, composer, footer, and optional right rail. | `opam exec -- dune exec examples/opencode_session.exe` |
 
-Run the OpenCode-inspired examples from the reference images:
-
-```bash
-opam exec -- dune exec examples/opencode_splash.exe
-opam exec -- dune exec examples/opencode_session.exe
-```
-
-The OpenCode examples open a full-screen preview and exit on any key. They size
-themselves from `COLUMNS`/`LINES` when exported, otherwise they query the active
-TTY. If your shell exports `NO_COLOR`, unset it for the preview:
+The OpenCode-inspired examples open a full-screen preview and exit on any key when run in an interactive terminal. They size themselves from `COLUMNS` and `LINES` when those variables are exported, otherwise they query the active TTY. If your shell exports `NO_COLOR`, unset it for the preview:
 
 ```bash
 env -u NO_COLOR opam exec -- dune exec examples/opencode_splash.exe
 ```
 
+## Development
+
 Run tests:
 
 ```bash
-dune runtest
+opam exec -- dune runtest
+```
+
+Build everything in the package:
+
+```bash
+opam exec -- dune build @all
+```
+
+Build the opam metadata:
+
+```bash
+opam exec -- dune build @opam
 ```
 
 ## Package Release
 
-The publishable OCaml package is `tui`. Package metadata lives in `dune-project`, and `tui.opam`
-is generated from it:
-
-```bash
-dune build @opam
-```
+The publishable OCaml package is `tui`. Package metadata lives in `dune-project`, and `tui.opam` is generated from it.
 
 Before publishing a tagged release, run the package checks from `apps/tui`:
 
 ```bash
 opam lint tui.opam
 opam install . --deps-only --with-test
-dune build
-dune runtest
+opam exec -- dune build @all
+opam exec -- dune runtest
 ```
 
-When the repository tag is pushed and a GitHub source archive is available, publish through the
-standard opam-repository PR flow:
+When the repository tag is pushed and a GitHub source archive is available, publish through the standard opam-repository PR flow:
 
 ```bash
 opam publish

--- a/apps/tui/docs/weakness.md
+++ b/apps/tui/docs/weakness.md
@@ -1,28 +1,103 @@
-  The weaker part is Components. It currently mixes three categories together:
+# TUI Toolkit Weaknesses
 
-  - real reusable primitives: panel, badge, tab_bar, table, key_value
-  - semi-reusable app patterns: header, app_shell, composer, log_feed, metric_card
-  - demo/OpenCode-specific pieces: wordmark, model_status, command_block, tip, hint_bar
+## Scope
 
-  The main issue is that many components hard-code Theme.dark, default labels, colors, and product assumptions.
-  For example model_status defaults to "DeepSeek V4 Pro" and "OpenCode Go" in lib/tui.ml:1703. That
-  belongs in an example or preset, not the public general component layer.
+This note evaluates the **TUI Toolkit Package** in `apps/tui`. It is about the reusable OCaml toolkit API, not the Personal Symphony **Terminal Console** runtime semantics.
 
-  For symphony-orchestrator, the library is already useful for a first version: dashboards, panels, job tables,
-  logs, status badges, progress bars, command footer, responsive viewport. But before calling it a general-
-  purpose library, I’d split the API like this:
+The package is already useful for a first Personal Symphony operator surface: it has a renderer-owned root tree, buffered cell surfaces, Toffee-backed layout, keyboard routing, viewport helpers, panels, tables, status badges, progress bars, log feeds, command bars, and dashboard examples. The main weakness is not rendering capability. The main weakness is API boundary clarity.
 
-  Tui
-    Core: Style, Color, Theme, Surface, Renderer, Terminal, Viewport, Keymap
-    Components: Box, Text, Input, Select, Table, Panel, Badge, Tabs, Progress, Log
-    Patterns: AppShell, Header, Footer, Composer, Modal, CommandPalette
-    Examples: OpenCode, Dashboard, Symphony
+## Original Primary Weakness
 
-  And I would move OpenCode-specific helpers out of Components into examples/ or a Presets.Open_code module.
+The first implementation of `Components` mixed three different abstraction levels in one public namespace:
 
-  The next important improvement is theme injection. Instead of components calling Theme.dark internally, they
-  should accept ?theme or a Design.t, so Symphony can have its own visual identity without rewriting
-  components.
+- Reusable primitives: `panel`, `badge`, `tab_bar`, `table`, `key_value`, `row`, `column`, `split`.
+- Reusable application patterns: `header`, `app_shell`, `composer`, `log_feed`, `metric_card`, `modal`, `command_bar`.
+- Demo- or product-shaped helpers: `wordmark`, `model_status`, `command_block`, `tip`, `hint_bar`.
 
-  So: usable for Symphony now, but not yet clean enough as a general library API. The next pass should be an
-  API cleanup, not more visual polish.
+That made the package easy to demo but harder to treat as a general library. A consumer could not tell which APIs were stable primitives, which were opinionated layout patterns, and which existed to recreate a specific OpenCode-inspired example.
+
+## Cleanup Status
+
+| Issue | Current evidence | Risk |
+| --- | --- | --- |
+| Theme is injectable at the component layer | `Components.make_design` creates a design context, and reusable helpers accept `?design`. `Theme.dark` remains only as the default design. | Remaining callers that manually style with `Theme.dark` can still be migrated when they need a shared visual identity. |
+| Product copy is no longer in core defaults | `Patterns.app_shell` defaults to `App`. OpenCode-specific copy lives under `Presets.Open_code`. | Preset defaults are still product-shaped by design; generic code should not depend on those presets. |
+| Primitive and pattern APIs are separated | `Components` now owns reusable widgets, `Patterns` owns application layouts, and `Presets.Open_code` owns OpenCode-inspired helpers. | The package still has no `.mli`, so all implementation helpers remain technically visible to OCaml consumers. |
+| Styling override behavior is partial | Helpers often preserve only selected fields from an incoming `style` value. | Consumers may pass style fields that silently disappear, producing surprising layouts. |
+| Semantic tone is design-driven | `tone` maps through `design.tone_color`, with the dark theme as the default. | Advanced design systems may still need more slots than the current tone set exposes. |
+| Examples use explicit presets | OpenCode-inspired examples use `Presets.Open_code` helpers instead of `Components` helpers. | Demo fidelity and stable toolkit design are now separated, but preset naming should remain clearly example-oriented. |
+
+## Better API Shape
+
+The implemented public structure now separates core rendering, reusable widgets, higher-level patterns, and example presets:
+
+```ocaml
+Tui
+  Core: Style, Color, Theme, Surface, Renderer, Terminal, Viewport, Keymap
+  Components: Box, Text, Input, Select, Table, Panel, Badge, Tabs, Progress, Log
+  Patterns: AppShell, Header, Footer, Composer, Modal, CommandPalette
+  Presets: Open_code
+```
+
+This split can continue incrementally. The first cleanup pass moved the obvious helpers, and the important part from here is keeping ownership clear:
+
+- Keep primitives stable and boring.
+- Move opinionated layout helpers into `Patterns`.
+- Move OpenCode-specific or screenshot-specific helpers into a `Presets.Open_code` module.
+- Keep Personal Symphony-specific composition outside the generic toolkit unless it is explicitly a `Presets.Symphony` layer.
+
+## Theme Injection
+
+Components now accept a design context instead of calling `Theme.dark` internally:
+
+```ocaml
+type design = {
+  theme : Theme.t;
+  tone_color : Components.tone -> Color.t;
+}
+```
+
+Implemented migration path:
+
+1. Added a lightweight design context with `Theme.dark` as the default.
+2. Threaded `?design` through reusable components, app patterns, and OpenCode-inspired presets.
+3. Replaced direct theme lookups inside those helpers with the supplied design context.
+4. Left a Personal Symphony design preset out of this pass until there is a concrete Terminal Console design need.
+
+This keeps existing examples working while allowing a Workspace Repository operator surface to use a distinct palette later.
+
+## Component Cleanup Priorities
+
+1. Rename and relocate OpenCode-shaped helpers.
+
+   `model_status`, `wordmark`, `tip`, and `hint_bar` should not be presented as generic components unless their labels, copy, and palette are fully caller-owned.
+
+2. Make defaults neutral.
+
+   A generic toolkit default should use labels such as `Model`, `Provider`, `Ready`, or no label at all. Product names belong in examples and presets.
+
+3. Normalize style merging.
+
+   Component helpers should either preserve all compatible fields from `style` or document which fields they own. Silent partial merging is a maintenance trap.
+
+4. Treat `tone` as semantic, not visual.
+
+   `Success`, `Warning`, `Error`, and similar values are good public language. The actual color lookup should come from the active theme or design context.
+
+5. Keep the README honest.
+
+   The README should describe `Components` as reusable widgets only after the namespace is cleaned up. Until then, it should call out dashboard and OpenCode-inspired helpers as examples or experimental patterns.
+
+## Readiness Assessment
+
+The TUI Toolkit Package is ready for internal Personal Symphony prototyping and is closer to a clean, general-purpose OCaml terminal UI library after the first API cleanup pass.
+
+The next pass should focus on API hardening rather than visual polish: add an interface file, normalize style merging, and decide which pattern helpers are stable enough to commit to.
+
+## Done Criteria For The First Cleanup
+
+- Reusable primitives can be used without OpenCode or Symphony copy appearing by default. Done.
+- Components can render with `Theme.dark`, `Theme.light`, or a caller-supplied theme. Done through `Components.make_design` and `?design`.
+- Example-specific helpers live outside the core `Components` namespace. Done through `Presets.Open_code`.
+- Existing dashboard and OpenCode-inspired examples still render after the move. Covered by `dune runtest` and updated examples.
+- Tests cover theme injection, neutral defaults, and at least one migrated example helper. Done in `apps/tui/test/test_tui.ml`.

--- a/apps/tui/examples/README.md
+++ b/apps/tui/examples/README.md
@@ -1,0 +1,37 @@
+# TUI Examples
+
+These examples show the main ways to use the `tui` package. Commands are meant to run from `apps/tui`.
+
+| Example | Source | README | Run |
+| --- | --- | --- | --- |
+| `demo` | [demo.ml](demo.ml) | [demo/README.md](demo/README.md) | `opam exec -- dune exec examples/demo.exe` |
+| `operations_dashboard` | [operations_dashboard.ml](operations_dashboard.ml) | [operations_dashboard/README.md](operations_dashboard/README.md) | `opam exec -- dune exec examples/operations_dashboard.exe` |
+| `agent_workspace` | [agent_workspace.ml](agent_workspace.ml) | [agent_workspace/README.md](agent_workspace/README.md) | `opam exec -- dune exec examples/agent_workspace.exe` |
+| `opencode_splash` | [opencode_splash.ml](opencode_splash.ml) | [opencode_splash/README.md](opencode_splash/README.md) | `opam exec -- dune exec examples/opencode_splash.exe` |
+| `opencode_session` | [opencode_session.ml](opencode_session.ml) | [opencode_session/README.md](opencode_session/README.md) | `opam exec -- dune exec examples/opencode_session.exe` |
+
+## Choosing An Example
+
+- Start with `demo` when learning the basic component tree and renderer flow.
+- Use `operations_dashboard` for dense dashboard layouts with metrics, tables, and logs.
+- Use `agent_workspace` for message-first layouts with a navigator, transcript, composer, and side panel.
+- Use `opencode_splash` to study responsive full-screen composition and OpenCode-inspired presets.
+- Use `opencode_session` to study viewport-driven branching, alternate-screen preview behavior, and a more complete session layout.
+
+## Terminal Behavior
+
+`demo`, `operations_dashboard`, and `agent_workspace` print fixed-size snapshots.
+
+`opencode_splash` and `opencode_session` use the active terminal size, enter the alternate screen when stdin/stdout are interactive, and exit on any key. In non-interactive output they print an ANSI snapshot instead.
+
+For deterministic responsive previews, export `COLUMNS` and `LINES` before running an OpenCode-inspired example:
+
+```bash
+COLUMNS=120 LINES=36 opam exec -- dune exec examples/opencode_splash.exe
+```
+
+If your shell exports `NO_COLOR`, unset it to see ANSI color:
+
+```bash
+env -u NO_COLOR opam exec -- dune exec examples/opencode_session.exe
+```

--- a/apps/tui/examples/agent_workspace.ml
+++ b/apps/tui/examples/agent_workspace.ml
@@ -1,5 +1,6 @@
 open Tui
 open Tui.Components
+open Tui.Patterns
 
 let sessions =
   [

--- a/apps/tui/examples/agent_workspace/README.md
+++ b/apps/tui/examples/agent_workspace/README.md
@@ -1,0 +1,31 @@
+# Agent Workspace Example
+
+Source: [../agent_workspace.ml](../agent_workspace.ml)
+
+Run from `apps/tui`:
+
+```bash
+opam exec -- dune exec examples/agent_workspace.exe
+```
+
+## Purpose
+
+`agent_workspace` shows a message-first interface for agent work. It combines navigation, conversation history, an input composer, and a run-state side panel.
+
+## What It Demonstrates
+
+- `Patterns.app_shell` for an application frame with status badges and footer commands.
+- `Components.split` for navigator plus workspace layout.
+- `Patterns.section_title` and `Patterns.nav_item` for sidebar navigation.
+- `Patterns.message` for transcript entries.
+- `scroll_box` for a scrollable conversation region.
+- `Patterns.composer` for a bordered input row.
+- `Patterns.timeline` and `Components.key_value` for run-state details.
+
+## Layout Notes
+
+The example renders at `132x38`. The conversation column flexes while the run-state panel keeps a fixed width. This makes the transcript the primary work area without losing task context.
+
+## When To Use It
+
+Use this example when building chat, agent-session, review, task-workspace, or command-center interfaces where a transcript is the main interaction surface.

--- a/apps/tui/examples/demo.ml
+++ b/apps/tui/examples/demo.ml
@@ -39,7 +39,7 @@ let () =
                 input ~style:Style.(make ~width:(Cells 24) ()) ~placeholder:"type here" ();
               ];
           ];
-        Components.footer [ ("q", "uit"); ("/", "search"); ("?", "help"); ("Tab", "focus") ];
+        Patterns.footer [ ("q", "uit"); ("/", "search"); ("?", "help"); ("Tab", "focus") ];
       ]
   in
   let renderer = Renderer.create ~width:96 ~height:24 root in

--- a/apps/tui/examples/demo/README.md
+++ b/apps/tui/examples/demo/README.md
@@ -1,0 +1,32 @@
+# Demo Example
+
+Source: [../demo.ml](../demo.ml)
+
+Run from `apps/tui`:
+
+```bash
+opam exec -- dune exec examples/demo.exe
+```
+
+## Purpose
+
+`demo` is the smallest broad tour of the toolkit. It builds a fixed-size component tree and prints a plain terminal snapshot.
+
+## What It Demonstrates
+
+- Opening `Tui` directly for the root helpers such as `box`, `text`, `select`, `progress_bar`, `sparkline`, and `input`.
+- Creating a small local `panel` helper from `box` plus `Style.make`.
+- Using fixed cell sizes with `Style.Cells`.
+- Combining column and row layout through `Style.flex_direction`.
+- Rendering with `Renderer.create` and `Renderer.render_to_string`.
+- Adding a footer with `Patterns.footer`.
+
+## When To Use It
+
+Use this example when learning the minimum shape of a TUI program:
+
+1. Build a tree of nodes.
+2. Give the renderer a width and height.
+3. Convert the rendered surface to a string.
+
+It is also a good starting point for snapshot-style tests because the output size is deterministic.

--- a/apps/tui/examples/opencode_session.ml
+++ b/apps/tui/examples/opencode_session.ml
@@ -1,5 +1,7 @@
 open Tui
 open Tui.Components
+open Tui.Patterns
+open Tui.Presets.Open_code
 
 let clamp low high value = max low (min high value)
 

--- a/apps/tui/examples/opencode_session/README.md
+++ b/apps/tui/examples/opencode_session/README.md
@@ -1,0 +1,44 @@
+# OpenCode Session Example
+
+Source: [../opencode_session.ml](../opencode_session.ml)
+
+Run from `apps/tui`:
+
+```bash
+opam exec -- dune exec examples/opencode_session.exe
+```
+
+For a deterministic size:
+
+```bash
+COLUMNS=132 LINES=38 opam exec -- dune exec examples/opencode_session.exe
+```
+
+## Purpose
+
+`opencode_session` recreates a compact agent-session view inspired by OpenCode. It shows a conversation area, command block, thinking state, model status, composer, footer hints, and an optional right rail.
+
+## What It Demonstrates
+
+- `Terminal.viewport` for responsive sizing.
+- Width-based compact behavior for conversation copy and model labels.
+- Optional right rail rendering when the viewport is wide enough.
+- `Presets.Open_code.command_block`, `model_status`, and `hint_bar`.
+- `Patterns.rule_panel` for the composer surface.
+- Manual right-rail composition with core `box`, `text`, `rich_text`, and `spacer`.
+- Alternate-screen rendering when stdin and stdout are interactive.
+- ANSI snapshot output when the process is not interactive.
+
+## Terminal Behavior
+
+In an interactive terminal, the example opens a full-screen preview and exits on any key. It restores the previous screen on exit.
+
+If your shell exports `NO_COLOR`, unset it to see colors:
+
+```bash
+env -u NO_COLOR opam exec -- dune exec examples/opencode_session.exe
+```
+
+## When To Use It
+
+Use this example when building a full agent session, chat workspace, or tool execution view that needs responsive layout decisions.

--- a/apps/tui/examples/opencode_splash.ml
+++ b/apps/tui/examples/opencode_splash.ml
@@ -1,5 +1,7 @@
 open Tui
 open Tui.Components
+open Tui.Patterns
+open Tui.Presets.Open_code
 
 let clamp low high value = max low (min high value)
 

--- a/apps/tui/examples/opencode_splash/README.md
+++ b/apps/tui/examples/opencode_splash/README.md
@@ -1,0 +1,43 @@
+# OpenCode Splash Example
+
+Source: [../opencode_splash.ml](../opencode_splash.ml)
+
+Run from `apps/tui`:
+
+```bash
+opam exec -- dune exec examples/opencode_splash.exe
+```
+
+For a deterministic size:
+
+```bash
+COLUMNS=120 LINES=36 opam exec -- dune exec examples/opencode_splash.exe
+```
+
+## Purpose
+
+`opencode_splash` recreates a responsive full-screen splash screen inspired by OpenCode. It demonstrates how to combine viewport detection, centered layout, preset helpers, and alternate-screen preview behavior.
+
+## What It Demonstrates
+
+- `Terminal.viewport` for runtime terminal sizing.
+- `Viewport` dimensions passed into a `root` function.
+- `Presets.Open_code.wordmark`, `model_status`, `hint_bar`, and `tip`.
+- `Patterns.rule_panel` for the prompt surface.
+- Conditional rendering based on width and height.
+- Alternate-screen rendering when stdin and stdout are interactive.
+- ANSI snapshot output when the process is not interactive.
+
+## Terminal Behavior
+
+In an interactive terminal, the example opens a full-screen preview and exits on any key. It restores the previous screen on exit.
+
+If your shell exports `NO_COLOR`, unset it to see colors:
+
+```bash
+env -u NO_COLOR opam exec -- dune exec examples/opencode_splash.exe
+```
+
+## When To Use It
+
+Use this example when building splash screens, prompt-first entry views, or responsive terminal landing states.

--- a/apps/tui/examples/operations_dashboard.ml
+++ b/apps/tui/examples/operations_dashboard.ml
@@ -1,19 +1,20 @@
 open Tui
 open Tui.Components
+open Tui.Patterns
 
 let metric_row =
   Components.row
     ~style:Style.(make ~height:(Cells 9) ~gap:1 ())
     [
-      Components.metric_card ~tone:Success ~label:"Revenue" ~value:"$128.4k"
+      metric_card ~tone:Success ~label:"Revenue" ~value:"$128.4k"
         ~style:Style.(make ~width:(Cells 30) ())
         ~detail:"+12.8% vs last hour" ~progress:0.72
         ~sparkline:[ 4.; 6.; 5.; 8.; 9.; 11.; 10.; 14.; 13.; 16. ] ();
-      Components.metric_card ~tone:Info ~label:"Latency" ~value:"42ms"
+      metric_card ~tone:Info ~label:"Latency" ~value:"42ms"
         ~style:Style.(make ~width:(Cells 30) ())
         ~detail:"p95 edge response" ~progress:0.42
         ~sparkline:[ 7.; 6.; 6.; 5.; 4.; 4.; 5.; 3.; 3.; 2. ] ();
-      Components.metric_card ~tone:Warning ~label:"Queue" ~value:"1,204"
+      metric_card ~tone:Warning ~label:"Queue" ~value:"1,204"
         ~style:Style.(make ~width:(Cells 30) ())
         ~detail:"jobs waiting" ~progress:0.61
         ~sparkline:[ 2.; 3.; 4.; 8.; 5.; 7.; 9.; 11.; 10.; 12. ] ();
@@ -70,7 +71,7 @@ let main_grid =
           ~tone:Info
           ~style:Style.(make ~width:(Cells 44) ())
           [
-            Components.log_feed
+            log_feed
               ~style:Style.(make ~height:(Cells 13) ())
               [
                 ("14:05:02", "INFO", "checkout deploy reached 42%");
@@ -99,7 +100,7 @@ let main_grid =
 
 let () =
   let root =
-    Components.app_shell ~title:"Operations Console"
+    app_shell ~title:"Operations Console"
       ~subtitle:"global production control plane"
       ~badges:[ (Success, "live"); (Info, "iad"); (Warning, "queue") ]
       ~footer_items:[ ("q", "uit"); ("r", "efresh"); ("/", "filter"); ("?", "help"); ("Tab", "focus") ]

--- a/apps/tui/examples/operations_dashboard/README.md
+++ b/apps/tui/examples/operations_dashboard/README.md
@@ -1,0 +1,31 @@
+# Operations Dashboard Example
+
+Source: [../operations_dashboard.ml](../operations_dashboard.ml)
+
+Run from `apps/tui`:
+
+```bash
+opam exec -- dune exec examples/operations_dashboard.exe
+```
+
+## Purpose
+
+`operations_dashboard` shows a dense, work-focused operations console. It is useful as a reference for dashboards that need metrics, service tables, event logs, runbook data, and a command footer.
+
+## What It Demonstrates
+
+- `Patterns.app_shell` for a full-page title, badges, content area, and command bar.
+- `Components.split` for a fixed-width sidebar plus flexible main content.
+- `Patterns.metric_card` for compact metrics with progress and sparkline data.
+- `Components.table` for fixed-width tabular status rows.
+- `Patterns.log_feed` for timestamped event streams.
+- `Components.key_value` for dense metadata.
+- Semantic tones such as `Success`, `Info`, `Warning`, and `Accent`.
+
+## Layout Notes
+
+The example renders at `132x38`, so it is intentionally wide. The sidebar uses a fixed width and the main grid uses `flex_grow` to fill the remaining space. This makes it a good reference for operator dashboards that prioritize scanning over decorative layout.
+
+## When To Use It
+
+Use this example when building a dashboard for services, jobs, queues, deployments, incidents, or other operational state.

--- a/apps/tui/lib/tui.ml
+++ b/apps/tui/lib/tui.ml
@@ -1390,6 +1390,40 @@ module Components = struct
     | Warning
     | Error
 
+  type design = { theme : Theme.t; tone_color : tone -> Color.t }
+
+  let default_tone_color theme = function
+    | Neutral -> theme Theme.Fg_muted
+    | Accent -> theme Theme.Accent_primary
+    | Info -> theme Theme.Status_info
+    | Success -> theme Theme.Status_success
+    | Warning -> theme Theme.Status_warning
+    | Error -> theme Theme.Status_error
+
+  let make_design ?(theme = Theme.dark) ?tone_color () =
+    let tone_color =
+      match tone_color with
+      | Some tone_color -> tone_color
+      | None -> default_tone_color theme
+    in
+    { theme; tone_color }
+
+  let default_design = make_design ()
+  let resolve_design = function None -> default_design | Some design -> design
+  let theme_color design slot = design.theme slot
+  let color_of_tone ?design tone = (resolve_design design).tone_color tone
+  let surface_of design = theme_color design Theme.Bg_surface
+  let overlay_of design = theme_color design Theme.Bg_overlay
+  let default_fg_of design = theme_color design Theme.Fg_default
+  let muted_fg_of design = theme_color design Theme.Fg_muted
+  let emphasis_fg_of design = theme_color design Theme.Fg_emphasis
+
+  let surface = surface_of default_design
+  let overlay = overlay_of default_design
+  let default_fg = default_fg_of default_design
+  let muted_fg = muted_fg_of default_design
+  let emphasis_fg = emphasis_fg_of default_design
+
   let text = Node.text
   let rich_text = Node.rich_text
   let vertical_rule = Node.vertical_rule
@@ -1402,53 +1436,8 @@ module Components = struct
   let sparkline = Node.sparkline
   let spacer = Node.spacer
 
-  let color_of_tone = function
-    | Neutral -> Theme.dark Theme.Fg_muted
-    | Accent -> Theme.dark Theme.Accent_primary
-    | Info -> Theme.dark Theme.Status_info
-    | Success -> Theme.dark Theme.Status_success
-    | Warning -> Theme.dark Theme.Status_warning
-    | Error -> Theme.dark Theme.Status_error
-
-  let surface = Theme.dark Theme.Bg_surface
-  let overlay = Theme.dark Theme.Bg_overlay
-  let default_fg = Theme.dark Theme.Fg_default
-  let muted_fg = Theme.dark Theme.Fg_muted
-  let emphasis_fg = Theme.dark Theme.Fg_emphasis
-
   let repeat s n =
     if n <= 0 then "" else String.concat "" (List.init n (fun _ -> s))
-
-  let glyph = function
-    | 'o' -> [ "████"; "█  █"; "█  █"; "█  █"; "████" ]
-    | 'p' -> [ "███ "; "█  █"; "███ "; "█   "; "█   " ]
-    | 'e' -> [ "████"; "█   "; "███ "; "█   "; "████" ]
-    | 'n' -> [ "█  █"; "██ █"; "█ ██"; "█  █"; "█  █" ]
-    | 'c' -> [ "████"; "█   "; "█   "; "█   "; "████" ]
-    | 'd' -> [ "███ "; "█  █"; "█  █"; "█  █"; "███ " ]
-    | 'a' -> [ " ██ "; "█  █"; "████"; "█  █"; "█  █" ]
-    | 'g' -> [ "████"; "█   "; "█ ██"; "█  █"; "████" ]
-    | 't' -> [ "████"; " ██ "; " ██ "; " ██ "; " ██ " ]
-    | 'w' -> [ "█  █"; "█  █"; "█  █"; "████"; "█  █" ]
-    | 'r' -> [ "███ "; "█  █"; "███ "; "█ █ "; "█  █" ]
-    | 'k' -> [ "█  █"; "█ █ "; "██  "; "█ █ "; "█  █" ]
-    | 's' -> [ "████"; "█   "; "████"; "   █"; "████" ]
-    | 'i' -> [ "███"; " █ "; " █ "; " █ "; "███" ]
-    | ' ' -> [ "  "; "  "; "  "; "  "; "  " ]
-    | _ -> [ "██"; "██"; "██"; "██"; "██" ]
-
-  let wordmark ?id ?(style = Style.default) label =
-    let rows = Array.make 5 "" in
-    label
-    |> String.lowercase_ascii
-    |> String.iter (fun ch ->
-           glyph ch
-           |> List.iteri (fun i part ->
-                  rows.(i) <- rows.(i) ^ part ^ " "));
-    box ?id ~style:Style.{ style with flex_direction = Column }
-      (Array.to_list rows
-      |> List.map (fun line ->
-             text ~style:Style.(make ~fg:(Theme.dark Theme.Fg_emphasis) ~attrs:[ Attr.Bold ] ()) line))
 
   let row ?id ?(style = Style.default) ?(gap = 1) children =
     box ?id ~style:Style.{ style with flex_direction = Row; gap } children
@@ -1457,13 +1446,14 @@ module Components = struct
     box ?id ~style:Style.{ style with flex_direction = Column; gap } children
 
   let panel ?id ?(tone = Accent) ?(title_align = Style.Title_left) ?bottom_title
-      ?(style = Style.default) title children =
+      ?(style = Style.default) ?design title children =
+    let design = resolve_design design in
     box ?id
       ~style:
         Style.
           {
             (make ~border:Rounded ~title ~title_align ?bottom_title
-               ~border_fg:(color_of_tone tone) ~padding:(spacing_all 1) ())
+               ~border_fg:(color_of_tone ~design tone) ~padding:(spacing_all 1) ())
             with
             width = style.width;
             height = style.height;
@@ -1481,45 +1471,15 @@ module Components = struct
             bottom = style.bottom;
             margin = style.margin;
             gap = style.gap;
-            fg = (match style.fg with Some _ -> style.fg | None -> Some default_fg);
+            fg = (match style.fg with Some _ -> style.fg | None -> Some (default_fg_of design));
             bg = style.bg;
             attrs = style.attrs;
           }
       children
 
-  let rule_panel ?id ?(tone = Accent) ?(style = Style.default) children =
-    box ?id
-      ~style:Style.{ style with flex_direction = Row; gap = 1 }
-      [
-        vertical_rule ~style:Style.(make ~width:(Cells 1) ~height:(Percent 1.) ~fg:(color_of_tone tone) ~attrs:[ Attr.Bold ] ()) ();
-        box ~style:Style.(make ~flex_grow:1. ~height:(Percent 1.) ~padding:(spacing_xy ~x:1 ~y:0) ~bg:(Color.indexed 235) ())
-          children;
-      ]
-
-  let modal ?id ?(tone = Accent) ?(style = Style.default) ?(bottom_title = "Esc/? close")
-      title children =
-    let modal_width = match style.width with Style.Auto -> Style.Cells 64 | width -> width in
-    let modal_height = match style.height with Style.Auto -> Style.Cells 16 | height -> height in
-    let content_style =
-      Style.
-        {
-          style with
-          width = modal_width;
-          height = modal_height;
-          flex_direction = Column;
-          bg = Some surface;
-        }
-    in
-    box ?id
-      ~style:
-        Style.(
-          make ~position:Absolute ~left:0 ~right:0 ~top:0 ~bottom:0
-            ~width:(Percent 1.) ~height:(Percent 1.) ~justify_content:Justify_center
-            ~align_items:Align_center ())
-      [ panel ~tone ~bottom_title ~style:content_style title children ]
-
-  let badge ?id ?(tone = Neutral) ?(style = Style.default) label =
-    let fg = color_of_tone tone in
+  let badge ?id ?(tone = Neutral) ?(style = Style.default) ?design label =
+    let design = resolve_design design in
+    let fg = color_of_tone ~design tone in
     box ?id
       ~style:
         Style.
@@ -1532,9 +1492,10 @@ module Components = struct
           }
       [ text ~style:Style.(make ~fg ~attrs:[ Attr.Bold ] ()) label ]
 
-  let tab_bar ?id ?(style = Style.default) tabs =
+  let tab_bar ?id ?(style = Style.default) ?design tabs =
+    let design = resolve_design design in
     let tab (label, active) =
-      let fg = if active then emphasis_fg else muted_fg in
+      let fg = if active then emphasis_fg_of design else muted_fg_of design in
       let attrs = if active then [ Attr.Bold; Attr.Underline ] else [ Attr.Dim ] in
       text ~style:Style.(make ~fg ~attrs ()) label
     in
@@ -1549,57 +1510,16 @@ module Components = struct
           }
       (List.map tab tabs)
 
-  let header ?id ?subtitle ?(badges = []) title =
-    let title_line =
-      text ~style:Style.(make ~fg:emphasis_fg ~attrs:[ Attr.Bold ] ()) title
-    in
-    let subtitle_line =
-      match subtitle with
-      | None -> []
-      | Some copy -> [ text ~style:Style.(make ~fg:muted_fg ~attrs:[ Attr.Dim ] ()) copy ]
-    in
-    let badge_nodes = badges |> List.map (fun (tone, label) -> badge ~tone label) in
-    box ?id
-      ~style:Style.(make ~height:(Cells 3) ~flex_direction:Row ~justify_content:Space_between ~align_items:Align_center ~padding:(spacing_xy ~x:2 ~y:0) ())
-      [
-        box ~style:Style.(make ~flex_direction:Column ()) (title_line :: subtitle_line);
-        box ~style:Style.(make ~flex_direction:Row ~gap:1 ()) badge_nodes;
-      ]
-
-  let metric_card ?id ?(tone = Info) ?detail ?progress ?sparkline:series
-      ?(style = Style.default) ~label ~value () =
-    let accent = color_of_tone tone in
-    let children =
-      [
-        text ~style:Style.(make ~fg:muted_fg ~attrs:[ Attr.Dim ] ()) label;
-        text ~style:Style.(make ~fg:emphasis_fg ~attrs:[ Attr.Bold ] ()) value;
-      ]
-      @ (match detail with None -> [] | Some d -> [ text ~style:Style.(make ~fg:accent ()) d ])
-      @ (match progress with None -> [] | Some p -> [ progress_bar ~style:Style.(make ~height:(Cells 1) ()) p ])
-      @
-      match series with
-      | None -> []
-      | Some values -> [ sparkline ~style:Style.(make ~fg:accent ~height:(Cells 1) ()) values ]
-    in
-    panel ?id ~tone
-      ~style:
-        Style.
-          {
-            style with
-            height =
-              (match style.height with Auto -> Cells (List.length children + 4) | other -> other);
-          }
-      label children
-
-  let key_value ?id ?(label_width = 12) ?(style = Style.default) pairs =
+  let key_value ?id ?(label_width = 12) ?(style = Style.default) ?design pairs =
+    let design = resolve_design design in
     let rows =
       pairs
       |> List.map (fun (key, value) ->
              let key_text = if String.length key >= label_width then key else key ^ String.make (label_width - String.length key) ' ' in
              rich_text
                [
-                 Span.make ~style:Style.(make ~fg:muted_fg ~attrs:[ Attr.Dim ] ()) key_text;
-                 Span.make ~style:Style.(make ~fg:default_fg ()) value;
+                 Span.make ~style:Style.(make ~fg:(muted_fg_of design) ~attrs:[ Attr.Dim ] ()) key_text;
+                 Span.make ~style:Style.(make ~fg:(default_fg_of design) ()) value;
                ])
     in
     box ?id ~style:Style.{ style with flex_direction = Column } rows
@@ -1628,45 +1548,167 @@ module Components = struct
         let clipped = Stdlib.Buffer.contents out ^ "…" in
         clipped ^ String.make (max 0 (width - Utf.string_width clipped)) ' '
 
-  let table ?id ?(style = Style.default) ?(header_tone = Accent) columns rows =
+  let table ?id ?(style = Style.default) ?(header_tone = Accent) ?design columns rows =
+    let design = resolve_design design in
     let widths = List.map snd columns in
     let line cells =
       List.map2 (fun width cell -> fit width cell) widths cells |> String.concat "  "
     in
-    let header_style = Style.(make ~fg:(color_of_tone header_tone) ~attrs:[ Attr.Bold ] ()) in
-    let row_style = Style.(make ~fg:default_fg ()) in
+    let header_style = Style.(make ~fg:(color_of_tone ~design header_tone) ~attrs:[ Attr.Bold ] ()) in
+    let row_style = Style.(make ~fg:(default_fg_of design) ()) in
     let header = text ~style:header_style (line (List.map fst columns)) in
     let divider =
-      text ~style:Style.(make ~fg:muted_fg ~attrs:[ Attr.Dim ] ())
+      text ~style:Style.(make ~fg:(muted_fg_of design) ~attrs:[ Attr.Dim ] ())
         (line (List.map (fun (_, width) -> repeat "─" width) columns))
     in
     let body = rows |> List.map (fun cells -> text ~style:row_style (line cells)) in
     box ?id ~style:Style.{ style with flex_direction = Column } (header :: divider :: body)
 
-  let log_feed ?id ?(style = Style.default) entries =
+  let split ?id ?(style = Style.default) ?(left_width = 32) left right =
+    box ?id
+      ~style:Style.{ style with flex_direction = Row; gap = 1 }
+      [
+        box ~style:Style.(make ~width:(Cells left_width) ~height:(Percent 1.) ()) left;
+        box ~style:Style.(make ~flex_grow:1. ~height:(Percent 1.) ()) right;
+      ]
+end
+
+module Patterns = struct
+  let rule_panel ?id ?(tone = Components.Accent) ?(style = Style.default) ?design children =
+    let design = Components.resolve_design design in
+    Components.box ?id
+      ~style:Style.{ style with flex_direction = Row; gap = 1 }
+      [
+        Components.vertical_rule
+          ~style:
+            Style.(
+              make ~width:(Cells 1) ~height:(Percent 1.)
+                ~fg:(Components.color_of_tone ~design tone)
+                ~attrs:[ Attr.Bold ] ())
+          ();
+        Components.box
+          ~style:
+            Style.(
+              make ~flex_grow:1. ~height:(Percent 1.)
+                ~padding:(spacing_xy ~x:1 ~y:0) ~bg:(Components.surface_of design)
+                ())
+          children;
+      ]
+
+  let modal ?id ?(tone = Components.Accent) ?(style = Style.default)
+      ?(bottom_title = "Esc/? close") ?design title children =
+    let design_value = Components.resolve_design design in
+    let modal_width = match style.width with Style.Auto -> Style.Cells 64 | width -> width in
+    let modal_height = match style.height with Style.Auto -> Style.Cells 16 | height -> height in
+    let content_style =
+      Style.
+        {
+          style with
+          width = modal_width;
+          height = modal_height;
+          flex_direction = Column;
+          bg = Some (Components.surface_of design_value);
+        }
+    in
+    Components.box ?id
+      ~style:
+        Style.(
+          make ~position:Absolute ~left:0 ~right:0 ~top:0 ~bottom:0
+            ~width:(Percent 1.) ~height:(Percent 1.) ~justify_content:Justify_center
+            ~align_items:Align_center ())
+      [ Components.panel ~tone ~bottom_title ~style:content_style ?design title children ]
+
+  let header ?id ?subtitle ?(badges = []) ?design title =
+    let design_value = Components.resolve_design design in
+    let title_line =
+      Components.text
+        ~style:Style.(make ~fg:(Components.emphasis_fg_of design_value) ~attrs:[ Attr.Bold ] ())
+        title
+    in
+    let subtitle_line =
+      match subtitle with
+      | None -> []
+      | Some copy ->
+          [
+            Components.text
+              ~style:Style.(make ~fg:(Components.muted_fg_of design_value) ~attrs:[ Attr.Dim ] ())
+              copy;
+          ]
+    in
+    let badge_nodes =
+      badges |> List.map (fun (tone, label) -> Components.badge ~tone ?design label)
+    in
+    Components.box ?id
+      ~style:Style.(make ~height:(Cells 3) ~flex_direction:Row ~justify_content:Space_between ~align_items:Align_center ~padding:(spacing_xy ~x:2 ~y:0) ())
+      [
+        Components.box ~style:Style.(make ~flex_direction:Column ()) (title_line :: subtitle_line);
+        Components.box ~style:Style.(make ~flex_direction:Row ~gap:1 ()) badge_nodes;
+      ]
+
+  let metric_card ?id ?(tone = Components.Info) ?detail ?progress ?sparkline:series
+      ?(style = Style.default) ?design ~label ~value () =
+    let design_value = Components.resolve_design design in
+    let accent = Components.color_of_tone ~design:design_value tone in
+    let children =
+      [
+        Components.text
+          ~style:Style.(make ~fg:(Components.muted_fg_of design_value) ~attrs:[ Attr.Dim ] ())
+          label;
+        Components.text
+          ~style:Style.(make ~fg:(Components.emphasis_fg_of design_value) ~attrs:[ Attr.Bold ] ())
+          value;
+      ]
+      @ (match detail with None -> [] | Some d -> [ Components.text ~style:Style.(make ~fg:accent ()) d ])
+      @ (match progress with None -> [] | Some p -> [ Components.progress_bar ~style:Style.(make ~height:(Cells 1) ()) p ])
+      @
+      match series with
+      | None -> []
+      | Some values -> [ Components.sparkline ~style:Style.(make ~fg:accent ~height:(Cells 1) ()) values ]
+    in
+    Components.panel ?id ~tone ?design
+      ~style:
+        Style.
+          {
+            style with
+            height =
+              (match style.height with Auto -> Cells (List.length children + 4) | other -> other);
+          }
+      label children
+
+  let log_feed ?id ?(style = Style.default) ?design entries =
+    let design_value = Components.resolve_design design in
     let tone_of_level = function
-      | "ERR" | "ERROR" | "FAIL" -> Error
-      | "WARN" | "WARNING" -> Warning
-      | "OK" | "DONE" -> Success
-      | "INFO" -> Info
-      | _ -> Neutral
+      | "ERR" | "ERROR" | "FAIL" -> Components.Error
+      | "WARN" | "WARNING" -> Components.Warning
+      | "OK" | "DONE" -> Components.Success
+      | "INFO" -> Components.Info
+      | _ -> Components.Neutral
     in
     let row (time, level, message) =
-      rich_text
+      Components.rich_text
         [
-          Span.make ~style:Style.(make ~fg:muted_fg ~attrs:[ Attr.Dim ] ()) (time ^ " ");
-          Span.make ~style:Style.(make ~fg:(color_of_tone (tone_of_level level)) ~attrs:[ Attr.Bold ] ()) (fit 5 level);
-          Span.make ~style:Style.(make ~fg:default_fg ()) (" " ^ message);
+          Span.make
+            ~style:Style.(make ~fg:(Components.muted_fg_of design_value) ~attrs:[ Attr.Dim ] ())
+            (time ^ " ");
+          Span.make
+            ~style:
+              Style.(
+                make
+                  ~fg:(Components.color_of_tone ~design:design_value (tone_of_level level))
+                  ~attrs:[ Attr.Bold ] ())
+            (Components.fit 5 level);
+          Span.make ~style:Style.(make ~fg:(Components.default_fg_of design_value) ()) (" " ^ message);
         ]
     in
-    scroll_box ?id ~style:Style.{ style with flex_direction = Column } (List.map row entries)
+    Components.scroll_box ?id ~style:Style.{ style with flex_direction = Column } (List.map row entries)
 
-  let section_title ?id ?(tone = Accent) ?(style = Style.default) title =
+  let section_title ?id ?(tone = Components.Accent) ?(style = Style.default) ?design title =
+    let design = Components.resolve_design design in
     Node.text ?id
       ~style:
         Style.
           {
-            (make ~height:(Cells 1) ~fg:(color_of_tone tone)
+            (make ~height:(Cells 1) ~fg:(Components.color_of_tone ~design tone)
                ~attrs:[ Attr.Bold ] ())
             with
             width = style.width;
@@ -1674,10 +1716,11 @@ module Components = struct
           }
       title
 
-  let nav_item ?id ?(active = false) ?meta ?(tone = Accent)
-      ?(style = Style.default) label =
+  let nav_item ?id ?(active = false) ?meta ?(tone = Components.Accent)
+      ?(style = Style.default) ?design label =
+    let design = Components.resolve_design design in
     let marker = if active then "› " else "  " in
-    let fg = if active then color_of_tone tone else default_fg in
+    let fg = if active then Components.color_of_tone ~design tone else Components.default_fg_of design in
     let attrs = if active then [ Attr.Bold ] else [] in
     let content =
       [
@@ -1688,28 +1731,32 @@ module Components = struct
       | None -> []
       | Some meta ->
           [
-            Span.make ~style:Style.(make ~fg:muted_fg ~attrs:[ Attr.Dim ] ())
+            Span.make
+              ~style:Style.(make ~fg:(Components.muted_fg_of design) ~attrs:[ Attr.Dim ] ())
               ("  " ^ meta);
           ]
     in
-    rich_text ?id ~style:Style.{ style with height = Cells 1 } content
+    Components.rich_text ?id ~style:Style.{ style with height = Cells 1 } content
 
-  let message ?id ?(tone = Neutral) ?time ?(style = Style.default) ~author body =
-    let accent = color_of_tone tone in
+  let message ?id ?(tone = Components.Neutral) ?time ?(style = Style.default) ?design ~author body =
+    let design = Components.resolve_design design in
+    let accent = Components.color_of_tone ~design tone in
     let header =
-      rich_text
+      Components.rich_text
         [
           Span.make ~style:Style.(make ~fg:accent ~attrs:[ Attr.Bold ] ()) author;
-          Span.make ~style:Style.(make ~fg:muted_fg ~attrs:[ Attr.Dim ] ())
+          Span.make
+            ~style:Style.(make ~fg:(Components.muted_fg_of design) ~attrs:[ Attr.Dim ] ())
             (match time with None -> "" | Some value -> "  " ^ value);
         ]
     in
     let lines =
       body
       |> String.split_on_char '\n'
-      |> List.map (fun line -> text ~style:Style.(make ~fg:default_fg ()) line)
+      |> List.map (fun line ->
+             Components.text ~style:Style.(make ~fg:(Components.default_fg_of design) ()) line)
     in
-    box ?id
+    Components.box ?id
       ~style:
         Style.
           {
@@ -1722,106 +1769,183 @@ module Components = struct
           }
       (header :: lines)
 
-  let model_status ?id ?(style = Style.default) ?(mode = "Build")
-      ?(model = "DeepSeek V4 Pro") ?(provider = "OpenCode Go")
-      ?(effort = "high") () =
-    rich_text ?id ~style
-      [
-        Span.make ~style:Style.(make ~fg:(Theme.dark Theme.Accent_secondary) ~attrs:[ Attr.Bold ] ()) mode;
-        Span.make ~style:Style.(make ~fg:muted_fg ()) " · ";
-        Span.make ~style:Style.(make ~fg:default_fg ~attrs:[ Attr.Bold ] ()) model;
-        Span.make ~style:Style.(make ~fg:muted_fg ()) (" " ^ provider ^ " · ");
-        Span.make ~style:Style.(make ~fg:(Theme.dark Theme.Status_warning) ~attrs:[ Attr.Bold ] ()) effort;
-      ]
-
-  let command_block ?id ?(tone = Accent) ?(style = Style.default) command =
-    rule_panel ?id ~tone
-      ~style:Style.{ style with height = (match style.height with Auto -> Cells 4 | h -> h) }
-      [ text ~style:Style.(make ~fg:default_fg ()) command ]
-
-  let hint_bar ?id ?(style = Style.default) items =
-    let spans =
-      items
-      |> List.concat_map (fun (key, label) ->
-             [
-               Span.make ~style:Style.(make ~fg:default_fg ~attrs:[ Attr.Bold ] ()) key;
-               Span.make ~style:Style.(make ~fg:muted_fg ()) (" " ^ label ^ "   ");
-             ])
-    in
-    rich_text ?id ~style spans
-
-  let tip ?id ?(style = Style.default) message =
-    rich_text ?id ~style
-      [
-        Span.make ~style:Style.(make ~fg:(Theme.dark Theme.Status_warning) ~attrs:[ Attr.Bold ] ()) "● Tip ";
-        Span.make ~style:Style.(make ~fg:muted_fg ()) message;
-      ]
-
-  let timeline ?id ?(style = Style.default) entries =
+  let timeline ?id ?(style = Style.default) ?design entries =
+    let design = Components.resolve_design design in
     let row (tone, label, detail) =
-      rich_text
+      Components.rich_text
         [
-          Span.make ~style:Style.(make ~fg:(color_of_tone tone) ~attrs:[ Attr.Bold ] ()) "● ";
-          Span.make ~style:Style.(make ~fg:emphasis_fg ~attrs:[ Attr.Bold ] ()) label;
-          Span.make ~style:Style.(make ~fg:muted_fg ~attrs:[ Attr.Dim ] ())
+          Span.make
+            ~style:
+              Style.(
+                make ~fg:(Components.color_of_tone ~design tone) ~attrs:[ Attr.Bold ] ())
+            "● ";
+          Span.make
+            ~style:Style.(make ~fg:(Components.emphasis_fg_of design) ~attrs:[ Attr.Bold ] ())
+            label;
+          Span.make
+            ~style:Style.(make ~fg:(Components.muted_fg_of design) ~attrs:[ Attr.Dim ] ())
             ("  " ^ detail);
         ]
     in
-    box ?id ~style:Style.{ style with flex_direction = Column } (List.map row entries)
+    Components.box ?id ~style:Style.{ style with flex_direction = Column } (List.map row entries)
 
-  let composer ?id ?(style = Style.default) ?(prompt = ">") ?(placeholder = "Type a message") () =
-    box ?id
+  let composer ?id ?(style = Style.default) ?design ?(prompt = ">")
+      ?(placeholder = "Type a message") () =
+    let design = Components.resolve_design design in
+    let accent = Components.color_of_tone ~design Components.Accent in
+    Components.box ?id
       ~style:
         Style.
           {
-            (make ~border:Rounded ~border_fg:(Theme.dark Theme.Accent_primary)
-               ~height:(Cells 3) ~padding:(spacing_xy ~x:1 ~y:0) ())
+            (make ~border:Rounded ~border_fg:accent ~height:(Cells 3)
+               ~padding:(spacing_xy ~x:1 ~y:0) ())
             with
             width = style.width;
             margin = style.margin;
           }
       [
-        box ~style:Style.(make ~flex_direction:Row ~gap:1 ())
+        Components.box ~style:Style.(make ~flex_direction:Row ~gap:1 ())
           [
-            text ~style:Style.(make ~fg:(Theme.dark Theme.Accent_primary) ~attrs:[ Attr.Bold ] ()) prompt;
-            input ~style:Style.(make ~flex_grow:1. ()) ~placeholder ();
+            Components.text ~style:Style.(make ~fg:accent ~attrs:[ Attr.Bold ] ()) prompt;
+            Components.input ~style:Style.(make ~flex_grow:1. ()) ~placeholder ();
           ];
       ]
 
-  let split ?id ?(style = Style.default) ?(left_width = 32) left right =
-    box ?id
-      ~style:Style.{ style with flex_direction = Row; gap = 1 }
-      [
-        box ~style:Style.(make ~width:(Cells left_width) ~height:(Percent 1.) ()) left;
-        box ~style:Style.(make ~flex_grow:1. ~height:(Percent 1.) ()) right;
-      ]
-
-  let command_bar ?id ?(style = Style.default) items =
+  let command_bar ?id ?(style = Style.default) ?design items =
+    let design = Components.resolve_design design in
     let content = items |> List.map (fun (key, label) -> "[" ^ key ^ "]" ^ label) |> String.concat " " in
     Node.text ?id
       ~style:
         Style.
           {
-            (make ~height:(Cells 1) ~width:(Percent 1.) ~bg:(Color.indexed 237)
-               ~fg:(Color.indexed 250) ~attrs:[ Attr.Dim ] ())
+            (make ~height:(Cells 1) ~width:(Percent 1.)
+               ~bg:(Components.overlay_of design) ~fg:(Components.default_fg_of design)
+               ~attrs:[ Attr.Dim ] ())
             with
             margin = style.margin;
           }
       content
 
-  let footer shortcuts =
-    command_bar shortcuts
+  let footer ?design shortcuts =
+    command_bar ?design shortcuts
 
-  let app_shell ?id ?(title = "Symphony TUI") ?subtitle ?(badges = [])
+  let app_shell ?id ?(title = "App") ?subtitle ?(badges = [])
       ?(footer_items = [ ("q", "uit"); ("?", "help"); ("Tab", "focus") ])
-      body =
-    box ?id
+      ?design body =
+    Components.box ?id
       ~style:Style.(make ~width:(Percent 1.) ~height:(Percent 1.) ~flex_direction:Column ())
       [
-        header ?subtitle ~badges title;
-        box ~style:Style.(make ~flex_grow:1. ~flex_direction:Column ~padding:(spacing_xy ~x:1 ~y:0) ()) body;
-        command_bar footer_items;
+        header ?subtitle ~badges ?design title;
+        Components.box
+          ~style:Style.(make ~flex_grow:1. ~flex_direction:Column ~padding:(spacing_xy ~x:1 ~y:0) ())
+          body;
+        command_bar ?design footer_items;
       ]
+end
+
+module Presets = struct
+  module Open_code = struct
+    let glyph = function
+      | 'o' -> [ "████"; "█  █"; "█  █"; "█  █"; "████" ]
+      | 'p' -> [ "███ "; "█  █"; "███ "; "█   "; "█   " ]
+      | 'e' -> [ "████"; "█   "; "███ "; "█   "; "████" ]
+      | 'n' -> [ "█  █"; "██ █"; "█ ██"; "█  █"; "█  █" ]
+      | 'c' -> [ "████"; "█   "; "█   "; "█   "; "████" ]
+      | 'd' -> [ "███ "; "█  █"; "█  █"; "█  █"; "███ " ]
+      | 'a' -> [ " ██ "; "█  █"; "████"; "█  █"; "█  █" ]
+      | 'g' -> [ "████"; "█   "; "█ ██"; "█  █"; "████" ]
+      | 't' -> [ "████"; " ██ "; " ██ "; " ██ "; " ██ " ]
+      | 'w' -> [ "█  █"; "█  █"; "█  █"; "████"; "█  █" ]
+      | 'r' -> [ "███ "; "█  █"; "███ "; "█ █ "; "█  █" ]
+      | 'k' -> [ "█  █"; "█ █ "; "██  "; "█ █ "; "█  █" ]
+      | 's' -> [ "████"; "█   "; "████"; "   █"; "████" ]
+      | 'i' -> [ "███"; " █ "; " █ "; " █ "; "███" ]
+      | ' ' -> [ "  "; "  "; "  "; "  "; "  " ]
+      | _ -> [ "██"; "██"; "██"; "██"; "██" ]
+
+    let wordmark ?id ?(style = Style.default) ?design label =
+      let design = Components.resolve_design design in
+      let rows = Array.make 5 "" in
+      label
+      |> String.lowercase_ascii
+      |> String.iter (fun ch ->
+             glyph ch
+             |> List.iteri (fun i part ->
+                    rows.(i) <- rows.(i) ^ part ^ " "));
+      Components.box ?id ~style:Style.{ style with flex_direction = Column }
+        (Array.to_list rows
+        |> List.map (fun line ->
+               Components.text
+                 ~style:Style.(make ~fg:(Components.emphasis_fg_of design) ~attrs:[ Attr.Bold ] ())
+                 line))
+
+    let model_status ?id ?(style = Style.default) ?design ?(mode = "Build")
+        ?(model = "DeepSeek V4 Pro") ?(provider = "OpenCode Go")
+        ?(effort = "high") () =
+      let design = Components.resolve_design design in
+      Components.rich_text ?id ~style
+        [
+          Span.make
+            ~style:
+              Style.(
+                make ~fg:(Components.theme_color design Theme.Accent_secondary)
+                  ~attrs:[ Attr.Bold ] ())
+            mode;
+          Span.make ~style:Style.(make ~fg:(Components.muted_fg_of design) ()) " · ";
+          Span.make
+            ~style:Style.(make ~fg:(Components.default_fg_of design) ~attrs:[ Attr.Bold ] ())
+            model;
+          Span.make ~style:Style.(make ~fg:(Components.muted_fg_of design) ())
+            (" " ^ provider ^ " · ");
+          Span.make
+            ~style:
+              Style.(
+                make ~fg:(Components.theme_color design Theme.Status_warning)
+                  ~attrs:[ Attr.Bold ] ())
+            effort;
+        ]
+
+    let command_block ?id ?(tone = Components.Accent) ?(style = Style.default)
+        ?design command =
+      let design_value = Components.resolve_design design in
+      Patterns.rule_panel ?id ~tone ?design
+        ~style:Style.{ style with height = (match style.height with Auto -> Cells 4 | h -> h) }
+        [
+          Components.text
+            ~style:Style.(make ~fg:(Components.default_fg_of design_value) ())
+            command;
+        ]
+
+    let hint_bar ?id ?(style = Style.default) ?design items =
+      let design = Components.resolve_design design in
+      let spans =
+        items
+        |> List.concat_map (fun (key, label) ->
+               [
+                 Span.make
+                   ~style:
+                     Style.(
+                       make ~fg:(Components.default_fg_of design) ~attrs:[ Attr.Bold ] ())
+                   key;
+                 Span.make ~style:Style.(make ~fg:(Components.muted_fg_of design) ())
+                   (" " ^ label ^ "   ");
+               ])
+      in
+      Components.rich_text ?id ~style spans
+
+    let tip ?id ?(style = Style.default) ?design message =
+      let design = Components.resolve_design design in
+      Components.rich_text ?id ~style
+        [
+          Span.make
+            ~style:
+              Style.(
+                make ~fg:(Components.theme_color design Theme.Status_warning)
+                  ~attrs:[ Attr.Bold ] ())
+            "● Tip ";
+          Span.make ~style:Style.(make ~fg:(Components.muted_fg_of design) ()) message;
+        ]
+  end
 end
 
 let text = Components.text
@@ -1834,6 +1958,6 @@ let select = Components.select
 let scroll_box = Components.scroll_box
 let progress_bar = Components.progress_bar
 let sparkline = Components.sparkline
-let modal = Components.modal
+let modal = Patterns.modal
 let terminal_viewport = Terminal.viewport
 let terminal_size = Terminal.size

--- a/apps/tui/lib/tui.ml
+++ b/apps/tui/lib/tui.ml
@@ -1381,7 +1381,7 @@ module Renderer = struct
             done))
 end
 
-module Components = struct
+module Components_core = struct
   type tone =
     | Neutral
     | Accent
@@ -1574,30 +1574,30 @@ module Components = struct
 end
 
 module Patterns = struct
-  let rule_panel ?id ?(tone = Components.Accent) ?(style = Style.default) ?design children =
-    let design = Components.resolve_design design in
-    Components.box ?id
+  let rule_panel ?id ?(tone = Components_core.Accent) ?(style = Style.default) ?design children =
+    let design = Components_core.resolve_design design in
+    Components_core.box ?id
       ~style:Style.{ style with flex_direction = Row; gap = 1 }
       [
-        Components.vertical_rule
+        Components_core.vertical_rule
           ~style:
             Style.(
               make ~width:(Cells 1) ~height:(Percent 1.)
-                ~fg:(Components.color_of_tone ~design tone)
+                ~fg:(Components_core.color_of_tone ~design tone)
                 ~attrs:[ Attr.Bold ] ())
           ();
-        Components.box
+        Components_core.box
           ~style:
             Style.(
               make ~flex_grow:1. ~height:(Percent 1.)
-                ~padding:(spacing_xy ~x:1 ~y:0) ~bg:(Components.surface_of design)
+                ~padding:(spacing_xy ~x:1 ~y:0) ~bg:(Components_core.surface_of design)
                 ())
           children;
       ]
 
-  let modal ?id ?(tone = Components.Accent) ?(style = Style.default)
+  let modal ?id ?(tone = Components_core.Accent) ?(style = Style.default)
       ?(bottom_title = "Esc/? close") ?design title children =
-    let design_value = Components.resolve_design design in
+    let design_value = Components_core.resolve_design design in
     let modal_width = match style.width with Style.Auto -> Style.Cells 64 | width -> width in
     let modal_height = match style.height with Style.Auto -> Style.Cells 16 | height -> height in
     let content_style =
@@ -1607,22 +1607,22 @@ module Patterns = struct
           width = modal_width;
           height = modal_height;
           flex_direction = Column;
-          bg = Some (Components.surface_of design_value);
+          bg = Some (Components_core.surface_of design_value);
         }
     in
-    Components.box ?id
+    Components_core.box ?id
       ~style:
         Style.(
           make ~position:Absolute ~left:0 ~right:0 ~top:0 ~bottom:0
             ~width:(Percent 1.) ~height:(Percent 1.) ~justify_content:Justify_center
             ~align_items:Align_center ())
-      [ Components.panel ~tone ~bottom_title ~style:content_style ?design title children ]
+      [ Components_core.panel ~tone ~bottom_title ~style:content_style ?design title children ]
 
   let header ?id ?subtitle ?(badges = []) ?design title =
-    let design_value = Components.resolve_design design in
+    let design_value = Components_core.resolve_design design in
     let title_line =
-      Components.text
-        ~style:Style.(make ~fg:(Components.emphasis_fg_of design_value) ~attrs:[ Attr.Bold ] ())
+      Components_core.text
+        ~style:Style.(make ~fg:(Components_core.emphasis_fg_of design_value) ~attrs:[ Attr.Bold ] ())
         title
     in
     let subtitle_line =
@@ -1630,42 +1630,42 @@ module Patterns = struct
       | None -> []
       | Some copy ->
           [
-            Components.text
-              ~style:Style.(make ~fg:(Components.muted_fg_of design_value) ~attrs:[ Attr.Dim ] ())
+            Components_core.text
+              ~style:Style.(make ~fg:(Components_core.muted_fg_of design_value) ~attrs:[ Attr.Dim ] ())
               copy;
           ]
     in
     let badge_nodes =
-      badges |> List.map (fun (tone, label) -> Components.badge ~tone ?design label)
+      badges |> List.map (fun (tone, label) -> Components_core.badge ~tone ?design label)
     in
-    Components.box ?id
+    Components_core.box ?id
       ~style:Style.(make ~height:(Cells 3) ~flex_direction:Row ~justify_content:Space_between ~align_items:Align_center ~padding:(spacing_xy ~x:2 ~y:0) ())
       [
-        Components.box ~style:Style.(make ~flex_direction:Column ()) (title_line :: subtitle_line);
-        Components.box ~style:Style.(make ~flex_direction:Row ~gap:1 ()) badge_nodes;
+        Components_core.box ~style:Style.(make ~flex_direction:Column ()) (title_line :: subtitle_line);
+        Components_core.box ~style:Style.(make ~flex_direction:Row ~gap:1 ()) badge_nodes;
       ]
 
-  let metric_card ?id ?(tone = Components.Info) ?detail ?progress ?sparkline:series
+  let metric_card ?id ?(tone = Components_core.Info) ?detail ?progress ?sparkline:series
       ?(style = Style.default) ?design ~label ~value () =
-    let design_value = Components.resolve_design design in
-    let accent = Components.color_of_tone ~design:design_value tone in
+    let design_value = Components_core.resolve_design design in
+    let accent = Components_core.color_of_tone ~design:design_value tone in
     let children =
       [
-        Components.text
-          ~style:Style.(make ~fg:(Components.muted_fg_of design_value) ~attrs:[ Attr.Dim ] ())
+        Components_core.text
+          ~style:Style.(make ~fg:(Components_core.muted_fg_of design_value) ~attrs:[ Attr.Dim ] ())
           label;
-        Components.text
-          ~style:Style.(make ~fg:(Components.emphasis_fg_of design_value) ~attrs:[ Attr.Bold ] ())
+        Components_core.text
+          ~style:Style.(make ~fg:(Components_core.emphasis_fg_of design_value) ~attrs:[ Attr.Bold ] ())
           value;
       ]
-      @ (match detail with None -> [] | Some d -> [ Components.text ~style:Style.(make ~fg:accent ()) d ])
-      @ (match progress with None -> [] | Some p -> [ Components.progress_bar ~style:Style.(make ~height:(Cells 1) ()) p ])
+      @ (match detail with None -> [] | Some d -> [ Components_core.text ~style:Style.(make ~fg:accent ()) d ])
+      @ (match progress with None -> [] | Some p -> [ Components_core.progress_bar ~style:Style.(make ~height:(Cells 1) ()) p ])
       @
       match series with
       | None -> []
-      | Some values -> [ Components.sparkline ~style:Style.(make ~fg:accent ~height:(Cells 1) ()) values ]
+      | Some values -> [ Components_core.sparkline ~style:Style.(make ~fg:accent ~height:(Cells 1) ()) values ]
     in
-    Components.panel ?id ~tone ?design
+    Components_core.panel ?id ~tone ?design
       ~style:
         Style.
           {
@@ -1676,39 +1676,39 @@ module Patterns = struct
       label children
 
   let log_feed ?id ?(style = Style.default) ?design entries =
-    let design_value = Components.resolve_design design in
+    let design_value = Components_core.resolve_design design in
     let tone_of_level = function
-      | "ERR" | "ERROR" | "FAIL" -> Components.Error
-      | "WARN" | "WARNING" -> Components.Warning
-      | "OK" | "DONE" -> Components.Success
-      | "INFO" -> Components.Info
-      | _ -> Components.Neutral
+      | "ERR" | "ERROR" | "FAIL" -> Components_core.Error
+      | "WARN" | "WARNING" -> Components_core.Warning
+      | "OK" | "DONE" -> Components_core.Success
+      | "INFO" -> Components_core.Info
+      | _ -> Components_core.Neutral
     in
     let row (time, level, message) =
-      Components.rich_text
+      Components_core.rich_text
         [
           Span.make
-            ~style:Style.(make ~fg:(Components.muted_fg_of design_value) ~attrs:[ Attr.Dim ] ())
+            ~style:Style.(make ~fg:(Components_core.muted_fg_of design_value) ~attrs:[ Attr.Dim ] ())
             (time ^ " ");
           Span.make
             ~style:
               Style.(
                 make
-                  ~fg:(Components.color_of_tone ~design:design_value (tone_of_level level))
+                  ~fg:(Components_core.color_of_tone ~design:design_value (tone_of_level level))
                   ~attrs:[ Attr.Bold ] ())
-            (Components.fit 5 level);
-          Span.make ~style:Style.(make ~fg:(Components.default_fg_of design_value) ()) (" " ^ message);
+            (Components_core.fit 5 level);
+          Span.make ~style:Style.(make ~fg:(Components_core.default_fg_of design_value) ()) (" " ^ message);
         ]
     in
-    Components.scroll_box ?id ~style:Style.{ style with flex_direction = Column } (List.map row entries)
+    Components_core.scroll_box ?id ~style:Style.{ style with flex_direction = Column } (List.map row entries)
 
-  let section_title ?id ?(tone = Components.Accent) ?(style = Style.default) ?design title =
-    let design = Components.resolve_design design in
+  let section_title ?id ?(tone = Components_core.Accent) ?(style = Style.default) ?design title =
+    let design = Components_core.resolve_design design in
     Node.text ?id
       ~style:
         Style.
           {
-            (make ~height:(Cells 1) ~fg:(Components.color_of_tone ~design tone)
+            (make ~height:(Cells 1) ~fg:(Components_core.color_of_tone ~design tone)
                ~attrs:[ Attr.Bold ] ())
             with
             width = style.width;
@@ -1716,11 +1716,11 @@ module Patterns = struct
           }
       title
 
-  let nav_item ?id ?(active = false) ?meta ?(tone = Components.Accent)
+  let nav_item ?id ?(active = false) ?meta ?(tone = Components_core.Accent)
       ?(style = Style.default) ?design label =
-    let design = Components.resolve_design design in
+    let design = Components_core.resolve_design design in
     let marker = if active then "› " else "  " in
-    let fg = if active then Components.color_of_tone ~design tone else Components.default_fg_of design in
+    let fg = if active then Components_core.color_of_tone ~design tone else Components_core.default_fg_of design in
     let attrs = if active then [ Attr.Bold ] else [] in
     let content =
       [
@@ -1732,21 +1732,21 @@ module Patterns = struct
       | Some meta ->
           [
             Span.make
-              ~style:Style.(make ~fg:(Components.muted_fg_of design) ~attrs:[ Attr.Dim ] ())
+              ~style:Style.(make ~fg:(Components_core.muted_fg_of design) ~attrs:[ Attr.Dim ] ())
               ("  " ^ meta);
           ]
     in
-    Components.rich_text ?id ~style:Style.{ style with height = Cells 1 } content
+    Components_core.rich_text ?id ~style:Style.{ style with height = Cells 1 } content
 
-  let message ?id ?(tone = Components.Neutral) ?time ?(style = Style.default) ?design ~author body =
-    let design = Components.resolve_design design in
-    let accent = Components.color_of_tone ~design tone in
+  let message ?id ?(tone = Components_core.Neutral) ?time ?(style = Style.default) ?design ~author body =
+    let design = Components_core.resolve_design design in
+    let accent = Components_core.color_of_tone ~design tone in
     let header =
-      Components.rich_text
+      Components_core.rich_text
         [
           Span.make ~style:Style.(make ~fg:accent ~attrs:[ Attr.Bold ] ()) author;
           Span.make
-            ~style:Style.(make ~fg:(Components.muted_fg_of design) ~attrs:[ Attr.Dim ] ())
+            ~style:Style.(make ~fg:(Components_core.muted_fg_of design) ~attrs:[ Attr.Dim ] ())
             (match time with None -> "" | Some value -> "  " ^ value);
         ]
     in
@@ -1754,9 +1754,9 @@ module Patterns = struct
       body
       |> String.split_on_char '\n'
       |> List.map (fun line ->
-             Components.text ~style:Style.(make ~fg:(Components.default_fg_of design) ()) line)
+             Components_core.text ~style:Style.(make ~fg:(Components_core.default_fg_of design) ()) line)
     in
-    Components.box ?id
+    Components_core.box ?id
       ~style:
         Style.
           {
@@ -1770,30 +1770,30 @@ module Patterns = struct
       (header :: lines)
 
   let timeline ?id ?(style = Style.default) ?design entries =
-    let design = Components.resolve_design design in
+    let design = Components_core.resolve_design design in
     let row (tone, label, detail) =
-      Components.rich_text
+      Components_core.rich_text
         [
           Span.make
             ~style:
               Style.(
-                make ~fg:(Components.color_of_tone ~design tone) ~attrs:[ Attr.Bold ] ())
+                make ~fg:(Components_core.color_of_tone ~design tone) ~attrs:[ Attr.Bold ] ())
             "● ";
           Span.make
-            ~style:Style.(make ~fg:(Components.emphasis_fg_of design) ~attrs:[ Attr.Bold ] ())
+            ~style:Style.(make ~fg:(Components_core.emphasis_fg_of design) ~attrs:[ Attr.Bold ] ())
             label;
           Span.make
-            ~style:Style.(make ~fg:(Components.muted_fg_of design) ~attrs:[ Attr.Dim ] ())
+            ~style:Style.(make ~fg:(Components_core.muted_fg_of design) ~attrs:[ Attr.Dim ] ())
             ("  " ^ detail);
         ]
     in
-    Components.box ?id ~style:Style.{ style with flex_direction = Column } (List.map row entries)
+    Components_core.box ?id ~style:Style.{ style with flex_direction = Column } (List.map row entries)
 
   let composer ?id ?(style = Style.default) ?design ?(prompt = ">")
       ?(placeholder = "Type a message") () =
-    let design = Components.resolve_design design in
-    let accent = Components.color_of_tone ~design Components.Accent in
-    Components.box ?id
+    let design = Components_core.resolve_design design in
+    let accent = Components_core.color_of_tone ~design Components_core.Accent in
+    Components_core.box ?id
       ~style:
         Style.
           {
@@ -1804,22 +1804,22 @@ module Patterns = struct
             margin = style.margin;
           }
       [
-        Components.box ~style:Style.(make ~flex_direction:Row ~gap:1 ())
+        Components_core.box ~style:Style.(make ~flex_direction:Row ~gap:1 ())
           [
-            Components.text ~style:Style.(make ~fg:accent ~attrs:[ Attr.Bold ] ()) prompt;
-            Components.input ~style:Style.(make ~flex_grow:1. ()) ~placeholder ();
+            Components_core.text ~style:Style.(make ~fg:accent ~attrs:[ Attr.Bold ] ()) prompt;
+            Components_core.input ~style:Style.(make ~flex_grow:1. ()) ~placeholder ();
           ];
       ]
 
   let command_bar ?id ?(style = Style.default) ?design items =
-    let design = Components.resolve_design design in
+    let design = Components_core.resolve_design design in
     let content = items |> List.map (fun (key, label) -> "[" ^ key ^ "]" ^ label) |> String.concat " " in
     Node.text ?id
       ~style:
         Style.
           {
             (make ~height:(Cells 1) ~width:(Percent 1.)
-               ~bg:(Components.overlay_of design) ~fg:(Components.default_fg_of design)
+               ~bg:(Components_core.overlay_of design) ~fg:(Components_core.default_fg_of design)
                ~attrs:[ Attr.Dim ] ())
             with
             margin = style.margin;
@@ -1832,11 +1832,11 @@ module Patterns = struct
   let app_shell ?id ?(title = "App") ?subtitle ?(badges = [])
       ?(footer_items = [ ("q", "uit"); ("?", "help"); ("Tab", "focus") ])
       ?design body =
-    Components.box ?id
+    Components_core.box ?id
       ~style:Style.(make ~width:(Percent 1.) ~height:(Percent 1.) ~flex_direction:Column ())
       [
         header ?subtitle ~badges ?design title;
-        Components.box
+        Components_core.box
           ~style:Style.(make ~flex_grow:1. ~flex_direction:Column ~padding:(spacing_xy ~x:1 ~y:0) ())
           body;
         command_bar ?design footer_items;
@@ -1864,7 +1864,7 @@ module Presets = struct
       | _ -> [ "██"; "██"; "██"; "██"; "██" ]
 
     let wordmark ?id ?(style = Style.default) ?design label =
-      let design = Components.resolve_design design in
+      let design = Components_core.resolve_design design in
       let rows = Array.make 5 "" in
       label
       |> String.lowercase_ascii
@@ -1872,52 +1872,52 @@ module Presets = struct
              glyph ch
              |> List.iteri (fun i part ->
                     rows.(i) <- rows.(i) ^ part ^ " "));
-      Components.box ?id ~style:Style.{ style with flex_direction = Column }
+      Components_core.box ?id ~style:Style.{ style with flex_direction = Column }
         (Array.to_list rows
         |> List.map (fun line ->
-               Components.text
-                 ~style:Style.(make ~fg:(Components.emphasis_fg_of design) ~attrs:[ Attr.Bold ] ())
+               Components_core.text
+                 ~style:Style.(make ~fg:(Components_core.emphasis_fg_of design) ~attrs:[ Attr.Bold ] ())
                  line))
 
     let model_status ?id ?(style = Style.default) ?design ?(mode = "Build")
         ?(model = "DeepSeek V4 Pro") ?(provider = "OpenCode Go")
         ?(effort = "high") () =
-      let design = Components.resolve_design design in
-      Components.rich_text ?id ~style
+      let design = Components_core.resolve_design design in
+      Components_core.rich_text ?id ~style
         [
           Span.make
             ~style:
               Style.(
-                make ~fg:(Components.theme_color design Theme.Accent_secondary)
+                make ~fg:(Components_core.theme_color design Theme.Accent_secondary)
                   ~attrs:[ Attr.Bold ] ())
             mode;
-          Span.make ~style:Style.(make ~fg:(Components.muted_fg_of design) ()) " · ";
+          Span.make ~style:Style.(make ~fg:(Components_core.muted_fg_of design) ()) " · ";
           Span.make
-            ~style:Style.(make ~fg:(Components.default_fg_of design) ~attrs:[ Attr.Bold ] ())
+            ~style:Style.(make ~fg:(Components_core.default_fg_of design) ~attrs:[ Attr.Bold ] ())
             model;
-          Span.make ~style:Style.(make ~fg:(Components.muted_fg_of design) ())
+          Span.make ~style:Style.(make ~fg:(Components_core.muted_fg_of design) ())
             (" " ^ provider ^ " · ");
           Span.make
             ~style:
               Style.(
-                make ~fg:(Components.theme_color design Theme.Status_warning)
+                make ~fg:(Components_core.theme_color design Theme.Status_warning)
                   ~attrs:[ Attr.Bold ] ())
             effort;
         ]
 
-    let command_block ?id ?(tone = Components.Accent) ?(style = Style.default)
+    let command_block ?id ?(tone = Components_core.Accent) ?(style = Style.default)
         ?design command =
-      let design_value = Components.resolve_design design in
+      let design_value = Components_core.resolve_design design in
       Patterns.rule_panel ?id ~tone ?design
         ~style:Style.{ style with height = (match style.height with Auto -> Cells 4 | h -> h) }
         [
-          Components.text
-            ~style:Style.(make ~fg:(Components.default_fg_of design_value) ())
+          Components_core.text
+            ~style:Style.(make ~fg:(Components_core.default_fg_of design_value) ())
             command;
         ]
 
     let hint_bar ?id ?(style = Style.default) ?design items =
-      let design = Components.resolve_design design in
+      let design = Components_core.resolve_design design in
       let spans =
         items
         |> List.concat_map (fun (key, label) ->
@@ -1925,27 +1925,50 @@ module Presets = struct
                  Span.make
                    ~style:
                      Style.(
-                       make ~fg:(Components.default_fg_of design) ~attrs:[ Attr.Bold ] ())
+                       make ~fg:(Components_core.default_fg_of design) ~attrs:[ Attr.Bold ] ())
                    key;
-                 Span.make ~style:Style.(make ~fg:(Components.muted_fg_of design) ())
+                 Span.make ~style:Style.(make ~fg:(Components_core.muted_fg_of design) ())
                    (" " ^ label ^ "   ");
                ])
       in
-      Components.rich_text ?id ~style spans
+      Components_core.rich_text ?id ~style spans
 
     let tip ?id ?(style = Style.default) ?design message =
-      let design = Components.resolve_design design in
-      Components.rich_text ?id ~style
+      let design = Components_core.resolve_design design in
+      Components_core.rich_text ?id ~style
         [
           Span.make
             ~style:
               Style.(
-                make ~fg:(Components.theme_color design Theme.Status_warning)
+                make ~fg:(Components_core.theme_color design Theme.Status_warning)
                   ~attrs:[ Attr.Bold ] ())
             "● Tip ";
-          Span.make ~style:Style.(make ~fg:(Components.muted_fg_of design) ()) message;
+          Span.make ~style:Style.(make ~fg:(Components_core.muted_fg_of design) ()) message;
         ]
   end
+end
+
+module Components = struct
+  include Components_core
+
+  let rule_panel = Patterns.rule_panel
+  let modal = Patterns.modal
+  let header = Patterns.header
+  let metric_card = Patterns.metric_card
+  let log_feed = Patterns.log_feed
+  let section_title = Patterns.section_title
+  let nav_item = Patterns.nav_item
+  let message = Patterns.message
+  let timeline = Patterns.timeline
+  let composer = Patterns.composer
+  let command_bar = Patterns.command_bar
+  let footer = Patterns.footer
+  let app_shell = Patterns.app_shell
+  let wordmark = Presets.Open_code.wordmark
+  let model_status = Presets.Open_code.model_status
+  let command_block = Presets.Open_code.command_block
+  let hint_bar = Presets.Open_code.hint_bar
+  let tip = Presets.Open_code.tip
 end
 
 let text = Components.text

--- a/apps/tui/test/test_tui.ml
+++ b/apps/tui/test/test_tui.ml
@@ -89,13 +89,13 @@ let table_component_fits_unicode () =
 
 let dashboard_components_render () =
   let root =
-    Components.app_shell ~title:"Ops" ~badges:[ (Components.Success, "live") ]
+    Patterns.app_shell ~title:"Ops" ~badges:[ (Components.Success, "live") ]
       [
         Components.row
           [
-            Components.metric_card ~label:"CPU" ~value:"67%" ~progress:0.67 ();
+            Patterns.metric_card ~label:"CPU" ~value:"67%" ~progress:0.67 ();
             Components.panel "Events"
-              [ Components.log_feed [ ("12:00", "INFO", "started"); ("12:01", "OK", "ready") ] ];
+              [ Patterns.log_feed [ ("12:00", "INFO", "started"); ("12:01", "OK", "ready") ] ];
           ];
       ]
   in
@@ -112,11 +112,11 @@ let opencode_helpers_render () =
   let root =
     box
       [
-        Components.wordmark "opencode";
-        Components.rule_panel
+        Presets.Open_code.wordmark "opencode";
+        Patterns.rule_panel
           [
-            Components.model_status ();
-            Components.hint_bar [ ("tab", "agents"); ("ctrl+p", "commands") ];
+            Presets.Open_code.model_status ();
+            Presets.Open_code.hint_bar [ ("tab", "agents"); ("ctrl+p", "commands") ];
           ];
       ]
   in
@@ -130,7 +130,7 @@ let modal_component_renders_overlay () =
       ~style:Style.(make ~width:(Cells 40) ~height:(Cells 12) ())
       [
         text "background";
-        Components.modal ~id:"help-modal" ~style:Style.(make ~width:(Cells 24) ~height:(Cells 7) ())
+        Patterns.modal ~id:"help-modal" ~style:Style.(make ~width:(Cells 24) ~height:(Cells 7) ())
           "Commands"
           [ text "q quit"; text "? close" ];
       ]
@@ -177,6 +177,46 @@ let renderer_viewport_and_resize () =
   Renderer.resize renderer ~width:0 ~height:0;
   Alcotest.(check (pair int int)) "resize clamps" (1, 1) (Renderer.size renderer)
 
+let component_design_injects_theme () =
+  let theme = function
+    | Theme.Fg_default -> Color.ansi 1
+    | Theme.Fg_muted -> Color.ansi 2
+    | Theme.Fg_emphasis -> Color.ansi 3
+    | Theme.Bg_base -> Color.ansi 4
+    | Theme.Bg_surface -> Color.ansi 5
+    | Theme.Bg_overlay -> Color.ansi 6
+    | Theme.Bg_selection -> Color.ansi 7
+    | Theme.Accent_primary -> Color.ansi 8
+    | Theme.Accent_secondary -> Color.ansi 9
+    | Theme.Status_error -> Color.ansi 10
+    | Theme.Status_warning -> Color.ansi 11
+    | Theme.Status_success -> Color.ansi 12
+    | Theme.Status_info -> Color.ansi 13
+  in
+  let design = Components.make_design ~theme () in
+  let root = Components.badge ~id:"badge" ~tone:Components.Success ~design "ok" in
+  (match Node.find_by_id "badge" root with
+  | Some node -> Alcotest.(check bool) "uses custom success color" true (node.style.fg = Some (Color.ansi 12))
+  | None -> Alcotest.fail "badge not found");
+  let light_design = Components.make_design ~theme:Theme.light () in
+  let light = Components.badge ~id:"light-badge" ~tone:Components.Success ~design:light_design "ok" in
+  match Node.find_by_id "light-badge" light with
+  | Some node ->
+      Alcotest.(check bool)
+        "uses light success color" true
+        (node.style.fg = Some (Theme.light Theme.Status_success))
+  | None -> Alcotest.fail "light badge not found"
+
+let app_shell_default_is_neutral () =
+  let output = Renderer.render_to_string (Renderer.create ~width:32 ~height:6 (Patterns.app_shell [])) in
+  Alcotest.(check bool) "default app title" true (contains_sub output "App");
+  Alcotest.(check bool) "no product title" false (contains_sub output "Symphony TUI")
+
+let opencode_preset_has_moved_helper () =
+  let root = Presets.Open_code.model_status () in
+  let output = Renderer.render_to_string (Renderer.create ~width:80 ~height:1 root) in
+  Alcotest.(check bool) "preset renders default model" true (contains_sub output "DeepSeek V4 Pro")
+
 let () =
   Alcotest.run "tui"
     [
@@ -196,6 +236,9 @@ let () =
           Alcotest.test_case "vertical rule" `Quick vertical_rule_fills_height;
           Alcotest.test_case "opencode helpers" `Quick opencode_helpers_render;
           Alcotest.test_case "modal overlay" `Quick modal_component_renders_overlay;
+          Alcotest.test_case "design injection" `Quick component_design_injects_theme;
+          Alcotest.test_case "neutral app shell default" `Quick app_shell_default_is_neutral;
+          Alcotest.test_case "opencode preset helper" `Quick opencode_preset_has_moved_helper;
         ] );
       ( "viewport",
         [

--- a/apps/tui/test/test_tui.ml
+++ b/apps/tui/test/test_tui.ml
@@ -217,6 +217,25 @@ let opencode_preset_has_moved_helper () =
   let output = Renderer.render_to_string (Renderer.create ~width:80 ~height:1 root) in
   Alcotest.(check bool) "preset renders default model" true (contains_sub output "DeepSeek V4 Pro")
 
+let component_compat_aliases_render () =
+  let root =
+    box
+      [
+        Components.header ~subtitle:"keeps old call sites working" "Compat";
+        Components.modal ~id:"compat-modal"
+          ~style:Style.(make ~width:(Cells 24) ~height:(Cells 7) ())
+          "Help"
+          [ text "q quit" ];
+        Components.model_status ();
+      ]
+  in
+  let renderer = Renderer.create ~width:48 ~height:12 root in
+  let output = Renderer.render_to_string renderer in
+  Alcotest.(check bool) "modal alias node exists" true
+    (Option.is_some (Node.find_by_id "compat-modal" renderer.root));
+  Alcotest.(check bool) "header alias renders" true (contains_sub output "Compat");
+  Alcotest.(check bool) "preset alias renders" true (contains_sub output "DeepSeek V4 Pro")
+
 let () =
   Alcotest.run "tui"
     [
@@ -239,6 +258,7 @@ let () =
           Alcotest.test_case "design injection" `Quick component_design_injects_theme;
           Alcotest.test_case "neutral app shell default" `Quick app_shell_default_is_neutral;
           Alcotest.test_case "opencode preset helper" `Quick opencode_preset_has_moved_helper;
+          Alcotest.test_case "compat aliases" `Quick component_compat_aliases_render;
         ] );
       ( "viewport",
         [


### PR DESCRIPTION
## Summary

- Expand the TUI package README with practical usage guidance for setup, API layers, layout, rendering, theming, keyboard handling, examples, and development commands.
- Add an examples index under `apps/tui/examples/README.md`.
- Add a README for each executable example: `demo`, `operations_dashboard`, `agent_workspace`, `opencode_splash`, and `opencode_session`.

## Impact

This gives TUI users a clearer path from first render to choosing the right example and understanding how each example is structured.

## Validation

- `opam exec -- dune build @all` from `apps/tui`
