### PR TITLE
[codex] Apply Cursor dark theme to Terminal Console

### DIFF
--- a/apps/backend/bin/terminal_console_tui.ml
+++ b/apps/backend/bin/terminal_console_tui.ml
@@ -1064,8 +1064,44 @@ let render_model model =
 
 let nonempty_lines fallback = function [] -> [ fallback ] | lines -> lines
 
-let span ?(attrs = []) slot text =
-  Span.make ~style:Style.(make ~fg:(Theme.dark slot) ~attrs ()) text
+let cursor_canvas = Color.rgb 22 21 18
+let cursor_canvas_soft = Color.rgb 30 29 25
+let cursor_surface_card = Color.rgb 38 37 32
+let cursor_surface_strong = Color.rgb 52 50 43
+let cursor_ink = Color.rgb 247 247 244
+let cursor_body = Color.rgb 214 211 202
+let cursor_muted = Color.rgb 160 156 146
+let cursor_orange = Color.rgb 245 78 0
+let cursor_success = Color.rgb 88 181 142
+let cursor_error = Color.rgb 232 83 118
+(* Cursor timeline pastels are reserved for agent timeline markers, not global semantics. *)
+let terminal_console_warning = Color.rgb 218 164 65
+let terminal_console_info = Color.rgb 139 177 224
+
+let terminal_console_theme =
+  Theme.of_palette
+    (Theme.make
+       ~fg_default:cursor_body
+       ~fg_muted:cursor_muted
+       ~fg_emphasis:cursor_ink
+       ~bg_base:cursor_canvas
+       ~bg_surface:cursor_canvas_soft
+       ~bg_overlay:cursor_surface_card
+       ~bg_selection:cursor_surface_strong
+       ~accent_primary:cursor_orange
+       ~accent_secondary:cursor_ink
+       ~status_error:cursor_error
+       ~status_warning:terminal_console_warning
+       ~status_success:cursor_success
+       ~status_info:terminal_console_info
+       ())
+
+let terminal_console_design = Components.make_design ~theme:terminal_console_theme ()
+
+let theme_color slot = terminal_console_theme slot
+
+let span ?(attrs = []) ?(bg = Theme.Bg_surface) slot text =
+  Span.make ~style:Style.(make ~fg:(theme_color slot) ~bg:(theme_color bg) ~attrs ()) text
 
 let theme_slot_of_tone = function
   | Components.Neutral -> Theme.Fg_muted
@@ -1316,7 +1352,8 @@ let line_nodes ?(spaced = false) lines =
          Components.text
            ~style:
              Style.(
-               make ~fg:(Theme.dark Theme.Fg_default) ~height:(Cells 1)
+               make ~fg:(theme_color Theme.Fg_default) ~bg:(theme_color Theme.Bg_surface)
+                 ~height:(Cells 1)
                  ~margin:(spacing ~bottom:(if spaced then 1 else 0) ()) ())
            line)
 
@@ -1326,7 +1363,8 @@ let content_line_nodes lines =
          Components.rich_text
            ~style:
              Style.(
-               make ~height:(Cells 1) ~fg:(Theme.dark Theme.Fg_default)
+               make ~height:(Cells 1) ~fg:(theme_color Theme.Fg_default)
+                 ~bg:(theme_color Theme.Bg_surface)
                  ~margin:(spacing ~bottom:1 ()) ())
            (content_line_spans line))
 
@@ -1334,12 +1372,15 @@ let log_line_nodes lines =
   lines |> nonempty_lines "No background logs captured yet."
   |> List.map (fun line ->
          Components.rich_text
-           ~style:Style.(make ~height:(Cells 1) ~fg:(Theme.dark Theme.Fg_default) ())
+           ~style:
+             Style.(
+               make ~height:(Cells 1) ~fg:(theme_color Theme.Fg_default)
+                 ~bg:(theme_color Theme.Bg_surface) ())
            (log_line_spans line))
 
 let command_help_row (key, label) =
   Components.rich_text
-    ~style:Style.(make ~height:(Cells 1) ())
+    ~style:Style.(make ~height:(Cells 1) ~bg:(theme_color Theme.Bg_surface) ())
     [
       span ~attrs:[ Attr.Bold ] Theme.Accent_primary key;
       span ~attrs:[] Theme.Fg_muted "  ";
@@ -1348,6 +1389,7 @@ let command_help_row (key, label) =
 
 let help_modal_node () =
   Components.modal ~id:"terminal-console-command-modal" ~tone:Components.Info
+    ~design:terminal_console_design
     ~style:Style.(make ~width:(Cells 72) ~height:(Cells 14) ())
     "Commands"
     [
@@ -1361,7 +1403,10 @@ let find_panel rendered title = List.find_opt (fun panel -> panel.title = title)
 let active_panel rendered interaction =
   match find_panel rendered (tab_title interaction.active_tab) with
   | Some panel -> panel
-  | None -> { title = tab_title interaction.active_tab; lines = [ "No content available." ] }
+  | None -> (
+      match rendered.panels with
+      | panel :: _ -> panel
+      | [] -> { title = tab_title interaction.active_tab; lines = [ "No content available." ] })
 
 let footer_segment_spans text =
   let text = Util.trim text in
@@ -1383,15 +1428,15 @@ let footer_node rendered =
   Components.rich_text
     ~style:
       Style.(
-        make ~height:(Cells 1) ~width:(Percent 1.) ~bg:(Theme.dark Theme.Bg_surface)
-          ~fg:(Theme.dark Theme.Fg_default) ())
+        make ~height:(Cells 1) ~width:(Percent 1.) ~bg:(theme_color Theme.Bg_surface)
+          ~fg:(theme_color Theme.Fg_default) ())
     (footer_spans rendered.footer)
 
 let tab_node active tab =
   let tone = tab_tone tab in
   let attrs = if active then [ Attr.Bold; Attr.Underline ] else [ Attr.Dim ] in
   Components.rich_text
-    ~style:Style.(make ~height:(Cells 1) ())
+    ~style:Style.(make ~height:(Cells 1) ~bg:(theme_color Theme.Bg_surface) ())
     [
       toned_span ~attrs tone (tab_title tab);
     ]
@@ -1399,15 +1444,20 @@ let tab_node active tab =
 let header_node rendered active_tab mode =
   let title =
     Components.text
-      ~style:Style.(make ~fg:(Theme.dark Theme.Fg_emphasis) ~attrs:[ Attr.Bold ] ())
+      ~style:
+        Style.(
+          make ~fg:(theme_color Theme.Fg_emphasis) ~bg:(theme_color Theme.Bg_base)
+            ~attrs:[ Attr.Bold ] ())
       rendered.heading
   in
   let subtitle =
-    Components.text ~style:Style.(make ~fg:(Theme.dark Theme.Fg_default) ()) rendered.subheading
+    Components.text
+      ~style:Style.(make ~fg:(theme_color Theme.Fg_default) ~bg:(theme_color Theme.Bg_base) ())
+      rendered.subheading
   in
   let badges =
     [ (tab_tone active_tab, tab_title active_tab); (status_badge_tone mode, rendered.status_label) ]
-    |> List.map (fun (tone, label) -> Components.badge ~tone label)
+    |> List.map (fun (tone, label) -> Components.badge ~tone ~design:terminal_console_design label)
   in
   Components.box
     ~style:
@@ -1430,22 +1480,23 @@ let view model =
         ~style:
           Style.(
             make ~height:(Cells 1) ~align_items:Align_center
-              ~padding:(spacing_xy ~x:2 ~y:0) ~bg:(Theme.dark Theme.Bg_surface) ())
+              ~padding:(spacing_xy ~x:2 ~y:0) ~bg:(theme_color Theme.Bg_surface) ())
         [
           Components.row ~gap:2
             (List.map (fun tab -> tab_node (tab = active_tab) tab) tab_order);
         ];
       Components.panel panel.title ~tone:(tab_tone active_tab)
+        ~design:terminal_console_design
         ~style:
           Style.(
             make ~flex_grow:1. ~flex_shrink:1. ~min_height:(Cells 0)
-              ~bg:(Theme.dark Theme.Bg_surface) ())
+              ~bg:(theme_color Theme.Bg_surface) ())
         [
           Components.scroll_box
             ~style:
               Style.(
                 make ~flex_grow:1. ~flex_shrink:1. ~min_height:(Cells 0)
-                  ~flex_direction:Column ~bg:(Theme.dark Theme.Bg_surface) ())
+                  ~flex_direction:Column ~bg:(theme_color Theme.Bg_surface) ())
             (if model.interaction.active_tab = Logs then log_line_nodes panel.lines
              else content_line_nodes panel.lines);
         ];
@@ -1457,8 +1508,8 @@ let view model =
     ~style:
       Style.(
         make ~width:(Percent 1.) ~height:(Percent 1.) ~flex_direction:Column
-          ~padding:(spacing_xy ~x:1 ~y:0) ~gap:1 ~bg:(Theme.dark Theme.Bg_base)
-          ~fg:(Theme.dark Theme.Fg_default) ())
+          ~padding:(spacing_xy ~x:1 ~y:0) ~gap:1 ~bg:(theme_color Theme.Bg_base)
+          ~fg:(theme_color Theme.Fg_default) ())
     children
 
 let init runtime () = (initial_model ~logs:runtime.initial_logs runtime.initial_state, ())

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -4823,6 +4823,45 @@ let test_terminal_console_tui_project_title_and_tabs () =
   Alcotest.(check string) "tabs" "Queue | Logs | Tasks | Readiness | Needs attention" rendered.Shell.tabs;
   check_line_absent "subheading does not repeat active tab" [ rendered.Shell.subheading ] "tab "
 
+let test_terminal_console_tui_uses_cursor_design_theme () =
+  let module Shell = Symphony_terminal_console_shell.Terminal_console_tui in
+  let module Color = Tui.Color in
+  let module Theme = Tui.Theme in
+  let check_slot label slot expected =
+    Alcotest.(check bool) label true (Shell.terminal_console_theme slot = expected)
+  in
+  check_slot "cursor dark canvas" Theme.Bg_base (Color.rgb 22 21 18);
+  check_slot "cursor dark canvas soft" Theme.Bg_surface (Color.rgb 30 29 25);
+  check_slot "cursor dark surface card" Theme.Bg_overlay (Color.rgb 38 37 32);
+  check_slot "cursor dark ink" Theme.Fg_emphasis (Color.rgb 247 247 244);
+  check_slot "cursor dark body" Theme.Fg_default (Color.rgb 214 211 202);
+  check_slot "cursor orange" Theme.Accent_primary (Color.rgb 245 78 0);
+  check_slot "cursor dark semantic success" Theme.Status_success (Color.rgb 88 181 142);
+  check_slot "cursor dark semantic error" Theme.Status_error (Color.rgb 232 83 118);
+  let timeline_pastels =
+    [
+      Color.rgb 223 168 143;
+      Color.rgb 159 201 162;
+      Color.rgb 159 187 224;
+      Color.rgb 192 168 221;
+      Color.rgb 192 133 50;
+    ]
+  in
+  let check_not_timeline label color =
+    Alcotest.(check bool) label false (List.exists (fun pastel -> pastel = color) timeline_pastels)
+  in
+  [
+    ("accent is not a timeline pastel", Shell.terminal_console_theme Theme.Accent_primary);
+    ("info is not a timeline pastel", Shell.terminal_console_theme Theme.Status_info);
+    ("warning is not a timeline pastel", Shell.terminal_console_theme Theme.Status_warning);
+    ("success is not a timeline pastel", Shell.terminal_console_theme Theme.Status_success);
+    ("error is not a timeline pastel", Shell.terminal_console_theme Theme.Status_error);
+  ]
+  |> List.iter (fun (label, color) -> check_not_timeline label color);
+  let root = Shell.view (Shell.initial_model (Runtime_state.empty ())) in
+  Alcotest.(check bool) "root uses cursor dark canvas" true
+    ((root.Tui.Node.style).Tui.Style.bg = Some (Shell.terminal_console_theme Theme.Bg_base))
+
 let terminal_console_queue_fixture () =
   {
     Runtime_state.entries =
@@ -5193,7 +5232,10 @@ let test_terminal_console_tui_minimum_size_message () =
   check_line_contains "minimum message" lines "Terminal Console needs at least 80 columns x 24 rows.";
   check_line_contains "current size" lines "Current size: 72 columns x 20 rows.";
   check_line_contains "resize help" lines "Resize the terminal to continue.";
-  ignore (Shell.view (Shell.initial_model ~terminal_size:small (Runtime_state.empty ())))
+  let model = Shell.initial_model ~terminal_size:small (Runtime_state.empty ()) in
+  let active_panel = Shell.active_panel (Shell.render_model model) model.Shell.interaction in
+  Alcotest.(check string) "active minimum panel" "Minimum Size" active_panel.Shell.title;
+  ignore (Shell.view model)
 
 let terminal_console_interaction_state () =
   let running_issue, running = terminal_console_running_row ~identifier:"#30" ~title:"Running task" "I30" in
@@ -14740,6 +14782,8 @@ let () =
             test_terminal_console_tui_initial_model_uses_projection;
           Alcotest.test_case "renders project title and primary tabs" `Quick
             test_terminal_console_tui_project_title_and_tabs;
+          Alcotest.test_case "uses Cursor design theme for Terminal Console" `Quick
+            test_terminal_console_tui_uses_cursor_design_theme;
           Alcotest.test_case "renders Tasks Home panel" `Quick
             test_terminal_console_tui_active_home_panel;
           Alcotest.test_case "renders readiness remediation panel" `Quick

--- a/apps/tui/lib/components/component_badge.re
+++ b/apps/tui/lib/components/component_badge.re
@@ -8,6 +8,7 @@ let make =
     ) => {
   let design = Component_design.resolve_design(design);
   let fg = Component_design.color_of_tone(~design, tone);
+  let bg = Component_design.theme_color(design, Theme.Bg_selection);
   Node.box(
     ~id?,
     ~style=
@@ -17,6 +18,7 @@ let make =
             ~height=Cells(1),
             ~padding=spacing_xy(~x=1, ~y=0),
             ~fg,
+            ~bg,
             ~attrs=[Attr.Bold],
             (),
           ),
@@ -24,6 +26,6 @@ let make =
         margin: style.margin,
         width: style.width,
       },
-    [Node.text(~style=Style.(make(~fg, ~attrs=[Attr.Bold], ())), label)],
+    [Node.text(~style=Style.(make(~fg, ~bg, ~attrs=[Attr.Bold], ())), label)],
   );
 };

--- a/apps/tui/lib/render.re
+++ b/apps/tui/lib/render.re
@@ -200,18 +200,39 @@
     | Some(_) => Surface.fill_rect(~clip, surface, rect, ~style)
     };
 
-  let render_text = (surface, clip, rect: Geometry.rect, spans) => {
+  let inherit_text_style = (parent: Style.t, child: Style.t) => {
+    let fg =
+      switch (child.Style.fg) {
+      | Some(_) => child.fg
+      | None => parent.fg
+      };
+    let bg =
+      switch (child.Style.bg) {
+      | Some(_) => child.bg
+      | None => parent.bg
+      };
+    let attrs =
+      List.fold_left(
+        (attrs, attr) => Attr.add(attr, attrs),
+        parent.attrs,
+        child.attrs,
+      );
+    Style.{...child, fg, bg, attrs};
+  };
+
+  let render_text = (surface, clip, rect: Geometry.rect, node_style, spans) => {
     let x = ref(rect.Geometry.x);
     let y = ref(rect.y);
     List.iter(
       span => {
+        let style = inherit_text_style(node_style, span.Span.style);
         let (nx, ny) =
           Surface.write(
             ~clip,
             surface,
             ~x=x^,
             ~y=y^,
-            ~style=span.Span.style,
+            ~style,
             span.text,
           );
         x := nx;
@@ -421,7 +442,13 @@
     draw_border(surface, positioned.clip, positioned.rect, node.style);
     switch (node.kind) {
     | Text(spans) =>
-      render_text(surface, positioned.clip, positioned.content, spans)
+      render_text(
+        surface,
+        positioned.clip,
+        positioned.content,
+        node.style,
+        spans,
+      )
     | Vertical_rule(char) =>
       render_vertical_rule(
         surface,

--- a/apps/tui/test/test_tui.re
+++ b/apps/tui/test/test_tui.re
@@ -59,6 +59,41 @@ let flex_row_layout = () => {
   );
 };
 
+let rich_text_inherits_node_paint = () => {
+  let root =
+    rich_text(
+      ~style=
+        Style.(make(~fg=Color.ansi(1), ~bg=Color.ansi(2), ~attrs=[Attr.Bold], ())),
+      [Span.make(~style=Style.(make(~fg=Color.ansi(3), ~attrs=[Attr.Underline], ())), "X")],
+    );
+  let renderer = Renderer.create(~width=2, ~height=1, root);
+  let surface = Renderer.request_render(renderer);
+  switch (Surface.get(surface, ~x=0, ~y=0)) {
+  | Some(cell) =>
+    Alcotest.(check(bool))(
+      "span keeps explicit fg",
+      true,
+      cell.Surface.style.Style.fg == Some(Color.ansi(3)),
+    );
+    Alcotest.(check(bool))(
+      "span inherits node bg",
+      true,
+      cell.style.bg == Some(Color.ansi(2)),
+    );
+    Alcotest.(check(bool))(
+      "span inherits parent attrs",
+      true,
+      Attr.mem(Attr.Bold, cell.style.attrs),
+    );
+    Alcotest.(check(bool))(
+      "span keeps child attrs",
+      true,
+      Attr.mem(Attr.Underline, cell.style.attrs),
+    )
+  | None => Alcotest.fail("missing rendered cell")
+  };
+};
+
 let input_editing = () => {
   let field = input(~id="field", ~value="ab", ());
   let renderer = Renderer.create(~width=8, ~height=1, field);
@@ -496,8 +531,24 @@ let component_design_injects_theme = () => {
       "uses custom success color",
       true,
       node.style.fg == Some(Color.ansi(12)),
+    );
+    Alcotest.(check(bool))(
+      "uses custom badge background",
+      true,
+      node.style.bg == Some(Color.ansi(7)),
     )
   | None => Alcotest.fail("badge not found")
+  };
+  let surface = Renderer.request_render(Renderer.create(~width=4, ~height=1, root));
+  switch (Surface.get(surface, ~x=1, ~y=0)) {
+  | Some(cell) =>
+    Alcotest.(check(string))("badge label cell", "o", cell.Surface.text);
+    Alcotest.(check(bool))(
+      "rendered badge label background",
+      true,
+      cell.style.bg == Some(Color.ansi(7)),
+    )
+  | None => Alcotest.fail("badge label cell not rendered")
   };
   let light_design = Components.make_design(~theme=Theme.light, ());
   let light =
@@ -727,6 +778,11 @@ let () =
         [
           Alcotest.test_case("plain snapshot", `Quick, plain_snapshot),
           Alcotest.test_case("flex row", `Quick, flex_row_layout),
+          Alcotest.test_case(
+            "rich text inherits node paint",
+            `Quick,
+            rich_text_inherits_node_paint,
+          ),
         ],
       ),
       (


### PR DESCRIPTION
## Summary

- Apply the Cursor dark theme to the backend Terminal Console instead of the light cream marketing palette.
- Add text paint inheritance so rich text spans render consistently against themed node backgrounds.
- Keep Cursor timeline pastels scoped away from global status, navigation, and terminal state colors.

## Why

The first pass mapped the Cursor design tokens too literally and produced a light Terminal Console with unreadable dark-background fragments. This change makes the terminal surface match the requested Cursor dark direction while preserving the design doc's constraint that timeline pastels are only for actual agent/timeline markers.

## Validation

- `rtk pnpm --filter @symphony-orchestrator/tui test`
- `rtk pnpm --filter @symphony-orchestrator/tui build`
- `rtk pnpm backend:build`
- `rtk pnpm test`
- `rtk git diff --check`