### PR TITLE
Add JSX TUI support planning artifacts

### DIFF
--- a/.compozy/tasks/tui-jsx-api/_idea.md
+++ b/.compozy/tasks/tui-jsx-api/_idea.md
@@ -1,0 +1,77 @@
+# TUI JSX API Idea
+
+## Overview
+
+Build a public Reason-native JSX authoring kit for `symphony-orchestrator-tui`. The kit should make terminal UI code easier to read, review, copy, and extend by letting users express TUI trees with JSX-style component composition while preserving the existing `Tui.Node.t` renderer and component model.
+
+V1 should serve external Reason/OCaml developers evaluating the standalone TUI package and internal Symphony contributors building Terminal Console surfaces. Internal Symphony examples are the proving ground, but the output should be public-package quality.
+
+## Problem
+
+Current TUI code composes nested lists of `Tui.Components`, `Tui.Patterns`, and node helpers. This is explicit and type-safe, but large screens become visually dense. Contributors reviewing layout changes must mentally reconstruct the tree from nested function calls.
+
+External adoption has a similar problem. Developers familiar with ReasonReact, Ink, or OpenTUI expect component-shaped UI examples. If the first package experience looks unlike familiar component composition, the package has to overcome avoidable friction before users even evaluate rendering, layout, or widgets.
+
+### Market Data
+
+Reason JSX is library-agnostic and compiles to normal function calls, so Symphony can use JSX without adopting React runtime semantics: [Reason JSX](https://reasonml.github.io/docs/en/jsx). ReasonReact demonstrates the typed component/children model users will expect: [ReasonReact JSX](https://reasonml.github.io/reason-react/docs/en/jsx). Ink and OpenTUI validate JSX/component models for terminal apps: [Ink](https://github.com/vadimdemedes/ink), [OpenTUI React bindings](https://opentui.com/docs/bindings/react/). Stack Overflow's 2025 survey reports broad JavaScript/TypeScript/React usage, supporting JSX familiarity as an adoption lever: [survey](https://survey.stackoverflow.co/2025/technology).
+
+## Core Features
+
+| # | Feature | Priority | Description |
+| --- | --- | --- | --- |
+| F1 | JSX Authoring Surface | Critical | Provide typed JSX-compatible components that render to existing `Tui.Node.t` values. |
+| F2 | Public Component Subset | Critical | Cover the first useful subset: text, box/layout, panel, row/column, input/select, badge, table/status data, and app shell primitives. |
+| F3 | Internal Proving Screen | High | Recreate one representative existing TUI screen or example using JSX and compare readability against the current call style. |
+| F4 | External Examples | High | Add public examples showing basic, dashboard, and agent/workflow UI composition. |
+| F5 | Documentation Path | High | Explain when to use JSX vs direct components, with Reason JSX caveats and no React-runtime assumptions. |
+| F6 | Equivalence Tests | High | Prove JSX-authored trees preserve rendering behavior for supported primitives. |
+
+## KPIs
+
+| KPI | Target | How to Measure |
+| --- | --- | --- |
+| Layout readability | Reduce representative screen layout LOC by >= 20% | Compare existing example/screen against JSX version. |
+| Rendering parity | 100% snapshot parity for equivalent supported examples | Add focused TUI tests comparing rendered output. |
+| First-run adoption | New JSX example runnable in < 5 minutes | Follow README from clean package setup. |
+| API containment | 0 JSX-only renderer semantics | Review supported JSX components against existing `Tui.Node.t`/Components behavior. |
+| Documentation coverage | >= 3 public examples documented | README and examples index include JSX usage path. |
+
+## Feature Assessment
+
+| Criteria | Question | Score |
+| --- | --- | --- |
+| **Impact** | How much more valuable does this make the product? | Strong |
+| **Reach** | What % of users would this affect? | Strong |
+| **Frequency** | How often would users encounter this value? | Strong |
+| **Differentiation** | Does this set us apart or just match competitors? | Strong |
+| **Defensibility** | Is this easy to copy or does it compound over time? | Maybe |
+| **Feasibility** | Can we actually build this? | Strong |
+
+Leverage type: Strategic Bet.
+
+## Council Insights
+
+- **Recommended approach:** Use JSX as an authoring layer over the existing TUI model; do not create a second renderer or runtime.
+- **Key trade-offs:** Bigger public scope improves adoption but raises API drift and documentation risks.
+- **Risks identified:** Dual idioms, JSX-only semantics, curated-demo bias, and overbuilding V1.
+- **Stretch goal (V2+):** Make JSX the recommended authoring path for new Reason TUI screens once V1 proves parity and readability.
+
+## Out of Scope (V1)
+
+- **React runtime compatibility** - V1 uses Reason JSX semantics, not React rendering.
+- **Full Terminal Console migration** - one internal proving screen is enough for V1.
+- **Every existing component/pattern** - V1 should support a small public subset first.
+- **State management framework** - input/focus behavior should reuse existing renderer semantics.
+- **Breaking direct component calls** - existing `Tui.Components` and `Tui.Patterns` remain supported.
+
+## Architecture Decision Records
+
+- [ADR-001: Constrain JSX TUI V1 To An Existing Node Authoring Layer](adrs/adr-001.md) - Superseded conservative council recommendation.
+- [ADR-002: Adopt Public JSX Kit Scope](adrs/adr-002.md) - Accepted public JSX kit direction.
+
+## Open Questions
+
+- Which exact internal screen should be the proving screen: `demo`, `agent_workspace`, or Terminal Console view?
+- Should JSX become the recommended path immediately, or remain experimental until parity/readability gates pass?
+- What is the minimum public component subset needed for a credible first release?

--- a/.compozy/tasks/tui-jsx-api/_prd.md
+++ b/.compozy/tasks/tui-jsx-api/_prd.md
@@ -1,0 +1,104 @@
+# TUI JSX API PRD
+
+## Overview
+
+Build an adoption-ready JSX authoring kit for `symphony-orchestrator-tui`. The feature gives Reason/OCaml developers a familiar, tree-shaped way to build standalone terminal tools while keeping direct component calls available as the lower-level API.
+
+The primary product outcome is external adoption. A new package evaluator should be able to land on the TUI docs, understand that JSX is the recommended path for new screens, and build a small standalone terminal UI without reading Symphony-specific source code first.
+
+## Goals
+
+- Make JSX the recommended authoring path for new TUI screens.
+- Help a new user build a small standalone TUI from docs in under 30 minutes.
+- Provide public examples that make the package easier to evaluate without reading internal Symphony code.
+- Preserve current TUI behavior for existing users.
+
+## User Stories
+
+- As a Reason/OCaml developer, I want JSX-style TUI examples so I can quickly understand how to compose screens.
+- As a package evaluator, I want a clear recommended path so I can decide whether the library fits my project.
+- As an existing TUI user, I want direct component calls to remain supported so my current code keeps working.
+- As a maintainer, I want docs and examples that reduce repeated onboarding explanation.
+
+## Core Features
+
+1. **Recommended JSX Authoring Path**: Public docs present JSX as the default for new TUI screens.
+2. **Standalone Quickstart**: A short path from install to a working terminal screen.
+3. **Public JSX Examples**: At least three runnable examples covering basic layout, dashboard/status UI, and workflow-oriented UI.
+4. **Migration Guidance**: Explain how existing direct component-call examples map to JSX.
+5. **Supported Surface Guide**: Make clear which components are ready for JSX use in V1.
+6. **Compatibility Messaging**: State that direct components remain supported as the lower-level API.
+
+## User Experience
+
+A new user lands on the TUI README, sees JSX as the recommended path, runs a quickstart, and gets a small terminal UI working without understanding Symphony internals. They can then open examples that match common standalone terminal-tool needs: simple layout, status/dashboard display, and command-center style workflow UI.
+
+Existing users should not feel forced into migration. The docs should frame JSX as the recommended path for new screens and direct components as stable lower-level primitives.
+
+## High-Level Technical Constraints
+
+- The JSX kit must preserve existing TUI rendering behavior from a user perspective.
+- The package must remain useful to standalone Reason/OCaml users, not only Symphony contributors.
+- JSX docs must not imply React runtime compatibility.
+- Existing direct component-call usage remains supported.
+
+## Non-Goals (Out of Scope)
+
+- Full Terminal Console migration.
+- React runtime compatibility.
+- Covering every TUI component or pattern in V1.
+- A new state-management model.
+- Deprecating direct `Tui.Components` or `Tui.Patterns` usage.
+
+## Phased Rollout Plan
+
+### MVP (Phase 1)
+
+- Publish JSX quickstart, supported surface guide, migration notes, and 2-3 runnable examples.
+- Success: a new user can build a small standalone TUI from docs in under 30 minutes.
+
+### Phase 2
+
+- Expand examples based on V1 gaps and user feedback.
+- Success: common standalone terminal-tool layouts no longer require reading lower-level examples first.
+
+### Phase 3
+
+- Consider positioning JSX as the main authoring story across all new public examples.
+- Success: docs, examples, and maintainer guidance consistently point new users to JSX first.
+
+## Success Metrics
+
+- New-user quickstart completion: under 30 minutes.
+- Public example coverage: at least 3 JSX examples.
+- Documentation coverage: quickstart, supported surface, migration guidance, compatibility notes.
+- Adoption clarity: README names JSX as the recommended path for new TUI screens.
+- Compatibility confidence: direct component-call path remains documented and supported.
+
+## Risks and Mitigations
+
+- **Risk: users think direct components are deprecated.** Mitigation: explicitly document them as stable lower-level primitives.
+- **Risk: JSX default feels overpromised if V1 surface is too small.** Mitigation: publish a clear supported surface guide.
+- **Risk: examples look polished but do not help real users build.** Mitigation: anchor success on the 30-minute standalone build path.
+- **Risk: external docs drift toward Symphony-specific terminology.** Mitigation: write examples for standalone terminal tools first.
+
+## Architecture Decision Records
+
+- [ADR-001: Constrain JSX TUI V1 To An Existing Node Authoring Layer](adrs/adr-001.md) - Superseded conservative scope.
+- [ADR-002: Adopt Public JSX Kit Scope](adrs/adr-002.md) - Accepted public JSX kit direction.
+- [ADR-003: Select Adoption-Ready Public JSX Kit Approach](adrs/adr-003.md) - Accepted external-adoption-first PRD approach.
+
+## Open Questions
+
+- Final supported JSX component set for V1.
+- Exact three public examples to include.
+- Whether migration guidance should include before-and-after snippets for every supported component.
+
+## Research Sources
+
+- [Reason JSX](https://reasonml.github.io/docs/en/jsx)
+- [ReasonReact JSX](https://reasonml.github.io/reason-react/docs/en/jsx)
+- [OpenTUI React bindings](https://opentui.com/docs/bindings/react/)
+- [Ink](https://github.com/vadimdemedes/ink)
+- [Stack Overflow Developer Survey 2025](https://survey.stackoverflow.co/2025/technology)
+- [GitHub Octoverse 2025](https://github.blog/news-insights/octoverse/octoverse-a-new-developer-joins-github-every-second-as-ai-leads-typescript-to-1/)

--- a/.compozy/tasks/tui-jsx-api/_tasks.md
+++ b/.compozy/tasks/tui-jsx-api/_tasks.md
@@ -1,0 +1,12 @@
+# TUI JSX API — Task List
+
+## Tasks
+
+| # | Title | Status | Complexity | Dependencies |
+|---|-------|--------|------------|--------------|
+| 01 | Add `Tui.Jsx` Namespace And Core Wrapper Conventions | pending | medium | — |
+| 02 | Add JSX Wrappers For Existing Components | pending | high | task_01 |
+| 03 | Add JSX Wrappers For Existing Patterns | pending | high | task_01, task_02 |
+| 04 | Add JSX `agent_workspace` Parity Example | pending | medium | task_02, task_03 |
+| 05 | Document JSX Quickstart, Supported Surface, And Migration Path | pending | medium | task_02, task_03, task_04 |
+| 06 | Finalize TUI Package Verification And Bundle Readiness | pending | low | task_01, task_02, task_03, task_04, task_05 |

--- a/.compozy/tasks/tui-jsx-api/_techspec.md
+++ b/.compozy/tasks/tui-jsx-api/_techspec.md
@@ -1,0 +1,138 @@
+# TUI JSX API TechSpec
+
+## Executive Summary
+
+Implement the TUI JSX API as public Reason wrapper modules over existing `Tui.Components` and `Tui.Patterns`. The wrappers expose JSX-friendly `make` functions, require explicit text nodes, return `Tui.Node.t`, and preserve direct component calls as the lower-level API.
+
+Primary trade-off: broad V1 wrapper coverage improves external adoption but increases parity and documentation work. The design keeps risk contained by avoiding a second renderer, separate component tree, or implicit string-child conversion.
+
+## System Architecture
+
+### Component Overview
+
+- **Tui.Jsx**: Public module namespace for JSX authoring wrappers.
+- **JSX wrapper modules**: Thin wrappers around existing `Components` and `Patterns`.
+- **Existing TUI model**: `Tui.Node.t` remains the only rendered tree shape.
+- **Examples**: Add JSX examples, with `agent_workspace` as the first parity target.
+- **Docs**: Update README and examples index to present JSX as the recommended path for new screens.
+
+## Implementation Design
+
+### Core Interfaces
+
+Reason implementation shape:
+
+```reason
+module Text = {
+  let make = (~id=?, ~style=Style.default, ~value) =>
+    Components.text(~id?, ~style, value);
+};
+
+module Box = {
+  let make = (~id=?, ~style=Style.default, ~children) =>
+    Components.box(~id?, ~style, children);
+};
+```
+
+Required contract sketch for task planning:
+
+```go
+type JSXComponent interface {
+    Render(children []TuiNode) TuiNode
+}
+
+type TuiNode struct {
+    ID       string
+    Kind     string
+    Children []TuiNode
+}
+```
+
+### Data Models
+
+- No new persisted data model.
+- `Tui.Node.t` remains the only runtime tree model.
+- JSX children are typed lists of `Tui.Node.t`.
+- Text content is explicit through text-node wrappers, not implicit string children.
+
+### API Endpoints
+
+None. This is a package authoring surface, not a server feature.
+
+## Integration Points
+
+No external service integration. The only integration boundary is the existing public `symphony-orchestrator-tui` package export surface.
+
+## Impact Analysis
+
+| Component | Impact Type | Description and Risk | Required Action |
+| --- | --- | --- | --- |
+| `apps/tui/lib/tui.re` | Modified | Exports the JSX namespace. Medium risk if public API names collide. | Add `Jsx` module export carefully. |
+| `apps/tui/lib/components/*` | Referenced | Existing behavior is the semantic source of truth. Low risk if wrappers stay thin. | Do not alter component semantics for JSX. |
+| `apps/tui/lib/patterns.re` | Referenced | Most patterns get JSX wrappers, excluding edge-case presets. Medium coverage risk. | Prioritize patterns used by `agent_workspace`. |
+| `apps/tui/examples/agent_workspace.ml` | Modified or paired | First parity target. Medium risk if example behavior drifts. | Add JSX version and compare rendered output. |
+| `apps/tui/README.md` | Modified | Main external adoption path. | Add quickstart, supported surface, and compatibility guidance. |
+| `apps/tui/test/test_tui.re` | Modified | Parity and wrapper coverage tests. | Add focused JSX tests. |
+
+## Testing Approach
+
+### Unit Tests
+
+- Verify wrappers return rendered output equivalent to direct components for representative primitives.
+- Cover explicit text-node behavior.
+- Cover most supported `Components` and `Patterns` wrappers enough to prevent drift.
+
+### Integration Tests
+
+- Render the JSX `agent_workspace` example and compare against the direct-call target.
+- Run package-level TUI tests through `pnpm --filter @symphony-orchestrator/tui test`.
+
+## Development Sequencing
+
+### Build Order
+
+1. Add `Tui.Jsx` namespace and minimal wrapper conventions - no dependencies.
+2. Add core wrappers for text, box, row, column, and panel - depends on step 1.
+3. Add broad wrappers for existing `Components` and `Patterns`, excluding presets - depends on step 2.
+4. Add JSX `agent_workspace` parity example - depends on step 3.
+5. Add focused wrapper and rendered parity tests - depends on steps 3 and 4.
+6. Update README, examples index, supported surface guide, and migration notes - depends on steps 3 through 5.
+7. Run TUI package verification - depends on steps 1 through 6.
+
+### Technical Dependencies
+
+- Existing Reason support in the package remains required.
+- No new runtime package should be introduced unless the implementation proves Reason JSX support cannot work with current tooling.
+- Dune/opam package metadata must stay consistent with the public package surface.
+
+## Monitoring and Observability
+
+No runtime monitoring is required. The useful visibility is package-level:
+
+- Test coverage for wrapper parity.
+- Example render stability.
+- Documentation completeness against the 30-minute quickstart goal.
+
+## Technical Considerations
+
+### Key Decisions
+
+- **Wrapper modules over existing components**: preserves `Tui.Node.t` and current renderer behavior.
+- **Explicit text nodes**: avoids hidden string coercion and keeps child typing predictable.
+- **Broad V1 coverage**: supports adoption-ready positioning, with presets excluded to control scope.
+- **`agent_workspace` parity target**: exercises realistic standalone command-center composition.
+- **TUI-only verification**: keeps completion scoped to the changed package.
+
+### Known Risks
+
+- Wrapper drift from direct components. Mitigation: parity tests and thin delegation.
+- Broad coverage delays delivery. Mitigation: prioritize wrappers needed for `agent_workspace`.
+- User confusion around explicit text nodes. Mitigation: quickstart explains the rule early.
+- Public API naming collisions. Mitigation: isolate wrappers under `Tui.Jsx`.
+
+## Architecture Decision Records
+
+- [ADR-001: Constrain JSX TUI V1 To An Existing Node Authoring Layer](adrs/adr-001.md) - Superseded conservative scope.
+- [ADR-002: Adopt Public JSX Kit Scope](adrs/adr-002.md) - Accepted public JSX kit direction.
+- [ADR-003: Select Adoption-Ready Public JSX Kit Approach](adrs/adr-003.md) - Accepted external-adoption-first PRD approach.
+- [ADR-004: Implement JSX As Wrapper Modules Over Existing TUI Components](adrs/adr-004.md) - Accepted technical wrapper-module architecture.

--- a/.compozy/tasks/tui-jsx-api/adrs/adr-001.md
+++ b/.compozy/tasks/tui-jsx-api/adrs/adr-001.md
@@ -1,0 +1,116 @@
+# ADR-001: Constrain JSX TUI V1 To An Existing Node Authoring Layer
+
+## Status
+
+Superseded by ADR-002
+
+## Date
+
+2026-05-20
+
+## Context
+
+Symphony TUI currently exposes a declarative component tree through `Tui.Node.t`,
+`Tui.Components`, `Tui.Patterns`, and related helpers. This works, but nested
+component-call lists become harder to scan in representative screens and examples.
+The user wants JSX-style code for using the TUI library, with the V1 goal focused
+on readability and adoption for both internal Symphony contributors and external
+Reason/OCaml developers.
+
+Reason JSX is a language-level syntax transform that can lower into ordinary
+function calls with typed labeled arguments and children handling. That makes it
+possible to validate JSX authoring without adopting React as a runtime or changing
+the renderer.
+
+## Decision
+
+V1 will treat JSX as a minimal authoring layer over the existing TUI node and
+component model. The proof should express one representative TUI screen or example
+in JSX-style Reason code and preserve the existing rendering behavior.
+
+V1 must not introduce an independent component model, divergent rendering
+semantics, or a broad public framework surface. The experiment should be framed as
+a readability and adoption validation path with explicit success criteria before
+it becomes the default style for the package.
+
+## Alternatives Considered
+
+### Alternative 1: Full JSX DSL Platform
+
+- **Description**: Build a broad JSX component framework for the TUI package with
+  extensive primitives, docs, examples, and migration guidance.
+- **Pros**: Stronger external positioning and clearer long-term adoption story if
+  successful.
+- **Cons**: Larger design surface, higher maintenance cost, and greater risk of
+  drifting from existing `Tui.Node.t`, `Components`, and `Patterns` semantics.
+- **Why rejected**: Too broad for the current validation goal. It would commit to
+  a framework before proving that JSX materially improves TUI authoring.
+
+### Alternative 2: Example-Only JSX Experiment
+
+- **Description**: Add one local JSX-authored example without any reusable package
+  layer or public API shape.
+- **Pros**: Lowest blast radius and easiest rollback.
+- **Cons**: Weak adoption signal because users cannot see a stable authoring path
+  they could reuse.
+- **Why rejected**: Useful as a spike, but too narrow for an idea intended to feed
+  a PRD. V1 needs at least enough reusable surface to express one real screen.
+
+### Alternative 3: Preserve Existing Component Calls Only
+
+- **Description**: Improve docs and examples while keeping the current nested
+  function-call style.
+- **Pros**: No new syntax surface and no migration risk.
+- **Cons**: Does not address the readability or adoption problem identified by the
+  user.
+- **Why rejected**: It avoids the core opportunity and leaves the TUI package less
+  approachable for developers familiar with JSX-style composition.
+
+## Consequences
+
+### Positive
+
+- Keeps the renderer, layout, widgets, tests, and package boundary centered on the
+  existing TUI model.
+- Produces a concrete readability comparison against current nested component-call
+  examples.
+- Creates an adoption story for Reason/React-adjacent developers without pulling
+  in React runtime semantics.
+
+### Negative
+
+- Introduces a second authoring style unless the experiment is clearly labeled and
+  bounded.
+- Requires documentation discipline so contributors know when JSX is supported and
+  when canonical component calls remain the source of truth.
+- May need follow-up design work if children, text conversion, or prop naming feel
+  awkward in real code.
+
+### Risks
+
+- **API drift**: JSX props or defaults could diverge from `Components` and
+  `Patterns`. Mitigation: require semantic equivalence for the V1 proof and avoid
+  JSX-only behavior.
+- **Premature adoption**: Contributors may cargo-cult one JSX example before the
+  experiment is evaluated. Mitigation: document V1 as experimental until success
+  criteria are met.
+- **False positive**: The first example may look better because it is curated, not
+  because JSX scales. Mitigation: compare against a representative existing screen
+  with clear readability and maintenance criteria.
+
+## Implementation Notes
+
+- Prefer one representative TUI example or screen as the proof, not a broad
+  Terminal Console migration.
+- Preserve `Tui.Node.t` as the rendered output shape.
+- Keep package boundaries intact: reusable TUI authoring belongs under `apps/tui`,
+  while product-specific Terminal Console wiring remains under `apps/backend`.
+- Future PRD and tech spec work should define measurable readability, rendering,
+  and documentation gates before expanding the JSX surface.
+
+## References
+
+- https://reasonml.github.io/docs/en/jsx
+- https://reasonml.github.io/reason-react/docs/en/jsx
+- https://github.com/vadimdemedes/ink
+- https://opentui.com/docs/bindings/react/

--- a/.compozy/tasks/tui-jsx-api/adrs/adr-002.md
+++ b/.compozy/tasks/tui-jsx-api/adrs/adr-002.md
@@ -1,0 +1,103 @@
+# ADR-002: Adopt Public JSX Kit Scope
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-20
+
+## Context
+
+The council recommended a minimal JSX authoring experiment over the existing
+`Tui.Node.t` and `Tui.Components` model. The opportunity scan then compared that
+constrained MVP against a more ambitious public Reason-native JSX terminal UI kit.
+The user selected the more ambitious direction.
+
+The product rationale is that external adoption needs more than a private proof:
+the package should present a coherent public authoring story for Reason/OCaml
+developers who expect JSX-style component composition from ReasonReact, Ink, or
+OpenTUI-like tools.
+
+## Decision
+
+V1 will target a public Reason-native JSX kit for `symphony-orchestrator-tui`.
+It should include a typed JSX authoring surface, public documentation, at least
+one internal proving screen or example, and enough examples for external users to
+understand the idiomatic path.
+
+The implementation still must preserve the existing renderer and node model.
+JSX is an authoring kit over `Tui.Node.t`, `Tui.Components`, and `Tui.Patterns`,
+not a new runtime.
+
+## Alternatives Considered
+
+### Alternative 1: Constrained Internal JSX MVP
+
+- **Description**: Add just enough JSX support to express one representative TUI
+  screen clearly.
+- **Pros**: Lower risk, fast feedback, easier rollback.
+- **Cons**: Weak external adoption signal and limited public positioning.
+- **Why rejected**: The user selected a broader adoption-focused public kit after
+  reviewing the opportunity scan.
+
+### Alternative 2: Example-Only JSX Spike
+
+- **Description**: Add one JSX-authored example without reusable public API.
+- **Pros**: Lowest cost and smallest blast radius.
+- **Cons**: Does not create a reusable authoring path or meaningful package-level
+  adoption story.
+- **Why rejected**: Too narrow for the product goal.
+
+### Alternative 3: Documentation-Only Authoring Cleanup
+
+- **Description**: Improve existing component-call examples without JSX.
+- **Pros**: No new API surface.
+- **Cons**: Does not address the JSX readability and adoption opportunity.
+- **Why rejected**: It avoids the user-selected direction.
+
+## Consequences
+
+### Positive
+
+- Gives external users a coherent, familiar way to evaluate the TUI package.
+- Creates stronger differentiation: Reason-native JSX for terminal workflow UIs.
+- Makes internal Symphony screens a credible proving ground for package adoption.
+
+### Negative
+
+- Larger V1 scope than the council's conservative recommendation.
+- Requires stronger documentation and API discipline from the start.
+- Increases maintenance risk if JSX authoring diverges from canonical component
+  behavior.
+
+### Risks
+
+- **Semantic drift**: JSX props or children behavior could become a second UI
+  model. Mitigation: keep `Tui.Node.t` as the output shape and test equivalence
+  against existing component behavior.
+- **Overbuilt V1**: Public kit scope could delay the first usable result.
+  Mitigation: require one internal proving screen and a small fixed component
+  subset before expanding coverage.
+- **Adoption ambiguity**: Users may not know whether JSX or direct components are
+  canonical. Mitigation: document JSX as the recommended authoring layer for new
+  Reason screens while preserving direct components as the lower-level API.
+
+## Implementation Notes
+
+- Public examples should show layout, text, panels, inputs/selects, status/data
+  display, and at least one larger terminal screen.
+- The kit should avoid React runtime assumptions and lean on Reason JSX semantics.
+- Existing component calls remain supported and should remain the semantic source
+  of truth.
+- The future PRD should define the first supported component subset and the
+  minimum documentation required for external users.
+
+## References
+
+- ADR-001: Constrain JSX TUI V1 To An Existing Node Authoring Layer
+- https://reasonml.github.io/docs/en/jsx
+- https://reasonml.github.io/reason-react/docs/en/jsx
+- https://github.com/vadimdemedes/ink
+- https://opentui.com/docs/bindings/react/

--- a/.compozy/tasks/tui-jsx-api/adrs/adr-003.md
+++ b/.compozy/tasks/tui-jsx-api/adrs/adr-003.md
@@ -1,0 +1,91 @@
+# ADR-003: Select Adoption-Ready Public JSX Kit Approach
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-20
+
+## Context
+
+The PRD clarification round set external adoption as the primary outcome for the
+TUI JSX API. The target audience is Reason/OCaml library users building
+standalone terminal tools. The V1 surface should be adoption-ready, not a private
+spike: public documentation, runnable examples, migration guidance, and clear
+recommendation that JSX is the default authoring path for new TUI screens.
+
+The success bar is that a new user can build a small standalone TUI from the docs
+in under 30 minutes.
+
+## Decision
+
+The PRD will use the Adoption-Ready Public Kit approach. V1 will position JSX as
+the recommended path for new standalone TUI screens and will require public docs,
+examples, migration guidance, and onboarding success criteria.
+
+Direct `Tui.Components` and `Tui.Patterns` calls remain supported as the lower
+level API, but the product experience should guide new users toward JSX first.
+
+## Alternatives Considered
+
+### Alternative 1: Guided Examples First
+
+- **Description**: Ship several polished JSX examples and keep documentation
+  short.
+- **Pros**: Faster to demonstrate visually and lower documentation effort.
+- **Cons**: Weaker for users trying to build their own screens from first
+  principles.
+- **Why rejected**: The selected primary outcome is external adoption, which needs
+  enough guidance for a new user to succeed without reading source examples as the
+  only tutorial.
+
+### Alternative 2: Conservative Dual-Path Launch
+
+- **Description**: Present JSX as optional alongside direct component calls until
+  more usage evidence exists.
+- **Pros**: Lower messaging risk and less pressure to declare a preferred
+  authoring style early.
+- **Cons**: Creates ambiguity for new users and weakens the adoption-ready
+  package story.
+- **Why rejected**: It conflicts with the selected direction that JSX should be
+  the default path for new TUI screens.
+
+## Consequences
+
+### Positive
+
+- Gives external users a clear first path through the TUI package.
+- Aligns examples, docs, and migration guidance around one recommended authoring
+  experience.
+- Makes the 30-minute standalone TUI success criterion concrete and testable.
+
+### Negative
+
+- Raises the documentation and examples bar for V1.
+- Requires careful wording so existing direct component users do not read the
+  change as a breaking shift.
+- May defer some lower-level component polish while the adoption surface is built.
+
+### Risks
+
+- **Overpromising default status**: Calling JSX the default too early could
+  frustrate users if common widgets are missing. Mitigation: define a clear V1
+  supported component set and document direct components as the escape hatch.
+- **Example bias**: Examples may look polished but fail to support real user
+  workflows. Mitigation: require a small standalone TUI build path in the docs.
+- **Existing user confusion**: Current users may wonder if direct component calls
+  are deprecated. Mitigation: state that direct calls remain supported as the
+  lower-level API.
+
+## Implementation Notes
+
+The PRD should stay product-focused. Technical choices about exact JSX modules,
+child conversion, and test structure belong in the future technical
+specification.
+
+## References
+
+- [ADR-002: Adopt Public JSX Kit Scope](adr-002.md)
+- [TUI JSX API Idea](../_idea.md)

--- a/.compozy/tasks/tui-jsx-api/adrs/adr-004.md
+++ b/.compozy/tasks/tui-jsx-api/adrs/adr-004.md
@@ -1,0 +1,109 @@
+# ADR-004: Implement JSX As Wrapper Modules Over Existing TUI Components
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-20
+
+## Context
+
+The PRD requires an adoption-ready JSX authoring kit for external Reason/OCaml
+users while preserving current TUI behavior. The existing package already exposes
+`Tui.Node.t`, `Tui.Components`, and `Tui.Patterns` as the stable component model.
+Reason JSX can call module `make` functions with labeled props and typed
+children, so the technical choice is where that JSX surface should attach.
+
+The technical clarification round selected these constraints:
+
+- JSX should use wrapper modules over existing `Components` and `Patterns`.
+- JSX should return `Tui.Node.t`.
+- V1 should use explicit text nodes only.
+- V1 should cover most existing `Components` and `Patterns`, excluding edge-case
+  presets.
+- `agent_workspace` should be the first parity target.
+- Verification should remain scoped to the TUI package.
+
+## Decision
+
+Implement JSX as public Reason wrapper modules that delegate to existing
+`Tui.Components` and `Tui.Patterns` functions. These modules will expose
+JSX-friendly `make` functions, accept typed labeled props, use explicit text
+nodes, and return `Tui.Node.t`.
+
+The wrapper layer must not introduce a second renderer, a separate component
+tree, implicit string-child conversion, or JSX-only behavior. Direct component
+calls remain the lower-level API and the semantic source of truth.
+
+## Alternatives Considered
+
+### Alternative 1: JSX-Specific Component Layer
+
+- **Description**: Create a separate JSX component model and translate it into
+  `Tui.Node.t`.
+- **Pros**: More freedom to design a JSX-first API.
+- **Cons**: Creates two component models, increases translation risk, and makes
+  parity with existing behavior harder to reason about.
+- **Why rejected**: The PRD requires behavior preservation and compatibility for
+  existing users.
+
+### Alternative 2: Intrinsic Lowercase Tags Only
+
+- **Description**: Expose only low-level tags such as text, box, row, and column.
+- **Pros**: Smaller surface and lower implementation risk.
+- **Cons**: Too narrow for the adoption-ready public kit selected in ADR-003.
+- **Why rejected**: The user selected broad V1 coverage over most existing
+  `Components` and `Patterns`.
+
+### Alternative 3: Implicit String Children
+
+- **Description**: Convert string children into text nodes inside selected JSX
+  wrappers.
+- **Pros**: More familiar to React users.
+- **Cons**: Adds hidden conversion rules and makes child typing less explicit.
+- **Why rejected**: The technical clarification selected explicit text nodes for
+  V1 to keep semantics predictable.
+
+## Consequences
+
+### Positive
+
+- Preserves the existing TUI model and rendering behavior.
+- Gives new users a JSX-first entrypoint without breaking current component-call
+  usage.
+- Keeps `agent_workspace` parity straightforward because wrappers can map to the
+  existing example structure.
+
+### Negative
+
+- Broad wrapper coverage increases V1 work compared with a minimal core subset.
+- Explicit text nodes are slightly more verbose than React-style string children.
+- Wrapper modules must stay aligned with existing component props as the package
+  evolves.
+
+### Risks
+
+- **Wrapper drift**: JSX wrappers may fall behind existing components. Mitigation:
+  add parity tests and keep wrappers thin.
+- **Overwide V1**: Covering most components and patterns could delay completion.
+  Mitigation: exclude presets and prioritize wrappers used by `agent_workspace`
+  before filling remaining coverage.
+- **Adoption confusion**: Users may not understand why text must be explicit.
+  Mitigation: document the Reason/terminal typing rationale in the quickstart.
+
+## Implementation Notes
+
+- Keep the implementation under `apps/tui` and use Reason source files.
+- Export the JSX surface through the public `Tui` module.
+- Use `agent_workspace` as the first end-to-end JSX example and rendered parity
+  target.
+- Verify with focused TUI tests plus `pnpm --filter @symphony-orchestrator/tui
+  test` and `pnpm --filter @symphony-orchestrator/tui build`.
+
+## References
+
+- [ADR-002: Adopt Public JSX Kit Scope](adr-002.md)
+- [ADR-003: Select Adoption-Ready Public JSX Kit Approach](adr-003.md)
+- [TUI JSX API PRD](../_prd.md)

--- a/.compozy/tasks/tui-jsx-api/task_01.md
+++ b/.compozy/tasks/tui-jsx-api/task_01.md
@@ -1,0 +1,79 @@
+---
+status: pending
+title: "Add `Tui.Jsx` Namespace And Core Wrapper Conventions"
+type: backend
+complexity: medium
+dependencies: []
+---
+
+# Task 01: Add `Tui.Jsx` Namespace And Core Wrapper Conventions
+
+## Overview
+This task establishes the public JSX namespace and the first wrapper conventions for the TUI package. It gives later wrapper tasks a stable module shape, explicit text-node rule, and export path without changing existing component behavior.
+
+<critical>
+- ALWAYS READ the PRD and TechSpec before starting
+- REFERENCE TECHSPEC for implementation details — do not duplicate here
+- FOCUS ON "WHAT" — describe what needs to be accomplished, not how
+- MINIMIZE CODE — show code only to illustrate current structure or problem areas
+- TESTS REQUIRED — every task MUST include tests in deliverables
+</critical>
+
+<requirements>
+- REQ-01 MUST add a public `Tui.Jsx` namespace under `apps/tui` using Reason source files.
+- REQ-02 MUST expose JSX-friendly wrapper modules for the core authoring convention, including explicit text nodes and child-list wrappers.
+- REQ-03 MUST return existing `Tui.Node.t` values from wrappers and MUST NOT introduce a second render tree.
+- REQ-04 MUST export the namespace through `apps/tui/lib/tui.re` without removing or renaming existing public exports.
+- REQ-05 MUST add focused tests proving the namespace compiles, core wrappers render, and direct component calls still work.
+</requirements>
+
+## Subtasks
+- [ ] 1.1 Review `_prd.md`, `_techspec.md`, and ADR-004 before editing.
+- [ ] 1.2 Add the `Tui.Jsx` namespace with the first wrapper modules and explicit text-node convention.
+- [ ] 1.3 Export `Jsx` from the public `Tui` module while preserving all existing aliases.
+- [ ] 1.4 Add focused tests for namespace availability, explicit text, and core wrapper output.
+- [ ] 1.5 Run the TUI package test/build commands required for this compile-surface change.
+
+## Implementation Details
+Create the JSX namespace in `apps/tui/lib` and export it from `apps/tui/lib/tui.re`. Reference the TechSpec "Core Interfaces" section for wrapper shape and ADR-004 for the explicit text-node and `Tui.Node.t` constraints.
+
+### Relevant Files
+- `apps/tui/lib/tui.re` — public package module exports and existing top-level aliases.
+- `apps/tui/lib/node.re` — source of the `Tui.Node.t` model and primitive constructors.
+- `apps/tui/lib/components/components_core.re` — existing component entrypoint used by wrappers.
+- `apps/tui/lib/dune` — public library stanza and subdirectory handling.
+- `apps/tui/test/test_tui.re` — existing package test suite for rendering and component behavior.
+
+### Dependent Files
+- `apps/tui/lib/components/*` — later tasks wrap these functions through the new namespace.
+- `apps/tui/lib/patterns.re` — later tasks wrap patterns through the same convention.
+- `apps/tui/examples/dune` — later examples depend on the exported namespace.
+
+### Related ADRs
+- [ADR-002: Adopt Public JSX Kit Scope](adrs/adr-002.md) — Establishes public JSX kit scope.
+- [ADR-004: Implement JSX As Wrapper Modules Over Existing TUI Components](adrs/adr-004.md) — Defines wrapper modules, explicit text nodes, and `Tui.Node.t` output.
+
+## Deliverables
+- Public `Tui.Jsx` namespace exported from the TUI package.
+- Core wrapper convention implemented with explicit text-node behavior.
+- Existing public `Tui` exports preserved.
+- Unit tests with 80%+ coverage for the new namespace behavior **(REQUIRED)**.
+- Integration tests for package compile/export behavior **(REQUIRED)**.
+
+## Tests
+- Unit tests:
+  - [ ] `Tui.Jsx.Text` renders the same visible text as `Components.text` for a simple string.
+  - [ ] `Tui.Jsx.Box` renders child nodes produced by explicit text wrappers.
+  - [ ] Existing direct `Tui.text` and `Tui.box` calls still render after the namespace export.
+- Integration tests:
+  - [ ] `pnpm --filter @symphony-orchestrator/tui test` passes after adding the namespace.
+  - [ ] `pnpm --filter @symphony-orchestrator/tui build` passes after adding the namespace.
+- Test coverage target: >=80%
+- All tests must pass
+
+## Success Criteria
+- All tests passing.
+- Test coverage >=80%.
+- `Tui.Jsx` is available from the public `Tui` module.
+- Core wrappers return existing `Tui.Node.t` values with no alternate tree model.
+- Existing direct component-call examples still compile.

--- a/.compozy/tasks/tui-jsx-api/task_02.md
+++ b/.compozy/tasks/tui-jsx-api/task_02.md
@@ -1,0 +1,84 @@
+---
+status: pending
+title: "Add JSX Wrappers For Existing Components"
+type: backend
+complexity: high
+dependencies:
+  - task_01
+---
+
+# Task 02: Add JSX Wrappers For Existing Components
+
+## Overview
+This task expands the JSX namespace across the existing `Tui.Components` surface. It makes the adoption-ready public kit useful for normal standalone TUI screens while keeping direct components as the semantic source of truth.
+
+<critical>
+- ALWAYS READ the PRD and TechSpec before starting
+- REFERENCE TECHSPEC for implementation details — do not duplicate here
+- FOCUS ON "WHAT" — describe what needs to be accomplished, not how
+- MINIMIZE CODE — show code only to illustrate current structure or problem areas
+- TESTS REQUIRED — every task MUST include tests in deliverables
+</critical>
+
+<requirements>
+- REQ-01 MUST add JSX wrappers for most existing `Components` primitives and widgets, excluding presets.
+- REQ-02 MUST preserve the direct component-call behavior for each wrapped component.
+- REQ-03 MUST keep wrapper props aligned with existing component labels unless a JSX-friendly name is clearly required and documented later.
+- REQ-04 MUST keep text explicit and MUST NOT add implicit string-child conversion.
+- REQ-05 MUST add parity tests for representative layout, input/select, status, and data-display wrappers.
+</requirements>
+
+## Subtasks
+- [ ] 2.1 Review the component list in `Components_core` and identify the V1 wrapper set.
+- [ ] 2.2 Add wrappers for primitive nodes and layout components.
+- [ ] 2.3 Add wrappers for interactive and data-display components.
+- [ ] 2.4 Add wrappers for status, empty state, divider, toolbar, and meter components.
+- [ ] 2.5 Add representative parity tests for the supported component groups.
+- [ ] 2.6 Run TUI package tests and build after component wrapper coverage is added.
+
+## Implementation Details
+Use the namespace and conventions from task 01. The component wrappers should delegate to `Components.text`, `rich_text`, `vertical_rule`, `box`, `input`, `option`, `select`, `scroll_box`, `progress_bar`, `sparkline`, `spacer`, `row`, `column`, `panel`, `badge`, `tab_bar`, `key_value`, `table`, `split`, `divider`, `callout`, `empty_state`, `toolbar`, and `meter` where applicable. Reference the TechSpec "Impact Analysis" and "Testing Approach" sections for coverage expectations.
+
+### Relevant Files
+- `apps/tui/lib/components/components_core.re` — canonical list of component exports.
+- `apps/tui/lib/components/component_layout.re` — row and column behavior.
+- `apps/tui/lib/components/component_panel.re` — panel behavior and style merging.
+- `apps/tui/lib/components/component_table.re` — table width and fit behavior.
+- `apps/tui/lib/components/component_key_value.re` — key/value display behavior.
+- `apps/tui/test/test_tui.re` — existing tests for components and rendering.
+
+### Dependent Files
+- `apps/tui/lib/tui.re` — public export should continue to expose the JSX namespace.
+- `apps/tui/examples/agent_workspace.ml` — later parity example depends on component wrappers.
+- `apps/tui/README.md` — later docs depend on the supported component set.
+
+### Related ADRs
+- [ADR-002: Adopt Public JSX Kit Scope](adrs/adr-002.md) — Requires enough public surface for adoption.
+- [ADR-004: Implement JSX As Wrapper Modules Over Existing TUI Components](adrs/adr-004.md) — Requires thin wrappers and parity with existing components.
+
+## Deliverables
+- JSX wrappers for the supported `Components` surface.
+- Representative component parity tests in the TUI test suite.
+- No behavior change to direct component calls.
+- Unit tests with 80%+ coverage for component wrapper groups **(REQUIRED)**.
+- Integration tests for rendering component wrappers together **(REQUIRED)**.
+
+## Tests
+- Unit tests:
+  - [ ] Wrapper row/column/panel composition renders equivalent layout text to direct components.
+  - [ ] Wrapper input/select construction preserves placeholder, options, and focusable behavior.
+  - [ ] Wrapper table and key/value components render aligned data from representative rows.
+  - [ ] Wrapper badge, divider, callout, empty state, toolbar, and meter render visible labels equivalent to direct components.
+- Integration tests:
+  - [ ] A mixed wrapper tree using layout, data, and status components renders through `Renderer.render_to_string`.
+  - [ ] `pnpm --filter @symphony-orchestrator/tui test` passes after wrapper expansion.
+  - [ ] `pnpm --filter @symphony-orchestrator/tui build` passes after wrapper expansion.
+- Test coverage target: >=80%
+- All tests must pass
+
+## Success Criteria
+- All tests passing.
+- Test coverage >=80%.
+- Most existing `Components` are available through `Tui.Jsx`.
+- Wrapper outputs are behaviorally equivalent to direct component calls.
+- No JSX wrapper introduces implicit text conversion or separate runtime state.

--- a/.compozy/tasks/tui-jsx-api/task_03.md
+++ b/.compozy/tasks/tui-jsx-api/task_03.md
@@ -1,0 +1,83 @@
+---
+status: pending
+title: "Add JSX Wrappers For Existing Patterns"
+type: backend
+complexity: high
+dependencies:
+  - task_01
+  - task_02
+---
+
+# Task 03: Add JSX Wrappers For Existing Patterns
+
+## Overview
+This task extends the JSX authoring surface to the higher-level `Tui.Patterns` helpers used by realistic terminal applications. It gives external users a JSX path for command-center and workflow UIs without duplicating pattern semantics.
+
+<critical>
+- ALWAYS READ the PRD and TechSpec before starting
+- REFERENCE TECHSPEC for implementation details — do not duplicate here
+- FOCUS ON "WHAT" — describe what needs to be accomplished, not how
+- MINIMIZE CODE — show code only to illustrate current structure or problem areas
+- TESTS REQUIRED — every task MUST include tests in deliverables
+</critical>
+
+<requirements>
+- REQ-01 MUST add JSX wrappers for most existing `Patterns` helpers used by standalone terminal tools.
+- REQ-02 MUST exclude edge-case presets from V1 wrapper scope unless needed by the parity example.
+- REQ-03 MUST preserve `Patterns` behavior and delegate to existing helpers.
+- REQ-04 MUST support the pattern wrappers needed by the `agent_workspace` parity example.
+- REQ-05 MUST add tests for representative shell, message, timeline, composer, and command/footer pattern wrappers.
+</requirements>
+
+## Subtasks
+- [ ] 3.1 Review `patterns.re` and define the V1 pattern wrapper set.
+- [ ] 3.2 Add wrappers for app shell, header, modal, and rule-panel style patterns.
+- [ ] 3.3 Add wrappers for message, timeline, composer, command bar, footer, and navigation patterns.
+- [ ] 3.4 Add wrappers for dashboard-style patterns such as metric cards and log feed.
+- [ ] 3.5 Add parity tests for representative pattern groups.
+- [ ] 3.6 Run the TUI package test/build commands after pattern wrapper coverage is added.
+
+## Implementation Details
+Use the wrapper namespace from task 01 and the component wrappers from task 02. The pattern wrappers should delegate to `Patterns.rule_panel`, `modal`, `header`, `metric_card`, `log_feed`, `section_title`, `nav_item`, `message`, `timeline`, `composer`, `command_bar`, `footer`, and `app_shell` where applicable. Reference the TechSpec "Key Decisions" section for the preset exclusion and `agent_workspace` priority.
+
+### Relevant Files
+- `apps/tui/lib/patterns.re` — canonical pattern helper implementations.
+- `apps/tui/examples/agent_workspace.ml` — uses app shell, split, panel, scroll box, composer, message, timeline, nav item, and section title patterns.
+- `apps/tui/examples/operations_dashboard.ml` — useful dashboard/status reference for metric and log-feed wrappers.
+- `apps/tui/test/test_tui.re` — existing tests for modal, app shell, and pattern helpers.
+
+### Dependent Files
+- `apps/tui/lib/components/*` — pattern wrappers depend on component wrappers and direct component behavior.
+- `apps/tui/examples/agent_workspace.ml` — later JSX parity example depends on these wrappers.
+- `apps/tui/examples/README.md` — later docs need the supported pattern set.
+
+### Related ADRs
+- [ADR-003: Select Adoption-Ready Public JSX Kit Approach](adrs/adr-003.md) — Requires examples and documentation around the recommended JSX path.
+- [ADR-004: Implement JSX As Wrapper Modules Over Existing TUI Components](adrs/adr-004.md) — Requires pattern wrappers to stay thin and return `Tui.Node.t`.
+
+## Deliverables
+- JSX wrappers for most existing `Patterns` helpers, excluding edge-case presets.
+- Pattern wrapper tests for realistic terminal UI structures.
+- Coverage for all patterns required by the `agent_workspace` parity target.
+- Unit tests with 80%+ coverage for pattern wrapper groups **(REQUIRED)**.
+- Integration tests for composed pattern-wrapper screens **(REQUIRED)**.
+
+## Tests
+- Unit tests:
+  - [ ] App shell wrapper renders title, subtitle, badges, body, and footer items equivalent to direct pattern usage.
+  - [ ] Message and timeline wrappers render representative entries equivalent to direct pattern usage.
+  - [ ] Composer, command bar, footer, section title, and nav item wrappers render expected labels and metadata.
+  - [ ] Metric card and log feed wrappers render representative dashboard content.
+- Integration tests:
+  - [ ] A composed wrapper screen using app shell, navigation, messages, timeline, and composer renders through `Renderer.render_to_string`.
+  - [ ] `pnpm --filter @symphony-orchestrator/tui test` passes after pattern wrapper expansion.
+  - [ ] `pnpm --filter @symphony-orchestrator/tui build` passes after pattern wrapper expansion.
+- Test coverage target: >=80%
+- All tests must pass
+
+## Success Criteria
+- All tests passing.
+- Test coverage >=80%.
+- Most existing `Patterns` used by standalone terminal tools are available through `Tui.Jsx`.
+- Pattern wrappers preserve existing direct pattern behavior.
+- `agent_workspace` has all JSX wrapper support needed for parity work.

--- a/.compozy/tasks/tui-jsx-api/task_04.md
+++ b/.compozy/tasks/tui-jsx-api/task_04.md
@@ -1,0 +1,85 @@
+---
+status: pending
+title: "Add JSX `agent_workspace` Parity Example"
+type: backend
+complexity: medium
+dependencies:
+  - task_02
+  - task_03
+---
+
+# Task 04: Add JSX `agent_workspace` Parity Example
+
+## Overview
+This task proves the adoption-ready JSX surface against a realistic standalone terminal UI. The `agent_workspace` example becomes the first parity target because it exercises navigation, messages, composer input, app shell layout, and run-state panels.
+
+<critical>
+- ALWAYS READ the PRD and TechSpec before starting
+- REFERENCE TECHSPEC for implementation details — do not duplicate here
+- FOCUS ON "WHAT" — describe what needs to be accomplished, not how
+- MINIMIZE CODE — show code only to illustrate current structure or problem areas
+- TESTS REQUIRED — every task MUST include tests in deliverables
+</critical>
+
+<requirements>
+- REQ-01 MUST add a runnable JSX-authored `agent_workspace` example or paired example variant.
+- REQ-02 MUST preserve the existing direct-call `agent_workspace` example behavior.
+- REQ-03 MUST compare rendered output between the direct-call and JSX parity target.
+- REQ-04 MUST register any new example in the TUI examples Dune stanza and examples index when applicable.
+- REQ-05 MUST keep the example focused on standalone terminal-tool users and avoid Symphony-specific runtime wiring.
+</requirements>
+
+## Subtasks
+- [ ] 4.1 Review the existing `agent_workspace` example and identify visible output that must remain equivalent.
+- [ ] 4.2 Add the JSX-authored parity example using wrappers from tasks 02 and 03.
+- [ ] 4.3 Register the example with the TUI example build if a new executable is created.
+- [ ] 4.4 Add rendered parity assertions for the direct-call and JSX example outputs.
+- [ ] 4.5 Run the TUI package test/build commands and the relevant example executable.
+
+## Implementation Details
+Use `apps/tui/examples/agent_workspace.ml` as the source parity target and keep it available. If a new file is added, name it clearly as the JSX variant and include it in `apps/tui/examples/dune`. Reference the TechSpec "Integration Tests" and "Development Sequencing" sections for parity requirements.
+
+### Relevant Files
+- `apps/tui/examples/agent_workspace.ml` — direct-call parity target.
+- `apps/tui/examples/dune` — executable registration for examples.
+- `apps/tui/examples/agent_workspace/README.md` — example-specific documentation that may need JSX mention later.
+- `apps/tui/test/test_tui.re` — place for rendered parity assertions.
+- `apps/tui/lib/patterns.re` — source behavior for app shell, message, timeline, composer, and navigation patterns.
+
+### Dependent Files
+- `apps/tui/lib/tui.re` — exposes the JSX namespace used by the example.
+- `apps/tui/lib/components/*` — component wrappers used by the JSX example.
+- `apps/tui/lib/patterns.re` — pattern wrappers used by the JSX example.
+- `apps/tui/examples/README.md` — docs task will reference the parity example.
+
+### Related ADRs
+- [ADR-002: Adopt Public JSX Kit Scope](adrs/adr-002.md) — Requires public examples for external users.
+- [ADR-003: Select Adoption-Ready Public JSX Kit Approach](adrs/adr-003.md) — Requires adoption-ready examples.
+- [ADR-004: Implement JSX As Wrapper Modules Over Existing TUI Components](adrs/adr-004.md) — Selects `agent_workspace` as first parity target.
+
+## Deliverables
+- Runnable JSX-authored `agent_workspace` parity example.
+- Direct-call example preserved.
+- Rendered parity checks between direct-call and JSX output.
+- Unit tests with 80%+ coverage for parity helper behavior **(REQUIRED)**.
+- Integration tests for the JSX example executable and rendered output **(REQUIRED)**.
+
+## Tests
+- Unit tests:
+  - [ ] JSX example root renders the same visible session labels as the direct-call example.
+  - [ ] JSX example root renders the same conversation labels and composer placeholder as the direct-call example.
+  - [ ] JSX example root renders the same run-state labels as the direct-call example.
+- Integration tests:
+  - [ ] Direct-call and JSX `agent_workspace` rendered strings match or intentionally documented differences are asserted.
+  - [ ] The JSX example executable builds through the examples Dune stanza.
+  - [ ] `pnpm --filter @symphony-orchestrator/tui test` passes after adding the parity example.
+  - [ ] `pnpm --filter @symphony-orchestrator/tui build` passes after adding the parity example.
+- Test coverage target: >=80%
+- All tests must pass
+
+## Success Criteria
+- All tests passing.
+- Test coverage >=80%.
+- JSX `agent_workspace` is runnable as a standalone package example.
+- Rendered parity is proven against the existing direct-call example.
+- No product-specific Terminal Console runtime wiring is introduced.

--- a/.compozy/tasks/tui-jsx-api/task_05.md
+++ b/.compozy/tasks/tui-jsx-api/task_05.md
@@ -1,0 +1,84 @@
+---
+status: pending
+title: "Document JSX Quickstart, Supported Surface, And Migration Path"
+type: docs
+complexity: medium
+dependencies:
+  - task_02
+  - task_03
+  - task_04
+---
+
+# Task 05: Document JSX Quickstart, Supported Surface, And Migration Path
+
+## Overview
+This task turns the implemented JSX surface into the adoption-ready public path required by the PRD. It updates the TUI documentation so external Reason/OCaml users can build a small standalone terminal UI without first reading internal Symphony source code.
+
+<critical>
+- ALWAYS READ the PRD and TechSpec before starting
+- REFERENCE TECHSPEC for implementation details — do not duplicate here
+- FOCUS ON "WHAT" — describe what needs to be accomplished, not how
+- MINIMIZE CODE — show code only to illustrate current structure or problem areas
+- TESTS REQUIRED — every task MUST include tests in deliverables
+</critical>
+
+<requirements>
+- REQ-01 MUST present JSX as the recommended authoring path for new TUI screens.
+- REQ-02 MUST document direct `Tui.Components` and `Tui.Patterns` calls as stable lower-level APIs, not deprecated paths.
+- REQ-03 MUST include a standalone quickstart that supports the PRD's under-30-minute success goal.
+- REQ-04 MUST document the supported V1 JSX component and pattern surface.
+- REQ-05 MUST include migration guidance from direct component calls to JSX, including explicit text-node expectations.
+- REQ-06 MUST keep examples and wording focused on standalone Reason/OCaml terminal-tool users.
+</requirements>
+
+## Subtasks
+- [ ] 5.1 Update the TUI README with the JSX recommended-path quickstart.
+- [ ] 5.2 Add a supported-surface section for JSX wrappers.
+- [ ] 5.3 Add migration guidance for direct component calls to JSX wrappers.
+- [ ] 5.4 Update the examples index to include JSX examples and when to use them.
+- [ ] 5.5 Update example-specific documentation for the JSX `agent_workspace` parity example.
+- [ ] 5.6 Verify documented commands and code snippets against the package.
+
+## Implementation Details
+Documentation should reference the implemented wrapper surface from tasks 02-04 and the PRD user experience. Keep implementation mechanics in the TechSpec and docs focused on usage, migration, and compatibility. Avoid implying React runtime compatibility.
+
+### Relevant Files
+- `apps/tui/README.md` — primary public package entrypoint.
+- `apps/tui/examples/README.md` — examples index and "Choosing An Example" guidance.
+- `apps/tui/examples/agent_workspace/README.md` — example-specific explanation for the parity target.
+- `apps/tui/examples/demo/README.md` — baseline quickstart/example reference.
+- `apps/tui/package.json` — package scripts documented for build/test.
+
+### Dependent Files
+- `apps/tui/lib/tui.re` — docs reference the public `Tui.Jsx` namespace.
+- `apps/tui/examples/*` — docs must match actual example names and commands.
+- `apps/tui/test/test_tui.re` — tests may include doc-snippet or example render coverage from prior tasks.
+
+### Related ADRs
+- [ADR-003: Select Adoption-Ready Public JSX Kit Approach](adrs/adr-003.md) — Requires docs, examples, migration guidance, and JSX as recommended path.
+- [ADR-004: Implement JSX As Wrapper Modules Over Existing TUI Components](adrs/adr-004.md) — Defines explicit text nodes and direct components as lower-level API.
+
+## Deliverables
+- Updated `apps/tui/README.md` with JSX quickstart and compatibility guidance.
+- Updated examples index and relevant example README files.
+- Supported JSX surface and migration guidance documented.
+- Unit tests with 80%+ coverage for any doc-backed snippet helpers or examples touched **(REQUIRED)**.
+- Integration tests for documented example commands and package docs consistency **(REQUIRED)**.
+
+## Tests
+- Unit tests:
+  - [ ] Any reusable documentation snippet or example helper introduced by this task is covered by focused TUI tests.
+  - [ ] Existing wrapper tests still cover the components and patterns named in the supported-surface guide.
+- Integration tests:
+  - [ ] Documented JSX example command builds or runs through the TUI package workflow.
+  - [ ] `pnpm --filter @symphony-orchestrator/tui test` passes after docs updates.
+  - [ ] `pnpm --filter @symphony-orchestrator/tui build` passes after docs updates.
+- Test coverage target: >=80%
+- All tests must pass
+
+## Success Criteria
+- All tests passing.
+- Test coverage >=80%.
+- README names JSX as the recommended path for new TUI screens.
+- Docs clearly state direct components remain supported lower-level APIs.
+- A new standalone Reason/OCaml user can follow the quickstart without Symphony-specific runtime knowledge.

--- a/.compozy/tasks/tui-jsx-api/task_06.md
+++ b/.compozy/tasks/tui-jsx-api/task_06.md
@@ -1,0 +1,84 @@
+---
+status: pending
+title: "Finalize TUI Package Verification And Bundle Readiness"
+type: chore
+complexity: low
+dependencies:
+  - task_01
+  - task_02
+  - task_03
+  - task_04
+  - task_05
+---
+
+# Task 06: Finalize TUI Package Verification And Bundle Readiness
+
+## Overview
+This task closes the feature by checking the full TUI package surface after wrappers, examples, and docs are in place. It is a readiness task that fixes any remaining package-local drift discovered by verification rather than introducing a separate testing-only workstream.
+
+<critical>
+- ALWAYS READ the PRD and TechSpec before starting
+- REFERENCE TECHSPEC for implementation details — do not duplicate here
+- FOCUS ON "WHAT" — describe what needs to be accomplished, not how
+- MINIMIZE CODE — show code only to illustrate current structure or problem areas
+- TESTS REQUIRED — every task MUST include tests in deliverables
+</critical>
+
+<requirements>
+- REQ-01 MUST run the TechSpec-required TUI package verification commands after all implementation and docs tasks are complete.
+- REQ-02 MUST fix package-local compile, test, example-registration, or documentation drift found by verification.
+- REQ-03 MUST confirm task metadata validation passes for `tui-jsx-api`.
+- REQ-04 MUST keep verification scoped to the TUI package unless a package-local change reveals a required adjacent fix.
+- REQ-05 MUST leave no generated frontend `.res.js` files or unrelated artifacts staged or required.
+</requirements>
+
+## Subtasks
+- [ ] 6.1 Review all completed task outputs against `_prd.md`, `_techspec.md`, and ADR-004.
+- [ ] 6.2 Run the TUI package test command and address any package-local failures.
+- [ ] 6.3 Run the TUI package build command and address any package-local failures.
+- [ ] 6.4 Run task validation for `tui-jsx-api` and fix metadata or template issues.
+- [ ] 6.5 Check for unrelated generated or accidental files in the task and package scope.
+
+## Implementation Details
+Use the TechSpec "Testing Approach" and "Development Sequencing" sections as the verification contract. This task should only make small package-local fixes discovered by final verification; larger behavior gaps should be resolved in the implementation task that owns them.
+
+### Relevant Files
+- `apps/tui/package.json` — defines the package `test` and `build` scripts.
+- `apps/tui/dune-project` — opam/package metadata for the public TUI package.
+- `apps/tui/lib/dune` — library stanza for public package builds.
+- `apps/tui/examples/dune` — example executable registration.
+- `.compozy/tasks/tui-jsx-api/_tasks.md` — master task list for validation.
+- `.compozy/tasks/tui-jsx-api/task_*.md` — task files validated by Compozy.
+
+### Dependent Files
+- `apps/tui/lib/tui.re` — final build proves public exports compile.
+- `apps/tui/test/test_tui.re` — final tests prove wrapper parity and example behavior.
+- `apps/tui/README.md` — final readback confirms public docs match implemented commands.
+
+### Related ADRs
+- [ADR-004: Implement JSX As Wrapper Modules Over Existing TUI Components](adrs/adr-004.md) — Defines TUI-only verification scope.
+
+## Deliverables
+- Passing TUI package test run.
+- Passing TUI package build run.
+- Passing Compozy task validation for `tui-jsx-api`.
+- Unit tests with 80%+ coverage for any final package-local fixes **(REQUIRED)**.
+- Integration tests for the final TUI package verification path **(REQUIRED)**.
+
+## Tests
+- Unit tests:
+  - [ ] Any package-local fix made during final verification includes a focused test in `apps/tui/test/test_tui.re`.
+  - [ ] Existing JSX wrapper and parity tests continue to pass without weakening assertions.
+- Integration tests:
+  - [ ] `pnpm --filter @symphony-orchestrator/tui test` exits 0.
+  - [ ] `pnpm --filter @symphony-orchestrator/tui build` exits 0.
+  - [ ] `compozy tasks validate --name tui-jsx-api` exits 0.
+- Test coverage target: >=80%
+- All tests must pass
+
+## Success Criteria
+- All tests passing.
+- Test coverage >=80%.
+- TUI package build and test commands pass from the product repository.
+- `compozy tasks validate --name tui-jsx-api` passes.
+- Final changed files are limited to the task bundle and intended TUI package/docs files.


### PR DESCRIPTION
## Summary
- Adds the complete planning bundle for `tui-jsx-api`
- Captures the idea, PRD, TechSpec, task breakdown, and four ADRs for the JSX-based TUI authoring direction
- Establishes the public wrapper-module approach, explicit text-node rule, and `agent_workspace` parity target

## Testing
- Validated the task bundle with `compozy tasks validate --name tui-jsx-api`
- Confirmed all 6 task files passed schema validation