### PR TITLE
Symphony: compozy:init-harness-detection from symphony/task-compozy_init-harness-detection into main

### DIFF
--- a/.compozy/tasks/init-harness-detection/_tasks.md
+++ b/.compozy/tasks/init-harness-detection/_tasks.md
@@ -9,4 +9,4 @@
 | 03 | Add Structured Bootstrap Settings Builder | completed | medium | task_01 |
 | 04 | Wire Adaptive Settings Into Idempotent Bootstrap | completed | high | task_02, task_03 |
 | 05 | Thread And Render Bootstrap Guidance | completed | medium | task_04 |
-| 06 | Document Adaptive Bootstrap Semantics | pending | medium | task_05 |
+| 06 | Document Adaptive Bootstrap Semantics | completed | medium | task_05 |

--- a/.compozy/tasks/init-harness-detection/_tasks.md
+++ b/.compozy/tasks/init-harness-detection/_tasks.md
@@ -4,9 +4,9 @@
 
 | # | Title | Status | Complexity | Dependencies |
 |---|-------|--------|------------|--------------|
-| 01 | Define Bootstrap Harness Detection Boundary | pending | medium | — |
-| 02 | Add Default Local Harness Probe Adapter | pending | medium | task_01 |
-| 03 | Add Structured Bootstrap Settings Builder | pending | medium | task_01 |
-| 04 | Wire Adaptive Settings Into Idempotent Bootstrap | pending | high | task_02, task_03 |
-| 05 | Thread And Render Bootstrap Guidance | pending | medium | task_04 |
+| 01 | Define Bootstrap Harness Detection Boundary | completed | medium | — |
+| 02 | Add Default Local Harness Probe Adapter | completed | medium | task_01 |
+| 03 | Add Structured Bootstrap Settings Builder | completed | medium | task_01 |
+| 04 | Wire Adaptive Settings Into Idempotent Bootstrap | completed | high | task_02, task_03 |
+| 05 | Thread And Render Bootstrap Guidance | completed | medium | task_04 |
 | 06 | Document Adaptive Bootstrap Semantics | pending | medium | task_05 |

--- a/.compozy/tasks/init-harness-detection/task_01.md
+++ b/.compozy/tasks/init-harness-detection/task_01.md
@@ -1,9 +1,10 @@
 ---
-status: pending
+status: completed
 title: Define Bootstrap Harness Detection Boundary
 type: backend
 complexity: medium
 dependencies: []
+
 ---
 
 # Task 1: Define Bootstrap Harness Detection Boundary
@@ -29,11 +30,11 @@ Define the pure Bootstrap Harness detection boundary that later tasks will use f
 </requirements>
 
 ## Subtasks
-- [ ] 1.1 Define the secret-free Harness status and detection result types.
-- [ ] 1.2 Define the injected probe contract for executable, auth, and bounded status checks.
-- [ ] 1.3 Define supported Harness metadata and the deterministic selection priority.
-- [ ] 1.4 Define guidance categories for selected, missing, and nonselectable Harness outcomes.
-- [ ] 1.5 Add focused Alcotest coverage for pure selection and guidance classification.
+- [x] 1.1 Define the secret-free Harness status and detection result types.
+- [x] 1.2 Define the injected probe contract for executable, auth, and bounded status checks.
+- [x] 1.3 Define supported Harness metadata and the deterministic selection priority.
+- [x] 1.4 Define guidance categories for selected, missing, and nonselectable Harness outcomes.
+- [x] 1.5 Add focused Alcotest coverage for pure selection and guidance classification.
 
 ## Implementation Details
 Create `apps/backend/lib/bootstrap_harness_detection.re` as the owner of the detection domain described in the TechSpec "Core Interfaces" and ADR-003. Keep the module pure for this task: tests should inject probe results directly and must not invoke real `codex`, `claude`, `cursor-agent`, or `pi` commands. Add tests in `apps/backend/test/test_backend.ml` near the existing Runtime Home and Harness readiness coverage.
@@ -63,14 +64,14 @@ Create `apps/backend/lib/bootstrap_harness_detection.re` as the owner of the det
 
 ## Tests
 - Unit tests:
-  - [ ] Codex-only probe result selects `codex` while marking Codex readiness confidence as executable-only.
-  - [ ] Claude-only, Cursor-only, and PI-only probe results each select their matching Harness.
-  - [ ] Multiple usable Harnesses select the deterministic priority winner and leave all statuses inspectable.
-  - [ ] `cursor-force` usable-looking input is retained as nonselectable and never becomes the selected Harness.
-  - [ ] No usable Harness produces no selected Harness and includes remediation categories.
-  - [ ] Token-like marker strings cannot appear in detection result fields or guidance lines.
+  - [x] Codex-only probe result selects `codex` while marking Codex readiness confidence as executable-only.
+  - [x] Claude-only, Cursor-only, and PI-only probe results each select their matching Harness.
+  - [x] Multiple usable Harnesses select the deterministic priority winner and leave all statuses inspectable.
+  - [x] `cursor-force` usable-looking input is retained as nonselectable and never becomes the selected Harness.
+  - [x] No usable Harness produces no selected Harness and includes remediation categories.
+  - [x] Token-like marker strings cannot appear in detection result fields or guidance lines.
 - Integration tests:
-  - [ ] Compile the backend test suite with the new Reason module available to OCaml tests.
+  - [x] Compile the backend test suite with the new Reason module available to OCaml tests.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/init-harness-detection/task_02.md
+++ b/.compozy/tasks/init-harness-detection/task_02.md
@@ -1,10 +1,11 @@
 ---
-status: pending
+status: completed
 title: Add Default Local Harness Probe Adapter
 type: backend
 complexity: medium
 dependencies:
   - task_01
+
 ---
 
 # Task 2: Add Default Local Harness Probe Adapter

--- a/.compozy/tasks/init-harness-detection/task_03.md
+++ b/.compozy/tasks/init-harness-detection/task_03.md
@@ -1,10 +1,11 @@
 ---
-status: pending
+status: completed
 title: Add Structured Bootstrap Settings Builder
 type: backend
 complexity: medium
 dependencies:
   - task_01
+
 ---
 
 # Task 3: Add Structured Bootstrap Settings Builder
@@ -31,11 +32,11 @@ Replace the static settings template concept with a structured Runtime Settings 
 </requirements>
 
 ## Subtasks
-- [ ] 3.1 Create the structured settings builder module.
-- [ ] 3.2 Preserve existing tracker, project, polling, workspace, sandbox, Git, pull request, stage, agent, and server defaults.
-- [ ] 3.3 Generate all supported Harness definitions with the existing command and loop defaults.
-- [ ] 3.4 Route Logical Agents to the selected Harness or preserve no-Harness fallback routes.
-- [ ] 3.5 Add tests that parse generated settings through `Config.from_settings_file`.
+- [x] 3.1 Create the structured settings builder module.
+- [x] 3.2 Preserve existing tracker, project, polling, workspace, sandbox, Git, pull request, stage, agent, and server defaults.
+- [x] 3.3 Generate all supported Harness definitions with the existing command and loop defaults.
+- [x] 3.4 Route Logical Agents to the selected Harness or preserve no-Harness fallback routes.
+- [x] 3.5 Add tests that parse generated settings through `Config.from_settings_file`.
 
 ## Implementation Details
 Create `apps/backend/lib/bootstrap_settings.re` and model the current default Runtime Settings from `apps/backend/lib/runtime_home.ml` as structured JSON. Reference the TechSpec "Data Models" and "Integration Points" sections for the selected-Harness routing behavior. Tests should assert shape and parser compatibility rather than comparing a large raw JSON string byte-for-byte.

--- a/.compozy/tasks/init-harness-detection/task_04.md
+++ b/.compozy/tasks/init-harness-detection/task_04.md
@@ -1,11 +1,12 @@
 ---
-status: pending
+status: completed
 title: Wire Adaptive Settings Into Idempotent Bootstrap
 type: backend
 complexity: high
 dependencies:
   - task_02
   - task_03
+
 ---
 
 # Task 4: Wire Adaptive Settings Into Idempotent Bootstrap

--- a/.compozy/tasks/init-harness-detection/task_05.md
+++ b/.compozy/tasks/init-harness-detection/task_05.md
@@ -1,10 +1,11 @@
 ---
-status: pending
+status: completed
 title: Thread And Render Bootstrap Guidance
 type: backend
 complexity: medium
 dependencies:
   - task_04
+
 ---
 
 # Task 5: Thread And Render Bootstrap Guidance
@@ -31,11 +32,11 @@ Expose the adaptive Bootstrap decision to users through explicit CLI and Termina
 </requirements>
 
 ## Subtasks
-- [ ] 5.1 Extend `Runtime_startup.prepared_runtime` to carry Bootstrap guidance.
-- [ ] 5.2 Add renderer helpers for selected-Harness, no-Harness, and existing-settings cases.
-- [ ] 5.3 Render guidance in explicit `symphony init`.
-- [ ] 5.4 Render guidance during implicit startup and append it to Terminal Console initial logs.
-- [ ] 5.5 Add output tests for wording, no-secret behavior, and readiness-authority phrasing.
+- [x] 5.1 Extend `Runtime_startup.prepared_runtime` to carry Bootstrap guidance.
+- [x] 5.2 Add renderer helpers for selected-Harness, no-Harness, and existing-settings cases.
+- [x] 5.3 Render guidance in explicit `symphony init`.
+- [x] 5.4 Render guidance during implicit startup and append it to Terminal Console initial logs.
+- [x] 5.5 Add output tests for wording, no-secret behavior, and readiness-authority phrasing.
 
 ## Implementation Details
 Modify `apps/backend/lib/runtime_startup.re` and `apps/backend/bin/main.ml` around the existing `prepared_runtime`, `bootstrap_report_log_lines`, `render_bootstrap_report`, and `init` flows. The existing startup code already carries Bootstrap report lines into `terminal_console_initial_logs`; append guidance lines in the same pipeline. Reference the TechSpec "Monitoring and Observability" section for required output cases.
@@ -66,15 +67,15 @@ Modify `apps/backend/lib/runtime_startup.re` and `apps/backend/bin/main.ml` arou
 
 ## Tests
 - Unit tests:
-  - [ ] Guidance renderer for selected Harness includes Harness name, local detection provenance, and runtime readiness authority.
-  - [ ] Guidance renderer for no usable Harness includes clear install or auth next steps.
-  - [ ] Guidance renderer for existing settings says settings were preserved and not regenerated.
-  - [ ] Guidance lines omit token-like markers and raw command output.
+  - [x] Guidance renderer for selected Harness includes Harness name, local detection provenance, and runtime readiness authority.
+  - [x] Guidance renderer for no usable Harness includes clear install or auth next steps.
+  - [x] Guidance renderer for existing settings says settings were preserved and not regenerated.
+  - [x] Guidance lines omit token-like markers and raw command output.
 - Integration tests:
-  - [ ] Explicit `symphony init` path renders selected-Harness guidance when settings are created.
-  - [ ] Explicit `symphony init` path renders existing-settings guidance on the second run.
-  - [ ] Implicit startup path carries guidance in `Runtime_startup.prepare_runtime` results.
-  - [ ] Terminal Console initial logs include Bootstrap guidance before the startup-completed line.
+  - [x] Explicit `symphony init` path renders selected-Harness guidance when settings are created.
+  - [x] Explicit `symphony init` path renders existing-settings guidance on the second run.
+  - [x] Implicit startup path carries guidance in `Runtime_startup.prepare_runtime` results.
+  - [x] Terminal Console initial logs include Bootstrap guidance before the startup-completed line.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/init-harness-detection/task_06.md
+++ b/.compozy/tasks/init-harness-detection/task_06.md
@@ -1,10 +1,11 @@
 ---
-status: pending
+status: completed
 title: Document Adaptive Bootstrap Semantics
 type: docs
 complexity: medium
 dependencies:
   - task_05
+
 ---
 
 # Task 6: Document Adaptive Bootstrap Semantics

--- a/.compozy/tasks/init-harness-detection/task_06.md
+++ b/.compozy/tasks/init-harness-detection/task_06.md
@@ -32,11 +32,11 @@ Update user-facing and architecture documentation to describe adaptive missing-s
 </requirements>
 
 ## Subtasks
-- [ ] 6.1 Update README setup text for selected-Harness, no-Harness, and existing-settings outcomes.
-- [ ] 6.2 Update the Agent Harness Runtime Settings ADR with the new Bootstrap amendment.
-- [ ] 6.3 Review `CONTEXT.md` for whether any glossary or relationship update is necessary.
-- [ ] 6.4 Extend docs tests for adaptive Bootstrap semantics and secret-free examples.
-- [ ] 6.5 Run docs and backend validation commands required by the changed assertions.
+- [x] 6.1 Update README setup text for selected-Harness, no-Harness, and existing-settings outcomes.
+- [x] 6.2 Update the Agent Harness Runtime Settings ADR with the new Bootstrap amendment.
+- [x] 6.3 Review `CONTEXT.md` for whether any glossary or relationship update is necessary.
+- [x] 6.4 Extend docs tests for adaptive Bootstrap semantics and secret-free examples.
+- [x] 6.5 Run docs and backend validation commands required by the changed assertions.
 
 ## Implementation Details
 Keep the documentation tied to the behavior implemented in Task 5. `README.md` should help a first-run individual developer understand what `symphony init` generated and what readiness still validates. The ADR should capture the architectural decision as an amendment to the existing Agent Harness Runtime Settings record rather than creating a competing runtime contract document.
@@ -68,15 +68,15 @@ Keep the documentation tied to the behavior implemented in Task 5. `README.md` s
 
 ## Tests
 - Unit tests:
-  - [ ] README assertion covers adaptive Bootstrap when settings are missing.
-  - [ ] README assertion covers existing settings preservation on repeated Bootstrap.
-  - [ ] ADR assertion covers selected-Harness guidance and runtime readiness authority.
-  - [ ] CONTEXT assertion is updated only if a glossary or relationship entry changes.
-  - [ ] Secret-free docs test still rejects token marker examples and secret assignments.
+  - [x] README assertion covers adaptive Bootstrap when settings are missing.
+  - [x] README assertion covers existing settings preservation on repeated Bootstrap.
+  - [x] ADR assertion covers selected-Harness guidance and runtime readiness authority.
+  - [x] CONTEXT assertion is updated only if a glossary or relationship entry changes.
+  - [x] Secret-free docs test still rejects token marker examples and secret assignments.
 - Integration tests:
-  - [ ] `pnpm test` passes after docs assertion updates.
-  - [ ] `pnpm docs:test` passes if the repository exposes that command for doc assertions.
-  - [ ] `compozy tasks validate --name init-harness-detection` passes for the completed task bundle.
+  - [x] `pnpm test` passes after docs assertion updates.
+  - [x] `pnpm docs:test` passes if the repository exposes that command for doc assertions.
+  - [x] `compozy tasks validate --name init-harness-detection` passes for the completed task bundle.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Edit `.symphony/settings.json` to choose an Issue Tracker, set tracker-specific 
 status states, and set runtime commands. Runtime Settings reference secrets by environment variable
 name; secret values belong only in the Local Environment.
 
+When `.symphony/settings.json` is missing, Bootstrap seeds it with normal Runtime Settings from a
+local, allowlisted Agent Harness detection pass. The output names a selected Agent Harness when one is
+usable, reports when no supported usable Agent Harness was found, or says that
+existing Runtime Settings are preserved on repeated Bootstrap. Existing settings are preserved without
+regeneration. This adaptive missing-settings Bootstrap is onboarding guidance only: runtime readiness
+remains the dispatch authority before any agent work starts.
+
 ### Default Terminal Console
 
 Run `symphony` from the Workspace Repository root to start the default read-first Terminal Console.
@@ -343,6 +350,12 @@ never secret values.
 To assign Cursor to any Logical Agent, set `agents.<name>.harness` to `cursor` or `cursor-force`.
 Keep `stageAgents.stages[]` routing by Logical Agent name rather than placing provider fields on the
 stage itself.
+
+Generated first-run Runtime Settings keep all supported Harness definitions available for editing. When
+Bootstrap detects a usable supported Harness, the default Logical Agents route to the selected Harness;
+when no Harness is usable, the default Logical Agent routes remain `codex`, `claude`, and `pi` so the
+next manual edit is explicit. Repeated Bootstrap preserves existing Runtime Contract files and does not
+reinterpret, regenerate, or rewrite Harness settings.
 
 Legacy settings that place Harness definitions under `agents.*`, such as `agents.pi.kind`, are
 migration input. When the new Runtime Settings shape is in use, Symphony reports a blocking Readiness

--- a/apps/backend/bin/main.ml
+++ b/apps/backend/bin/main.ml
@@ -90,6 +90,9 @@ let render_bootstrap_report report =
       Printf.eprintf "  %s %-7s %s\n%!" (status_badge item.status) (basename item.path) (dim item.path))
     report
 
+let render_bootstrap_guidance guidance =
+  Runtime_startup.bootstrap_guidance_lines guidance |> List.iter (fun line -> Printf.eprintf "%s\n%!" line)
+
 let tracker_issue_source config =
   match config.Config.tracker.kind with
   | "github" -> Printf.sprintf "%s/%s" config.tracker.owner config.tracker.repo
@@ -264,15 +267,19 @@ let run_runtime port once web queue_arg merge_args overrides =
         1
     | Ok prepared ->
         let home = prepared.Runtime_startup.home in
-        let terminal_console_initial_logs = ref (bootstrap_report_log_lines prepared.bootstrap_report) in
+        let terminal_console_initial_logs = ref [] in
         render_bootstrap_report prepared.bootstrap_report;
+        render_bootstrap_guidance prepared.bootstrap_guidance;
         let config = prepared.loaded.config in
         let prompt_template = prepared.loaded.prompt_template in
         let ordered_queue, queue_parse_problems = parse_ordered_queue_arg queue_arg in
         let mode = Cli_mode.select ~web in
         let mode_text = Cli_mode.to_string mode in
+        let startup_completed_line = startup_completed_log_line ~mode:mode_text ~config ~runtime_home:home.runtime_dir in
         terminal_console_initial_logs :=
-          !terminal_console_initial_logs @ [ startup_completed_log_line ~mode:mode_text ~config ~runtime_home:home.runtime_dir ];
+          Runtime_startup.terminal_console_initial_log_lines
+            ~bootstrap_report_lines:(bootstrap_report_log_lines prepared.bootstrap_report)
+            ~bootstrap_guidance:prepared.bootstrap_guidance ~startup_completed_line;
         render_startup_completed ~mode:mode_text ~config ~runtime_home:home.runtime_dir;
         if merge_args <> [] then run_manual_merge config merge_args
         else (
@@ -399,8 +406,9 @@ let init () =
         Printf.eprintf "event=init outcome=failed reason=%s\n%!" msg;
         1
     | Ok workspace_root ->
-        let _, report = Runtime_home.bootstrap workspace_root in
-        render_bootstrap_report report;
+        let bootstrap = Runtime_home.bootstrap_with_guidance workspace_root in
+        render_bootstrap_report bootstrap.Runtime_home.report;
+        render_bootstrap_guidance bootstrap.Runtime_home.guidance;
         Printf.eprintf "event=init outcome=completed runtime_home=%s\n%!" (Filename.concat workspace_root Runtime_home.runtime_dir_name);
         0
   with Runtime_home.Runtime_home_error msg ->

--- a/apps/backend/lib/bootstrap_harness_detection.re
+++ b/apps/backend/lib/bootstrap_harness_detection.re
@@ -1,0 +1,380 @@
+type auth_signal =
+  | Authenticated
+  | Auth_missing
+  | Auth_unknown
+  | Auth_not_checked;
+
+type status_signal =
+  | Status_succeeded
+  | Status_failed
+  | Status_unknown
+  | Status_not_checked;
+
+type readiness_confidence =
+  | Install_and_auth
+  | Install_and_status
+  | Executable_only
+  | Not_ready
+  | Nonselectable;
+
+type guidance_category =
+  | Selected_harness
+  | No_usable_harness
+  | Missing_install
+  | Missing_auth
+  | Missing_status
+  | Nonselectable_harness;
+
+type settings_mode =
+  | Generate_missing_runtime_settings
+  | Preserve_existing_runtime_settings;
+
+type harness_definition = {
+  name: string,
+  kind: string,
+  executable: string,
+  display_name: string,
+  selectable: bool,
+  requires_auth: bool,
+  requires_status: bool,
+};
+
+type probe = {
+  executable_available: string => bool,
+  auth_signal: harness_definition => auth_signal,
+  status_signal: harness_definition => status_signal,
+};
+
+type harness_status = {
+  name: string,
+  kind: string,
+  executable: string,
+  display_name: string,
+  executable_available: bool,
+  auth_signal,
+  status_signal,
+  selectable: bool,
+  probed_usable: bool,
+  auto_selectable: bool,
+  readiness_confidence,
+  remediation: string,
+};
+
+type guidance_item = {
+  category: guidance_category,
+  harness_name: option(string),
+  message: string,
+};
+
+type detection_result = {
+  supported: list(harness_status),
+  selected: option(harness_status),
+  nonselectable: list(harness_status),
+  guidance: list(guidance_item),
+  settings_mode,
+};
+
+let supported_definitions = [
+  {
+    name: "codex",
+    kind: "codex",
+    executable: "codex",
+    display_name: "Codex",
+    selectable: true,
+    requires_auth: false,
+    requires_status: false,
+  },
+  {
+    name: "claude",
+    kind: "claude",
+    executable: "claude",
+    display_name: "Claude Code",
+    selectable: true,
+    requires_auth: true,
+    requires_status: false,
+  },
+  {
+    name: "cursor",
+    kind: "cursor",
+    executable: "cursor-agent",
+    display_name: "Cursor CLI",
+    selectable: true,
+    requires_auth: false,
+    requires_status: true,
+  },
+  {
+    name: "cursor-force",
+    kind: "cursor",
+    executable: "cursor-agent",
+    display_name: "Cursor CLI force mode",
+    selectable: false,
+    requires_auth: false,
+    requires_status: true,
+  },
+  {
+    name: "pi",
+    kind: "pi",
+    executable: "pi",
+    display_name: "PI",
+    selectable: true,
+    requires_auth: true,
+    requires_status: false,
+  },
+];
+
+/* Stronger install plus auth/status evidence wins before Codex executable-only evidence. */
+let selection_priority = ["claude", "cursor", "pi", "codex"];
+
+let auth_signal_to_string =
+  fun
+  | Authenticated => "authenticated"
+  | Auth_missing => "missing_auth"
+  | Auth_unknown => "auth_unknown"
+  | Auth_not_checked => "auth_not_checked";
+
+let status_signal_to_string =
+  fun
+  | Status_succeeded => "status_succeeded"
+  | Status_failed => "status_failed"
+  | Status_unknown => "status_unknown"
+  | Status_not_checked => "status_not_checked";
+
+let readiness_confidence_to_string =
+  fun
+  | Install_and_auth => "install_and_auth"
+  | Install_and_status => "install_and_status"
+  | Executable_only => "executable_only"
+  | Not_ready => "not_ready"
+  | Nonselectable => "nonselectable";
+
+let guidance_category_to_string =
+  fun
+  | Selected_harness => "selected_harness"
+  | No_usable_harness => "no_usable_harness"
+  | Missing_install => "missing_install"
+  | Missing_auth => "missing_auth"
+  | Missing_status => "missing_status"
+  | Nonselectable_harness => "nonselectable_harness";
+
+let settings_mode_to_string =
+  fun
+  | Generate_missing_runtime_settings => "generate_missing_runtime_settings"
+  | Preserve_existing_runtime_settings => "preserve_existing_runtime_settings";
+
+let auth_satisfied = (definition: harness_definition, auth_signal) =>
+  !definition.requires_auth || auth_signal == Authenticated;
+
+let status_satisfied = (definition: harness_definition, status_signal) =>
+  !definition.requires_status || status_signal == Status_succeeded;
+
+let probed_usable =
+    (
+      definition: harness_definition,
+      executable_available,
+      auth_signal,
+      status_signal,
+    ) =>
+  executable_available
+  && auth_satisfied(definition, auth_signal)
+  && status_satisfied(definition, status_signal);
+
+let readiness_confidence =
+    (
+      definition: harness_definition,
+      executable_available,
+      auth_signal,
+      status_signal,
+      probed_usable,
+    ) =>
+  if (!definition.selectable) {
+    Nonselectable;
+  } else if (!probed_usable) {
+    Not_ready;
+  } else if (definition.requires_auth && auth_signal == Authenticated) {
+    Install_and_auth;
+  } else if (definition.requires_status && status_signal == Status_succeeded) {
+    Install_and_status;
+  } else if (executable_available) {
+    Executable_only;
+  } else {
+    Not_ready;
+  };
+
+let remediation =
+    (
+      definition: harness_definition,
+      executable_available,
+      auth_signal,
+      status_signal,
+      probed_usable,
+    ) =>
+  if (!definition.selectable) {
+    definition.name
+    ++ " is an explicit Runtime Settings Harness definition and is never selected automatically.";
+  } else if (!executable_available) {
+    "Install "
+    ++ definition.display_name
+    ++ " so the "
+    ++ definition.executable
+    ++ " executable is available.";
+  } else if (definition.requires_auth && auth_signal != Authenticated) {
+    "Authenticate "
+    ++ definition.display_name
+    ++ " without storing secrets in Runtime Settings.";
+  } else if (definition.requires_status && status_signal != Status_succeeded) {
+    "Confirm the "
+    ++ definition.display_name
+    ++ " status probe succeeds without exposing credentials.";
+  } else if (probed_usable) {
+    "Runtime readiness still validates the selected Agent Harness before dispatch.";
+  } else {
+    "Review "
+    ++ definition.display_name
+    ++ " install and authentication state.";
+  };
+
+let status_of_definition = (probe: probe, definition: harness_definition) => {
+  let executable_available =
+    probe.executable_available(definition.executable);
+  let auth_signal =
+    if (definition.requires_auth) {
+      probe.auth_signal(definition);
+    } else {
+      Auth_not_checked;
+    };
+  let status_signal =
+    if (definition.requires_status) {
+      probe.status_signal(definition);
+    } else {
+      Status_not_checked;
+    };
+  let probed_usable =
+    probed_usable(
+      definition,
+      executable_available,
+      auth_signal,
+      status_signal,
+    );
+  let auto_selectable = definition.selectable && probed_usable;
+  let readiness_confidence =
+    readiness_confidence(
+      definition,
+      executable_available,
+      auth_signal,
+      status_signal,
+      probed_usable,
+    );
+  let remediation =
+    remediation(
+      definition,
+      executable_available,
+      auth_signal,
+      status_signal,
+      probed_usable,
+    );
+  {
+    name: definition.name,
+    kind: definition.kind,
+    executable: definition.executable,
+    display_name: definition.display_name,
+    executable_available,
+    auth_signal,
+    status_signal,
+    selectable: definition.selectable,
+    probed_usable,
+    auto_selectable,
+    readiness_confidence,
+    remediation,
+  };
+};
+
+let status_named = (statuses: list(harness_status), name) =>
+  List.find_opt(status => status.name == name, statuses);
+
+let select_status = (statuses: list(harness_status)) =>
+  selection_priority
+  |> List.filter_map(name =>
+       switch (status_named(statuses, name)) {
+       | Some(status) when status.auto_selectable => Some(status)
+       | _ => None
+       }
+     )
+  |> (
+    fun
+    | [selected, ..._] => Some(selected)
+    | [] => None
+  );
+
+let missing_category = (status: harness_status) =>
+  if (!status.executable_available) {
+    Missing_install;
+  } else {
+    switch (status.auth_signal, status.status_signal) {
+    | (Auth_missing, _)
+    | (Auth_unknown, _) => Missing_auth
+    | (_, Status_failed)
+    | (_, Status_unknown) => Missing_status
+    | _ => No_usable_harness
+    };
+  };
+
+let selected_guidance = (status: harness_status) => {
+  category: Selected_harness,
+  harness_name: Some(status.name),
+  message:
+    "Selected "
+    ++ status.name
+    ++ " from local Bootstrap detection; runtime readiness remains the dispatch authority.",
+};
+
+let missing_guidance = (status: harness_status) => {
+  category: missing_category(status),
+  harness_name: Some(status.name),
+  message: status.remediation,
+};
+
+let no_usable_guidance = {
+  category: No_usable_harness,
+  harness_name: None,
+  message: "No supported usable Agent Harness was found by local Bootstrap detection.",
+};
+
+let nonselectable_guidance = (status: harness_status) => {
+  category: Nonselectable_harness,
+  harness_name: Some(status.name),
+  message: status.remediation,
+};
+
+let guidance = (statuses: list(harness_status), selected, nonselectable) => {
+  let primary =
+    switch (selected) {
+    | Some(status) => [selected_guidance(status)]
+    | None => [
+        no_usable_guidance,
+        ...statuses
+           |> List.filter(status =>
+                status.selectable && !status.probed_usable
+              )
+           |> List.map(missing_guidance),
+      ]
+    };
+  primary @ List.map(nonselectable_guidance, nonselectable);
+};
+
+let detect = (~settings_mode=Generate_missing_runtime_settings, ~probe, ()) => {
+  let supported =
+    List.map(status_of_definition(probe), supported_definitions);
+  let selected = select_status(supported);
+  let nonselectable = List.filter(status => !status.selectable, supported);
+  let guidance = guidance(supported, selected, nonselectable);
+  {
+    supported,
+    selected,
+    nonselectable,
+    guidance,
+    settings_mode,
+  };
+};
+
+let guidance_lines = result =>
+  List.map(item => item.message, result.guidance);

--- a/apps/backend/lib/bootstrap_settings.re
+++ b/apps/backend/lib/bootstrap_settings.re
@@ -140,16 +140,25 @@ let logical_agent =
     | Some(selected) => selected.name
     | None => default.fallback_harness
     };
+  let override_fields =
+    switch (selected_harness) {
+    | Some(_) => []
+    | None => [
+        ("model", str(default.model)),
+        ("reasoningEffort", str(default.reasoning_effort)),
+      ]
+    };
   (
     default.name,
-    obj([
-      ("harness", str(harness)),
-      ("model", str(default.model)),
-      ("reasoningEffort", str(default.reasoning_effort)),
-      ("turnTimeoutMs", int(3600000)),
-      ("readTimeoutMs", int(5000)),
-      ("stallTimeoutMs", int(300000)),
-    ]),
+    obj(
+      [("harness", str(harness))]
+      @ override_fields
+      @ [
+        ("turnTimeoutMs", int(3600000)),
+        ("readTimeoutMs", int(5000)),
+        ("stallTimeoutMs", int(300000)),
+      ],
+    ),
   );
 };
 

--- a/apps/backend/lib/bootstrap_settings.re
+++ b/apps/backend/lib/bootstrap_settings.re
@@ -1,0 +1,350 @@
+type json = Yojson.Safe.t;
+
+type selected_harness = {
+  name: string,
+  kind: string,
+};
+
+type settings_result = {
+  json,
+  selected_harness: option(selected_harness),
+};
+
+type logical_agent_default = {
+  name: string,
+  fallback_harness: string,
+  model: string,
+  reasoning_effort: string,
+};
+
+let obj = fields => `Assoc(fields);
+let str = value => `String(value);
+let int = value => `Int(value);
+let bool = value => `Bool(value);
+let list = values => `List(values);
+let strings = values => list(List.map(value => str(value), values));
+
+let supported_harness_names = [
+  "codex",
+  "claude",
+  "cursor",
+  "cursor-force",
+  "pi",
+];
+
+let routeable_selected_harness = result =>
+  switch (result.Bootstrap_harness_detection.selected) {
+  | Some(status)
+      when
+        status.Bootstrap_harness_detection.auto_selectable
+        && List.mem(
+             status.Bootstrap_harness_detection.name,
+             supported_harness_names,
+           )
+        && status.Bootstrap_harness_detection.name != "cursor-force" =>
+    Some({
+      name: status.Bootstrap_harness_detection.name,
+      kind: status.Bootstrap_harness_detection.kind,
+    })
+  | _ => None
+  };
+
+let loop = (~enabled, ~command) =>
+  obj([("enabled", bool(enabled)), ("command", str(command))]);
+
+let harness = (~kind, ~command, ~loop_enabled, ~loop_command) =>
+  obj([
+    ("kind", str(kind)),
+    ("command", str(command)),
+    ("loop", loop(~enabled=loop_enabled, ~command=loop_command)),
+  ]);
+
+let harnesses =
+  obj([
+    (
+      "codex",
+      harness(
+        ~kind="codex",
+        ~command=Config.default_codex_command,
+        ~loop_enabled=true,
+        ~loop_command=Config.default_codex_loop_command,
+      ),
+    ),
+    (
+      "claude",
+      harness(
+        ~kind="claude",
+        ~command=Config.default_claude_command,
+        ~loop_enabled=false,
+        ~loop_command="",
+      ),
+    ),
+    (
+      "cursor",
+      harness(
+        ~kind="cursor",
+        ~command=Config.default_cursor_command,
+        ~loop_enabled=false,
+        ~loop_command="",
+      ),
+    ),
+    (
+      "cursor-force",
+      harness(
+        ~kind="cursor",
+        ~command=
+          "cursor-agent -p --force --model <model> --output-format stream-json",
+        ~loop_enabled=false,
+        ~loop_command="",
+      ),
+    ),
+    (
+      "pi",
+      harness(
+        ~kind="pi",
+        ~command=Config.default_pi_command,
+        ~loop_enabled=false,
+        ~loop_command="",
+      ),
+    ),
+  ]);
+
+let logical_agent_defaults = [
+  {
+    name: "planner",
+    fallback_harness: "codex",
+    model: Config.default_model,
+    reasoning_effort: "medium",
+  },
+  {
+    name: "engineer",
+    fallback_harness: "claude",
+    model: "opus-4.7",
+    reasoning_effort: "xhigh",
+  },
+  {
+    name: "reviewer",
+    fallback_harness: "pi",
+    model: "openai-codex/gpt-5.5",
+    reasoning_effort: "high",
+  },
+];
+
+let logical_agent =
+    (
+      selected_harness: option(selected_harness),
+      default: logical_agent_default,
+    ) => {
+  let harness =
+    switch (selected_harness) {
+    | Some(selected) => selected.name
+    | None => default.fallback_harness
+    };
+  (
+    default.name,
+    obj([
+      ("harness", str(harness)),
+      ("model", str(default.model)),
+      ("reasoningEffort", str(default.reasoning_effort)),
+      ("turnTimeoutMs", int(3600000)),
+      ("readTimeoutMs", int(5000)),
+      ("stallTimeoutMs", int(300000)),
+    ]),
+  );
+};
+
+let agents = (selected_harness: option(selected_harness)) =>
+  obj(
+    List.map(
+      default => logical_agent(selected_harness, default),
+      logical_agent_defaults,
+    ),
+  );
+
+let commit = (~enabled, ~type_) =>
+  obj([
+    ("enabled", bool(enabled)),
+    ("type", str(type_)),
+    ("message", str(Config.default_commit_message)),
+    ("push", bool(false)),
+  ]);
+
+let stage =
+    (
+      ~states,
+      ~agent,
+      ~start_status,
+      ~success_status,
+      ~retry_status,
+      ~commit_enabled,
+      ~commit_type,
+    ) => {
+  let status_fields =
+    switch (start_status) {
+    | Some(status) => [("startStatus", str(status))]
+    | None => []
+    };
+  obj(
+    [
+      ("states", strings(states)),
+      ("agent", str(agent)),
+      ("skills", list([])),
+    ]
+    @ status_fields
+    @ [
+      ("successStatus", str(success_status)),
+      ("retryStatus", str(retry_status)),
+      ("goal", obj([("enabled", bool(false))])),
+      ("commit", commit(~enabled=commit_enabled, ~type_=commit_type)),
+    ],
+  );
+};
+
+let json = result => {
+  let selected_harness = routeable_selected_harness(result);
+  obj([
+    (
+      "tracker",
+      obj([
+        ("kind", str("github")),
+        ("owner", str("your-org")),
+        ("repo", str("your-repo")),
+        ("projectNumber", int(1)),
+        ("apiKeyEnv", str("GITHUB_TOKEN")),
+      ]),
+    ),
+    (
+      "project",
+      obj([
+        ("statusField", str("Status")),
+        ("readyStatus", str(Config.default_ready_status)),
+        (
+          "activeStates",
+          strings([
+            "Backlog",
+            "Todo",
+            "To-Do",
+            "In progress",
+            "In Progress",
+            "In review",
+          ]),
+        ),
+        ("terminalStates", strings(["Done", "Closed", "Cancelled"])),
+        ("startStatus", str(Config.default_dispatch_status)),
+        ("reviewStatus", str(Config.default_review_status)),
+        ("retryStatus", str(Config.default_retry_status)),
+        ("ensureStatuses", bool(true)),
+      ]),
+    ),
+    ("polling", obj([("intervalMs", int(30000))])),
+    ("workspace", obj([("root", str(".symphony/workspaces"))])),
+    (
+      "sandbox",
+      obj([
+        ("enabled", bool(false)),
+        ("type", str("docker")),
+        ("image", str("ghcr.io/your-org/symphony-agent:latest")),
+        ("bootstrapCommands", list([])),
+        ("persistent", bool(true)),
+        ("networkEnabled", bool(false)),
+        ("cpuLimit", int(2)),
+        ("memoryMb", int(4096)),
+      ]),
+    ),
+    ("harnesses", harnesses),
+    ("agents", agents(selected_harness)),
+    (
+      "git",
+      obj([
+        ("taskBranchPrefix", str("symphony/task-")),
+        ("protectedTrunkBranches", strings(["main", "master"])),
+        ("autoMerge", bool(true)),
+        ("mergeAttentionStatus", str(Config.default_merge_attention_status)),
+        (
+          "cleanup",
+          obj([
+            ("removeWorktreeAfterMerge", bool(true)),
+            ("keepTaskBranch", bool(true)),
+          ]),
+        ),
+      ]),
+    ),
+    (
+      "pullRequest",
+      obj([
+        ("enabled", bool(false)),
+        ("mode", str("batch")),
+        ("baseBranch", str("main")),
+        ("title", str("Symphony batch from <head_branch>")),
+        (
+          "body",
+          str(
+            "Opened automatically by Symphony after orchestration became idle.",
+          ),
+        ),
+      ]),
+    ),
+    (
+      "stageAgents",
+      obj([
+        ("enabled", bool(true)),
+        ("root", str(".symphony/agents")),
+        ("defaultAgent", str("engineer")),
+        (
+          "stages",
+          list([
+            stage(
+              ~states=["Backlog"],
+              ~agent="planner",
+              ~start_status=None,
+              ~success_status="To-Do",
+              ~retry_status="Backlog",
+              ~commit_enabled=false,
+              ~commit_type="feature",
+            ),
+            stage(
+              ~states=["Todo", "To-Do", "In progress", "In Progress"],
+              ~agent="engineer",
+              ~start_status=Some("In progress"),
+              ~success_status="In review",
+              ~retry_status="To-Do",
+              ~commit_enabled=true,
+              ~commit_type="feature",
+            ),
+            stage(
+              ~states=["In review", "In Review"],
+              ~agent="reviewer",
+              ~start_status=None,
+              ~success_status="Done",
+              ~retry_status="In progress",
+              ~commit_enabled=false,
+              ~commit_type="refactor",
+            ),
+          ]),
+        ),
+      ]),
+    ),
+    (
+      "agent",
+      obj([
+        ("maxConcurrentAgents", int(2)),
+        ("maxTurns", int(10)),
+        ("maxRetryBackoffMs", int(300000)),
+      ]),
+    ),
+    ("server", obj([("port", int(8080))])),
+  ]);
+};
+
+let build = result => {
+  let selected_harness = routeable_selected_harness(result);
+  {
+    json: json(result),
+    selected_harness,
+  };
+};
+
+let to_yojson = result => build(result).json;
+
+let to_string = result =>
+  Yojson.Safe.pretty_to_string(to_yojson(result)) ++ "\n";

--- a/apps/backend/lib/runtime_home.ml
+++ b/apps/backend/lib/runtime_home.ml
@@ -2,6 +2,13 @@ type bootstrap_status = Created | Already_present | Skipped_existing
 
 type bootstrap_item = { path : string; status : bootstrap_status }
 
+type bootstrap_selected_harness = { name : string; kind : string }
+
+type bootstrap_guidance =
+  | Bootstrap_selected_harness of bootstrap_selected_harness
+  | Bootstrap_no_usable_harness
+  | Bootstrap_existing_settings_preserved
+
 type t = {
   workspace_root : string;
   runtime_dir : string;
@@ -10,6 +17,8 @@ type t = {
   env_path : string;
   agents_dir : string;
 }
+
+type bootstrap_result = { home : t; report : bootstrap_item list; guidance : bootstrap_guidance }
 
 exception Runtime_home_error of string
 
@@ -309,11 +318,67 @@ let ensure_file report path content =
     Util.write_file path content;
     { path; status = Created } :: report)
 
-let bootstrap workspace_root =
+let bootstrap_probe_harness (definition : Bootstrap_harness_detection.harness_definition) =
+  {
+    Config.name = definition.Bootstrap_harness_detection.name;
+    kind = definition.Bootstrap_harness_detection.kind;
+    command = definition.Bootstrap_harness_detection.executable;
+    model = Config.default_model;
+    reasoning_effort = Config.default_reasoning_effort;
+    turn_timeout_ms = 3600000;
+    read_timeout_ms = 5000;
+    stall_timeout_ms = 300000;
+    loop_enabled = false;
+    loop_command = "";
+  }
+
+let default_bootstrap_probe : Bootstrap_harness_detection.probe =
+  {
+    executable_available = Config.executable_available;
+    auth_signal =
+      (fun (definition : Bootstrap_harness_detection.harness_definition) ->
+        match definition.Bootstrap_harness_detection.name with
+        | "claude" ->
+            if Config.claude_env_auth_configured () || Config.claude_credentials_configured () then
+              Bootstrap_harness_detection.Authenticated
+            else Bootstrap_harness_detection.Auth_missing
+        | "pi" ->
+            if Config.pi_any_auth_configured () || Config.pi_any_env_configured () then
+              Bootstrap_harness_detection.Authenticated
+            else Bootstrap_harness_detection.Auth_missing
+        | _ -> Bootstrap_harness_detection.Auth_not_checked);
+    status_signal =
+      (fun (definition : Bootstrap_harness_detection.harness_definition) ->
+        match definition.Bootstrap_harness_detection.name with
+        | "cursor" | "cursor-force" ->
+            if
+              Config.executable_available definition.Bootstrap_harness_detection.executable
+              && Config.cursor_harness_auth_configured (bootstrap_probe_harness definition)
+            then
+              Bootstrap_harness_detection.Status_succeeded
+            else Bootstrap_harness_detection.Status_failed
+        | _ -> Bootstrap_harness_detection.Status_not_checked);
+  }
+
+let bootstrap_guidance_of_detection (detection : Bootstrap_harness_detection.detection_result) =
+  match detection.Bootstrap_harness_detection.selected with
+  | Some status ->
+      Bootstrap_selected_harness
+        { name = status.Bootstrap_harness_detection.name; kind = status.Bootstrap_harness_detection.kind }
+  | None -> Bootstrap_no_usable_harness
+
+let bootstrap_with_guidance ?(probe = default_bootstrap_probe) workspace_root =
   let home = paths workspace_root in
+  let settings_exists = Sys.file_exists home.settings_path in
+  let settings_content, guidance =
+    if settings_exists then (settings_json, Bootstrap_existing_settings_preserved)
+    else
+      let detection = Bootstrap_harness_detection.detect ~probe () in
+      (Bootstrap_settings.to_string detection, bootstrap_guidance_of_detection detection)
+  in
   let report = [] in
   let report = ensure_dir report home.runtime_dir in
-  let report = ensure_file report home.settings_path settings_json in
+  let report = ensure_file report home.settings_path settings_content in
   let report = ensure_file report home.prompt_path prompt_md in
   let report = ensure_file report (Filename.concat home.runtime_dir ".env.example") env_example in
   let report = ensure_file report (Filename.concat home.runtime_dir ".gitignore") gitignore in
@@ -324,7 +389,11 @@ let bootstrap workspace_root =
   let report = ensure_file report (Filename.concat home.agents_dir "planner.md") planner_agent_md in
   let report = ensure_file report (Filename.concat home.agents_dir "engineer.md") engineer_agent_md in
   let report = ensure_file report (Filename.concat home.agents_dir "reviewer.md") reviewer_agent_md in
-  (home, List.rev report)
+  { home; report = List.rev report; guidance }
+
+let bootstrap workspace_root =
+  let result = bootstrap_with_guidance workspace_root in
+  (result.home, result.report)
 
 let is_env_name name =
   let valid_char = function 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' -> true | _ -> false in

--- a/apps/backend/lib/runtime_startup.re
+++ b/apps/backend/lib/runtime_startup.re
@@ -6,6 +6,7 @@ type loaded_config = {
 type prepared_runtime = {
   home: Runtime_home.t,
   bootstrap_report: list(Runtime_home.bootstrap_item),
+  bootstrap_guidance: Runtime_home.bootstrap_guidance,
   loaded: loaded_config,
 };
 
@@ -37,14 +38,49 @@ let load_runtime_config = (~overrides=empty_runtime_invocation_overrides, home) 
   {config, prompt_template};
 };
 
-let prepare_runtime = (~overrides=empty_runtime_invocation_overrides, ()) =>
+let prepare_runtime =
+    (
+      ~overrides=empty_runtime_invocation_overrides,
+      ~bootstrap_probe=Runtime_home.default_bootstrap_probe,
+      (),
+    ) =>
   switch (Runtime_home.require_workspace_root()) {
   | Error(msg) => Error(msg)
   | Ok(workspace_root) =>
-    let (home, bootstrap_report) = Runtime_home.bootstrap(workspace_root);
+    let bootstrap =
+      Runtime_home.bootstrap_with_guidance(~probe=bootstrap_probe, workspace_root);
+    let home = bootstrap.Runtime_home.home;
+    let bootstrap_report = bootstrap.Runtime_home.report;
+    let bootstrap_guidance = bootstrap.Runtime_home.guidance;
     let loaded = load_runtime_config(~overrides, home);
-    Ok({home, bootstrap_report, loaded});
+    Ok({home, bootstrap_report, bootstrap_guidance, loaded});
   };
+
+let bootstrap_guidance_lines = guidance =>
+  switch (guidance) {
+  | Runtime_home.Bootstrap_selected_harness(selected) => [
+      Printf.sprintf(
+        "bootstrap guidance: selected Agent Harness %s (%s) from local Bootstrap detection; runtime readiness remains the dispatch authority before dispatch.",
+        selected.Runtime_home.name,
+        selected.Runtime_home.kind,
+      ),
+      "bootstrap next: run Symphony normally to let runtime readiness validate the selected Harness.",
+    ]
+  | Runtime_home.Bootstrap_no_usable_harness => [
+      "bootstrap guidance: no supported usable Agent Harness was found by local Bootstrap detection; Bootstrap still created any missing Runtime Contract files.",
+      "bootstrap next: install or authenticate Codex, Claude Code, Cursor CLI, or PI, then rerun Symphony so runtime readiness can validate dispatch.",
+    ]
+  | Runtime_home.Bootstrap_existing_settings_preserved => [
+      "bootstrap guidance: existing Runtime Settings were preserved; Bootstrap did not reinterpret, regenerate, or rewrite Harness settings.",
+      "bootstrap next: edit .symphony/settings.json manually if you want to change Agent Harness routing.",
+    ]
+  };
+
+let terminal_console_initial_log_lines =
+    (~bootstrap_report_lines, ~bootstrap_guidance, ~startup_completed_line) =>
+  bootstrap_report_lines
+  @ bootstrap_guidance_lines(bootstrap_guidance)
+  @ [startup_completed_line];
 
 let startup_completed_event = (~mode, ~config, ~runtime_home) =>
   Printf.sprintf(

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -4651,6 +4651,16 @@ let assert_all_default_logical_agents_route_to expected json =
         (bootstrap_settings_string [ "agents"; name; "harness" ] json))
     [ "planner"; "engineer"; "reviewer" ]
 
+let assert_selected_logical_agents_use_harness_defaults expected json =
+  assert_all_default_logical_agents_route_to expected json;
+  List.iter
+    (fun name ->
+      Alcotest.(check bool) (name ^ " model inherits Harness default") true
+        (bootstrap_settings_member json [ "agents"; name; "model" ] = `Null);
+      Alcotest.(check bool) (name ^ " reasoning inherits Harness default") true
+        (bootstrap_settings_member json [ "agents"; name; "reasoningEffort" ] = `Null))
+    [ "planner"; "engineer"; "reviewer" ]
+
 let test_bootstrap_settings_routes_selected_harnesses_to_logical_agents () =
   let cases =
     [
@@ -4665,7 +4675,7 @@ let test_bootstrap_settings_routes_selected_harnesses_to_logical_agents () =
   in
   List.iter
     (fun (expected, settings) ->
-      assert_all_default_logical_agents_route_to expected settings.Bootstrap_settings.json;
+      assert_selected_logical_agents_use_harness_defaults expected settings.Bootstrap_settings.json;
       Alcotest.(check (option string)) (expected ^ " selected metadata") (Some expected)
         (Option.map
            (fun (selected : Bootstrap_settings.selected_harness) -> selected.Bootstrap_settings.name)
@@ -4701,7 +4711,7 @@ let test_bootstrap_settings_never_assigns_cursor_force_automatically () =
   in
   Alcotest.(check string) "cursor-force remains defined" "cursor"
     (bootstrap_settings_string [ "harnesses"; "cursor-force"; "kind" ] selected_cursor.Bootstrap_settings.json);
-  assert_all_default_logical_agents_route_to "cursor" selected_cursor.Bootstrap_settings.json;
+  assert_selected_logical_agents_use_harness_defaults "cursor" selected_cursor.Bootstrap_settings.json;
   assert_default_logical_agent_routes cursor_force_only.Bootstrap_settings.json;
   List.iter
     (fun json ->
@@ -4778,6 +4788,7 @@ let test_runtime_contract_docs_use_current_harness_examples () =
   let read path = Util.read_file (repository_file path) in
   let readme = read "README.md" in
   let context = read "CONTEXT.md" in
+  let adr = read "docs/adr/0021-agent-harness-runtime-settings.md" in
   List.iter
     (fun text ->
       Alcotest.(check bool) "documents harnesses section" true (contains_substring text "\"harnesses\": {");
@@ -4797,6 +4808,22 @@ let test_runtime_contract_docs_use_current_harness_examples () =
       "\"command\": \"cursor-agent -p --model <model> --output-format stream-json\"";
       "\"command\": \"cursor-agent -p --force --model <model> --output-format stream-json\"";
       "\"command\": \"/goal\"";
+      "adaptive missing-settings Bootstrap";
+      "selected Agent Harness";
+      "existing Runtime Settings are preserved";
+      "default Logical Agents route to the selected Harness";
+      "remains the dispatch authority";
+    ];
+  List.iter
+    (fun expected ->
+      Alcotest.(check bool) ("ADR includes adaptive Bootstrap " ^ expected) true (contains_substring adr expected))
+    [
+      "amended 2026-05-08, 2026-05-17, and 2026-05-23";
+      "Bootstrap may seed missing Runtime Settings";
+      "route default Logical Agents to the selected Harness";
+      "not auto-selected";
+      "Existing `.symphony/settings.json` files are preserved byte-for-byte";
+      "Runtime readiness remains the dispatch authority";
     ];
   List.iter
     (fun obsolete ->
@@ -4860,7 +4887,7 @@ let test_runtime_contract_docs_cover_sandbox_settings () =
   List.iter
     (fun expected -> Alcotest.(check bool) ("ADR includes " ^ expected) true (contains_substring adr expected))
     [
-      "Accepted, amended 2026-05-08 and 2026-05-17";
+      "Accepted, amended 2026-05-08, 2026-05-17, and 2026-05-23";
       "top-level `sandbox` block";
       "`sandbox.enabled` is `true`";
       "`sandbox.type` must be `docker`";
@@ -5126,6 +5153,9 @@ let test_project_adr_documents_migration_and_loop_semantics () =
       "cursor-agent -p --model <model> --output-format stream-json";
       "cursor-agent -p --force --model <model> --output-format stream-json";
       "Cursor Harness readiness validation checks only selected Cursor Harnesses";
+      "Bootstrap may seed missing Runtime Settings";
+      "adaptive missing-settings Bootstrap";
+      "Runtime readiness remains the dispatch authority";
       "Bootstrap defaults enable Codex loop with `/goal` and disable Claude, Cursor, and PI loops";
     ]
 

--- a/apps/backend/test/test_backend.ml
+++ b/apps/backend/test/test_backend.ml
@@ -4144,6 +4144,165 @@ let test_project_status_order_uses_transition_flow () =
   Alcotest.(check (list string)) "kanban status order" [ "To-Do"; "In progress"; "In review"; "Done" ]
     (Config.project_status_order config)
 
+let bootstrap_secret_markers =
+  [ "github_pat_"; "ghp_"; "sk-ant-"; "sk-proj-"; "xoxb-"; "ANTHROPIC_API_KEY="; "CURSOR_API_KEY="; "GITHUB_TOKEN=" ]
+
+let assert_text_contains label text expected =
+  Alcotest.(check bool) label true (contains_substring text expected)
+
+let assert_text_absent label text unexpected =
+  Alcotest.(check bool) label false (contains_substring text unexpected)
+
+let assert_bootstrap_texts_secret_free label texts =
+  List.iter
+    (fun marker ->
+      Alcotest.(check bool) (label ^ " secret marker absent " ^ marker) false
+        (List.exists (fun text -> contains_substring text marker) texts))
+    bootstrap_secret_markers
+
+let bootstrap_harness_probe ?(executables = []) ?(auth = []) ?(status = []) () :
+    Bootstrap_harness_detection.probe =
+  let assoc name values default = match List.assoc_opt name values with Some value -> value | None -> default in
+  {
+    executable_available = (fun executable -> List.exists (( = ) executable) executables);
+    auth_signal =
+      (fun (definition : Bootstrap_harness_detection.harness_definition) ->
+        assoc definition.Bootstrap_harness_detection.name auth Bootstrap_harness_detection.Auth_missing);
+    status_signal =
+      (fun (definition : Bootstrap_harness_detection.harness_definition) ->
+        assoc definition.Bootstrap_harness_detection.name status Bootstrap_harness_detection.Status_failed);
+  }
+
+let bootstrap_guidance_text guidance = Runtime_startup.bootstrap_guidance_lines guidance |> String.concat "\n"
+
+let test_bootstrap_guidance_renderer_selected_harness () =
+  let selected : Runtime_home.bootstrap_selected_harness = { name = "claude"; kind = "claude" } in
+  let lines = Runtime_startup.bootstrap_guidance_lines (Runtime_home.Bootstrap_selected_harness selected) in
+  let text = String.concat "\n" lines in
+  assert_text_contains "names selected Harness" text "selected Agent Harness claude (claude)";
+  assert_text_contains "states local detection provenance" text "local Bootstrap detection";
+  assert_text_contains "states readiness authority" text "runtime readiness remains the dispatch authority";
+  assert_text_contains "states readiness validation next step" text "runtime readiness validate the selected Harness";
+  assert_bootstrap_texts_secret_free "selected guidance" lines
+
+let test_bootstrap_guidance_renderer_no_usable_harness () =
+  let lines = Runtime_startup.bootstrap_guidance_lines Runtime_home.Bootstrap_no_usable_harness in
+  let text = String.concat "\n" lines in
+  assert_text_contains "reports no usable Harness" text "no supported usable Agent Harness";
+  assert_text_contains "reports Runtime Contract creation" text "Runtime Contract files";
+  assert_text_contains "reports install or auth next action" text "install or authenticate";
+  assert_text_contains "keeps runtime readiness authority" text "runtime readiness can validate dispatch";
+  assert_bootstrap_texts_secret_free "no Harness guidance" lines
+
+let test_bootstrap_guidance_renderer_existing_settings () =
+  let lines = Runtime_startup.bootstrap_guidance_lines Runtime_home.Bootstrap_existing_settings_preserved in
+  let text = String.concat "\n" lines in
+  assert_text_contains "reports preserved settings" text "existing Runtime Settings were preserved";
+  assert_text_contains "reports no regeneration" text "did not reinterpret, regenerate, or rewrite Harness settings";
+  assert_text_contains "reports manual settings path" text ".symphony/settings.json";
+  assert_text_absent "does not imply fresh selection" text "selected Agent Harness";
+  assert_bootstrap_texts_secret_free "existing settings guidance" lines
+
+let test_bootstrap_guidance_renderer_omits_raw_probe_output () =
+  let selected : Runtime_home.bootstrap_selected_harness = { name = "cursor"; kind = "cursor" } in
+  let lines =
+    Runtime_startup.bootstrap_guidance_lines (Runtime_home.Bootstrap_selected_harness selected)
+    @ Runtime_startup.bootstrap_guidance_lines Runtime_home.Bootstrap_no_usable_harness
+    @ Runtime_startup.bootstrap_guidance_lines Runtime_home.Bootstrap_existing_settings_preserved
+  in
+  List.iter
+    (fun marker ->
+      Alcotest.(check bool) ("raw probe output absent " ^ marker) false
+        (List.exists (fun text -> contains_substring text marker) lines))
+    [ "stdout"; "stderr"; "exit "; "Usage:"; "command output"; "gh auth"; "cursor-agent status:" ];
+  assert_bootstrap_texts_secret_free "all guidance" lines
+
+let test_bootstrap_with_guidance_reports_selected_harness_for_created_settings () =
+  with_temp_dir "symphony-bootstrap-guidance-selected-" (fun root ->
+      let probe =
+        bootstrap_harness_probe ~executables:[ "claude" ]
+          ~auth:[ ("claude", Bootstrap_harness_detection.Authenticated) ] ()
+      in
+      let bootstrap = Runtime_home.bootstrap_with_guidance ~probe root in
+      (match bootstrap.Runtime_home.guidance with
+      | Runtime_home.Bootstrap_selected_harness selected ->
+          Alcotest.(check string) "selected Harness name" "claude" selected.name;
+          Alcotest.(check string) "selected Harness kind" "claude" selected.kind
+      | _ -> Alcotest.fail "expected selected-Harness Bootstrap guidance");
+      let settings = Yojson.Safe.from_file bootstrap.home.settings_path in
+      Alcotest.(check string) "planner routes to selected Harness" "claude"
+        (Yojson.Safe.Util.(settings |> member "agents" |> member "planner" |> member "harness" |> to_string));
+      let guidance = bootstrap_guidance_text bootstrap.guidance in
+      assert_text_contains "created settings selected guidance" guidance "selected Agent Harness claude (claude)";
+      assert_text_contains "created settings readiness authority" guidance "runtime readiness remains the dispatch authority")
+
+let test_bootstrap_with_guidance_reports_no_usable_harness_for_created_settings () =
+  with_temp_dir "symphony-bootstrap-guidance-none-" (fun root ->
+      let bootstrap = Runtime_home.bootstrap_with_guidance ~probe:(bootstrap_harness_probe ()) root in
+      (match bootstrap.Runtime_home.guidance with
+      | Runtime_home.Bootstrap_no_usable_harness -> ()
+      | _ -> Alcotest.fail "expected no-usable-Harness Bootstrap guidance");
+      Alcotest.(check bool) "settings still created" true (Sys.file_exists bootstrap.home.settings_path);
+      let guidance = bootstrap_guidance_text bootstrap.guidance in
+      assert_text_contains "no Harness Runtime Contract created" guidance "Runtime Contract files";
+      assert_text_contains "no Harness next action" guidance "install or authenticate")
+
+let test_bootstrap_with_guidance_reports_existing_settings_preserved () =
+  with_temp_dir "symphony-bootstrap-guidance-existing-" (fun root ->
+      let selected_probe =
+        bootstrap_harness_probe ~executables:[ "claude" ]
+          ~auth:[ ("claude", Bootstrap_harness_detection.Authenticated) ] ()
+      in
+      let first = Runtime_home.bootstrap_with_guidance ~probe:selected_probe root in
+      let before = Util.read_file first.Runtime_home.home.settings_path in
+      let second = Runtime_home.bootstrap_with_guidance ~probe:(bootstrap_harness_probe ~executables:[ "codex" ] ()) root in
+      Alcotest.(check string) "settings preserved byte-for-byte" before
+        (Util.read_file second.Runtime_home.home.settings_path);
+      (match second.Runtime_home.guidance with
+      | Runtime_home.Bootstrap_existing_settings_preserved -> ()
+      | _ -> Alcotest.fail "expected existing-settings-preserved Bootstrap guidance");
+      let guidance = bootstrap_guidance_text second.Runtime_home.guidance in
+      assert_text_contains "existing settings preserved" guidance "existing Runtime Settings were preserved";
+      assert_text_contains "existing settings not regenerated" guidance
+        "did not reinterpret, regenerate, or rewrite Harness settings")
+
+let test_runtime_startup_prepare_carries_bootstrap_guidance () =
+  with_temp_dir "symphony-runtime-startup-guidance-" (fun root ->
+      init_repo root "main";
+      let probe =
+        bootstrap_harness_probe ~executables:[ "cursor-agent" ]
+          ~status:[ ("cursor", Bootstrap_harness_detection.Status_succeeded) ] ()
+      in
+      let original = Unix.getcwd () in
+      Fun.protect
+        ~finally:(fun () -> Unix.chdir original)
+        (fun () ->
+          Unix.chdir root;
+          match Runtime_startup.prepare_runtime ~bootstrap_probe:probe () with
+          | Error error -> Alcotest.fail ("prepare failed: " ^ error)
+          | Ok prepared -> (
+              match prepared.Runtime_startup.bootstrap_guidance with
+              | Runtime_home.Bootstrap_selected_harness selected ->
+                  Alcotest.(check string) "prepared selected Harness" "cursor" selected.Runtime_home.name;
+                  assert_text_contains "prepared guidance line" (bootstrap_guidance_text prepared.bootstrap_guidance)
+                    "runtime readiness remains the dispatch authority"
+              | _ -> Alcotest.fail "expected prepare_runtime selected-Harness guidance")))
+
+let test_terminal_console_initial_logs_include_guidance_before_startup_completed () =
+  let guidance =
+    Runtime_home.Bootstrap_selected_harness ({ name = "codex"; kind = "codex" } : Runtime_home.bootstrap_selected_harness)
+  in
+  let lines =
+    Runtime_startup.terminal_console_initial_log_lines
+      ~bootstrap_report_lines:[ "bootstrap 12 created 0 already configured" ] ~bootstrap_guidance:guidance
+      ~startup_completed_line:"startup ready terminal_console tracker compozy_tasks /tmp/tasks"
+  in
+  let text = String.concat "\n" lines in
+  match (substring_index text "bootstrap guidance:", substring_index text "startup ready terminal_console") with
+  | Some guidance_index, Some startup_index ->
+      Alcotest.(check bool) "guidance precedes startup completed" true (guidance_index < startup_index)
+  | _ -> Alcotest.fail "expected guidance and startup log lines"
+
 let test_bootstrap_idempotency_preserves_user_files () =
   with_temp_dir "symphony-bootstrap-" (fun root ->
       let home, first = Runtime_home.bootstrap root in
@@ -4181,7 +4340,8 @@ let test_bootstrap_idempotency_preserves_user_files () =
 
 let test_bootstrap_default_runtime_contract_shape () =
   with_temp_dir "symphony-bootstrap-default-contract-" (fun root ->
-      let home, _ = Runtime_home.bootstrap root in
+      let bootstrap = Runtime_home.bootstrap_with_guidance ~probe:(bootstrap_harness_probe ()) root in
+      let home = bootstrap.Runtime_home.home in
       let settings = Util.read_file home.settings_path in
       let json = Yojson.Safe.from_string settings in
       let member path =
@@ -4241,6 +4401,378 @@ let test_bootstrap_default_runtime_contract_shape () =
       Alcotest.(check bool) "bootstrapped sandbox remains disabled" false config.sandbox.enabled;
       Alcotest.(check (list string)) "bootstrapped disabled sandbox has no gaps" []
         (Config.readiness_gaps config |> sandbox_requirements))
+
+let detect_bootstrap_harness ?executables ?auth ?status () =
+  let probe = bootstrap_harness_probe ?executables ?auth ?status () in
+  Bootstrap_harness_detection.detect ~probe ()
+
+let bootstrap_harness_status name (result : Bootstrap_harness_detection.detection_result) =
+  match
+    List.find_opt
+      (fun (status : Bootstrap_harness_detection.harness_status) ->
+        status.Bootstrap_harness_detection.name = name)
+      result.Bootstrap_harness_detection.supported
+  with
+  | Some status -> status
+  | None -> Alcotest.fail ("expected Harness detection status " ^ name)
+
+let selected_bootstrap_harness_name result =
+  match result.Bootstrap_harness_detection.selected with
+  | Some status -> status.Bootstrap_harness_detection.name
+  | None -> Alcotest.fail "expected selected Bootstrap Harness"
+
+let has_bootstrap_guidance_category category result =
+  List.exists
+    (fun (item : Bootstrap_harness_detection.guidance_item) ->
+      item.Bootstrap_harness_detection.category = category)
+    result.Bootstrap_harness_detection.guidance
+
+let test_bootstrap_harness_detection_selects_codex_executable_only () =
+  let result = detect_bootstrap_harness ~executables:[ "codex" ] () in
+  Alcotest.(check string) "selected Harness" "codex" (selected_bootstrap_harness_name result);
+  let codex = bootstrap_harness_status "codex" result in
+  Alcotest.(check bool) "codex executable available" true codex.Bootstrap_harness_detection.executable_available;
+  Alcotest.(check bool) "codex usable" true codex.Bootstrap_harness_detection.probed_usable;
+  Alcotest.(check string) "codex confidence" "executable_only"
+    (Bootstrap_harness_detection.readiness_confidence_to_string
+       codex.Bootstrap_harness_detection.readiness_confidence);
+  Alcotest.(check string) "codex auth not checked" "auth_not_checked"
+    (Bootstrap_harness_detection.auth_signal_to_string codex.Bootstrap_harness_detection.auth_signal);
+  Alcotest.(check string) "codex status not checked" "status_not_checked"
+    (Bootstrap_harness_detection.status_signal_to_string codex.Bootstrap_harness_detection.status_signal);
+  Alcotest.(check bool) "selected guidance" true
+    (has_bootstrap_guidance_category Bootstrap_harness_detection.Selected_harness result)
+
+let test_bootstrap_harness_detection_selects_single_strong_harnesses () =
+  let check_selected label expected result =
+    Alcotest.(check string) label expected (selected_bootstrap_harness_name result)
+  in
+  let claude =
+    detect_bootstrap_harness ~executables:[ "claude" ]
+      ~auth:[ ("claude", Bootstrap_harness_detection.Authenticated) ] ()
+  in
+  check_selected "claude selected" "claude" claude;
+  Alcotest.(check string) "claude confidence" "install_and_auth"
+    (Bootstrap_harness_detection.readiness_confidence_to_string
+       (bootstrap_harness_status "claude" claude).Bootstrap_harness_detection.readiness_confidence);
+  let cursor =
+    detect_bootstrap_harness ~executables:[ "cursor-agent" ]
+      ~status:[ ("cursor", Bootstrap_harness_detection.Status_succeeded) ] ()
+  in
+  check_selected "cursor selected" "cursor" cursor;
+  Alcotest.(check string) "cursor confidence" "install_and_status"
+    (Bootstrap_harness_detection.readiness_confidence_to_string
+       (bootstrap_harness_status "cursor" cursor).Bootstrap_harness_detection.readiness_confidence);
+  let pi =
+    detect_bootstrap_harness ~executables:[ "pi" ]
+      ~auth:[ ("pi", Bootstrap_harness_detection.Authenticated) ] ()
+  in
+  check_selected "pi selected" "pi" pi;
+  Alcotest.(check string) "pi confidence" "install_and_auth"
+    (Bootstrap_harness_detection.readiness_confidence_to_string
+       (bootstrap_harness_status "pi" pi).Bootstrap_harness_detection.readiness_confidence)
+
+let test_bootstrap_harness_detection_uses_deterministic_priority () =
+  let result =
+    detect_bootstrap_harness
+      ~executables:[ "codex"; "claude"; "cursor-agent"; "pi" ]
+      ~auth:
+        [
+          ("claude", Bootstrap_harness_detection.Authenticated);
+          ("pi", Bootstrap_harness_detection.Authenticated);
+        ]
+      ~status:
+        [
+          ("cursor", Bootstrap_harness_detection.Status_succeeded);
+          ("cursor-force", Bootstrap_harness_detection.Status_succeeded);
+        ]
+      ()
+  in
+  Alcotest.(check (list string)) "selection priority" [ "claude"; "cursor"; "pi"; "codex" ]
+    Bootstrap_harness_detection.selection_priority;
+  Alcotest.(check string) "priority winner" "claude" (selected_bootstrap_harness_name result);
+  Alcotest.(check int) "all supported statuses inspectable" 5
+    (List.length result.Bootstrap_harness_detection.supported);
+  List.iter
+    (fun name ->
+      Alcotest.(check string) ("status exists " ^ name) name
+        (bootstrap_harness_status name result).Bootstrap_harness_detection.name)
+    [ "codex"; "claude"; "cursor"; "cursor-force"; "pi" ];
+  Alcotest.(check bool) "codex was usable but lower priority" true
+    (bootstrap_harness_status "codex" result).Bootstrap_harness_detection.auto_selectable
+
+let test_bootstrap_harness_detection_never_selects_cursor_force () =
+  let result =
+    detect_bootstrap_harness ~executables:[ "cursor-agent" ]
+      ~status:
+        [
+          ("cursor", Bootstrap_harness_detection.Status_failed);
+          ("cursor-force", Bootstrap_harness_detection.Status_succeeded);
+        ]
+      ()
+  in
+  Alcotest.(check bool) "no selected Harness" true (Option.is_none result.Bootstrap_harness_detection.selected);
+  let cursor_force = bootstrap_harness_status "cursor-force" result in
+  Alcotest.(check bool) "cursor-force probe looks usable" true
+    cursor_force.Bootstrap_harness_detection.probed_usable;
+  Alcotest.(check bool) "cursor-force is not selectable" false
+    cursor_force.Bootstrap_harness_detection.auto_selectable;
+  Alcotest.(check string) "cursor-force confidence" "nonselectable"
+    (Bootstrap_harness_detection.readiness_confidence_to_string
+       cursor_force.Bootstrap_harness_detection.readiness_confidence);
+  Alcotest.(check bool) "nonselectable guidance" true
+    (has_bootstrap_guidance_category Bootstrap_harness_detection.Nonselectable_harness result)
+
+let test_bootstrap_harness_detection_no_usable_guidance () =
+  let result = detect_bootstrap_harness () in
+  Alcotest.(check bool) "no selected Harness" true (Option.is_none result.Bootstrap_harness_detection.selected);
+  Alcotest.(check bool) "no usable guidance" true
+    (has_bootstrap_guidance_category Bootstrap_harness_detection.No_usable_harness result);
+  Alcotest.(check bool) "install remediation guidance" true
+    (has_bootstrap_guidance_category Bootstrap_harness_detection.Missing_install result);
+  Alcotest.(check bool) "guidance lines available" true
+    (List.length (Bootstrap_harness_detection.guidance_lines result) > 0);
+  List.iter
+    (fun (status : Bootstrap_harness_detection.harness_status) ->
+      if status.Bootstrap_harness_detection.selectable then
+        Alcotest.(check bool) ("not selectable " ^ status.Bootstrap_harness_detection.name) false
+          status.Bootstrap_harness_detection.auto_selectable)
+    result.Bootstrap_harness_detection.supported
+
+let test_bootstrap_harness_detection_result_is_secret_free () =
+  let result =
+    detect_bootstrap_harness
+      ~executables:[ "codex"; "claude"; "cursor-agent"; "pi" ]
+      ~auth:
+        [
+          ("claude", Bootstrap_harness_detection.Authenticated);
+          ("pi", Bootstrap_harness_detection.Authenticated);
+        ]
+      ~status:
+        [
+          ("cursor", Bootstrap_harness_detection.Status_succeeded);
+          ("cursor-force", Bootstrap_harness_detection.Status_succeeded);
+        ]
+      ()
+  in
+  let status_texts (status : Bootstrap_harness_detection.harness_status) =
+    [
+      status.name;
+      status.kind;
+      status.executable;
+      status.display_name;
+      Bootstrap_harness_detection.auth_signal_to_string status.auth_signal;
+      Bootstrap_harness_detection.status_signal_to_string status.status_signal;
+      Bootstrap_harness_detection.readiness_confidence_to_string status.readiness_confidence;
+      status.remediation;
+    ]
+  in
+  let guidance_texts (item : Bootstrap_harness_detection.guidance_item) =
+    [
+      Bootstrap_harness_detection.guidance_category_to_string item.category;
+      item.message;
+      Option.value item.harness_name ~default:"";
+    ]
+  in
+  let texts =
+    [ Bootstrap_harness_detection.settings_mode_to_string result.settings_mode ]
+    @ (result.supported |> List.map status_texts |> List.concat)
+    @ (result.guidance |> List.map guidance_texts |> List.concat)
+  in
+  List.iter
+    (fun marker ->
+      Alcotest.(check bool) ("secret marker absent " ^ marker) false
+        (List.exists (fun text -> contains_substring text marker) texts))
+    [ "github_pat_"; "ghp_"; "sk-ant-"; "sk-proj-"; "xoxb-"; "ANTHROPIC_API_KEY="; "CURSOR_API_KEY="; "GITHUB_TOKEN=" ]
+
+let bootstrap_settings_member json path =
+  List.fold_left (fun node key -> Yojson.Safe.Util.member key node) json path
+
+let bootstrap_settings_string path json =
+  Yojson.Safe.Util.to_string (bootstrap_settings_member json path)
+
+let bootstrap_settings_bool path json =
+  Yojson.Safe.Util.to_bool (bootstrap_settings_member json path)
+
+let bootstrap_settings_list path json =
+  Yojson.Safe.Util.to_list (bootstrap_settings_member json path)
+
+let bootstrap_settings_object_keys path json =
+  match bootstrap_settings_member json path with
+  | `Assoc fields -> List.map fst fields
+  | _ -> Alcotest.fail "expected JSON object"
+
+let build_bootstrap_settings ?executables ?auth ?status () =
+  detect_bootstrap_harness ?executables ?auth ?status () |> Bootstrap_settings.build
+
+let write_bootstrap_settings settings f =
+  with_temp_dir "symphony-bootstrap-settings-" (fun root ->
+      Util.mkdir_p (Filename.concat root ".symphony/workspaces");
+      Util.mkdir_p (Filename.concat root ".symphony/agents");
+      let path = Filename.concat root "settings.json" in
+      Util.write_file path (Yojson.Safe.pretty_to_string settings.Bootstrap_settings.json);
+      f root path)
+
+let test_bootstrap_settings_includes_supported_harness_definitions () =
+  let settings = build_bootstrap_settings () in
+  let json = settings.Bootstrap_settings.json in
+  let harness_names = bootstrap_settings_object_keys [ "harnesses" ] json in
+  Alcotest.(check (list string)) "supported Harness definitions"
+    [ "codex"; "claude"; "cursor"; "cursor-force"; "pi" ]
+    harness_names;
+  Alcotest.(check string) "codex command" Config.default_codex_command
+    (bootstrap_settings_string [ "harnesses"; "codex"; "command" ] json);
+  Alcotest.(check bool) "codex loop enabled" true
+    (bootstrap_settings_bool [ "harnesses"; "codex"; "loop"; "enabled" ] json);
+  Alcotest.(check string) "codex loop command" Config.default_codex_loop_command
+    (bootstrap_settings_string [ "harnesses"; "codex"; "loop"; "command" ] json);
+  Alcotest.(check string) "claude command" Config.default_claude_command
+    (bootstrap_settings_string [ "harnesses"; "claude"; "command" ] json);
+  Alcotest.(check string) "cursor command" Config.default_cursor_command
+    (bootstrap_settings_string [ "harnesses"; "cursor"; "command" ] json);
+  Alcotest.(check string) "cursor-force command"
+    "cursor-agent -p --force --model <model> --output-format stream-json"
+    (bootstrap_settings_string [ "harnesses"; "cursor-force"; "command" ] json);
+  Alcotest.(check string) "pi command" Config.default_pi_command
+    (bootstrap_settings_string [ "harnesses"; "pi"; "command" ] json)
+
+let assert_default_logical_agent_routes json =
+  Alcotest.(check string) "planner Harness" "codex"
+    (bootstrap_settings_string [ "agents"; "planner"; "harness" ] json);
+  Alcotest.(check string) "engineer Harness" "claude"
+    (bootstrap_settings_string [ "agents"; "engineer"; "harness" ] json);
+  Alcotest.(check string) "reviewer Harness" "pi"
+    (bootstrap_settings_string [ "agents"; "reviewer"; "harness" ] json)
+
+let assert_all_default_logical_agents_route_to expected json =
+  List.iter
+    (fun name ->
+      Alcotest.(check string) (name ^ " selected Harness") expected
+        (bootstrap_settings_string [ "agents"; name; "harness" ] json))
+    [ "planner"; "engineer"; "reviewer" ]
+
+let test_bootstrap_settings_routes_selected_harnesses_to_logical_agents () =
+  let cases =
+    [
+      ("claude", build_bootstrap_settings ~executables:[ "claude" ]
+                   ~auth:[ ("claude", Bootstrap_harness_detection.Authenticated) ] ());
+      ("cursor", build_bootstrap_settings ~executables:[ "cursor-agent" ]
+                   ~status:[ ("cursor", Bootstrap_harness_detection.Status_succeeded) ] ());
+      ("pi", build_bootstrap_settings ~executables:[ "pi" ]
+               ~auth:[ ("pi", Bootstrap_harness_detection.Authenticated) ] ());
+      ("codex", build_bootstrap_settings ~executables:[ "codex" ] ());
+    ]
+  in
+  List.iter
+    (fun (expected, settings) ->
+      assert_all_default_logical_agents_route_to expected settings.Bootstrap_settings.json;
+      Alcotest.(check (option string)) (expected ^ " selected metadata") (Some expected)
+        (Option.map
+           (fun (selected : Bootstrap_settings.selected_harness) -> selected.Bootstrap_settings.name)
+           settings.Bootstrap_settings.selected_harness))
+    cases
+
+let test_bootstrap_settings_preserves_no_harness_fallback_routes () =
+  let settings = build_bootstrap_settings () in
+  let json = settings.Bootstrap_settings.json in
+  Alcotest.(check bool) "no selected Harness metadata" true
+    (Option.is_none settings.Bootstrap_settings.selected_harness);
+  assert_default_logical_agent_routes json;
+  Alcotest.(check string) "planner model" Config.default_model
+    (bootstrap_settings_string [ "agents"; "planner"; "model" ] json);
+  Alcotest.(check string) "engineer model" "opus-4.7"
+    (bootstrap_settings_string [ "agents"; "engineer"; "model" ] json);
+  Alcotest.(check string) "reviewer model" "openai-codex/gpt-5.5"
+    (bootstrap_settings_string [ "agents"; "reviewer"; "model" ] json)
+
+let test_bootstrap_settings_never_assigns_cursor_force_automatically () =
+  let selected_cursor =
+    build_bootstrap_settings ~executables:[ "cursor-agent" ]
+      ~status:[ ("cursor", Bootstrap_harness_detection.Status_succeeded) ] ()
+  in
+  let cursor_force_only =
+    build_bootstrap_settings ~executables:[ "cursor-agent" ]
+      ~status:
+        [
+          ("cursor", Bootstrap_harness_detection.Status_failed);
+          ("cursor-force", Bootstrap_harness_detection.Status_succeeded);
+        ]
+      ()
+  in
+  Alcotest.(check string) "cursor-force remains defined" "cursor"
+    (bootstrap_settings_string [ "harnesses"; "cursor-force"; "kind" ] selected_cursor.Bootstrap_settings.json);
+  assert_all_default_logical_agents_route_to "cursor" selected_cursor.Bootstrap_settings.json;
+  assert_default_logical_agent_routes cursor_force_only.Bootstrap_settings.json;
+  List.iter
+    (fun json ->
+      List.iter
+        (fun name ->
+          Alcotest.(check bool) (name ^ " not cursor-force") false
+            (bootstrap_settings_string [ "agents"; name; "harness" ] json = "cursor-force"))
+        [ "planner"; "engineer"; "reviewer" ])
+    [ selected_cursor.Bootstrap_settings.json; cursor_force_only.Bootstrap_settings.json ]
+
+let test_bootstrap_settings_stage_agents_route_by_agent_only () =
+  let settings =
+    build_bootstrap_settings ~executables:[ "claude" ]
+      ~auth:[ ("claude", Bootstrap_harness_detection.Authenticated) ] ()
+  in
+  let json = settings.Bootstrap_settings.json in
+  let stages = bootstrap_settings_list [ "stageAgents"; "stages" ] json in
+  Alcotest.(check int) "stage count" 3 (List.length stages);
+  List.iteri
+    (fun index stage ->
+      Alcotest.(check bool) (Printf.sprintf "stage %d has agent" index) true
+        (Yojson.Safe.Util.member "agent" stage <> `Null);
+      Alcotest.(check bool) (Printf.sprintf "stage %d has no Harness" index) true
+        (Yojson.Safe.Util.member "harness" stage = `Null))
+    stages
+
+let test_bootstrap_settings_text_is_secret_free () =
+  let settings =
+    build_bootstrap_settings ~executables:[ "codex"; "claude"; "cursor-agent"; "pi" ]
+      ~auth:
+        [
+          ("claude", Bootstrap_harness_detection.Authenticated);
+          ("pi", Bootstrap_harness_detection.Authenticated);
+        ]
+      ~status:
+        [
+          ("cursor", Bootstrap_harness_detection.Status_succeeded);
+          ("cursor-force", Bootstrap_harness_detection.Status_succeeded);
+        ]
+      ()
+  in
+  let text = Yojson.Safe.pretty_to_string settings.Bootstrap_settings.json in
+  List.iter
+    (fun marker ->
+      Alcotest.(check bool) ("secret marker absent " ^ marker) false (contains_substring text marker))
+    [ "github_pat_"; "ghp_"; "sk-ant-"; "sk-proj-"; "xoxb-"; "ANTHROPIC_API_KEY="; "CURSOR_API_KEY="; "GITHUB_TOKEN=" ]
+
+let assert_parsed_bootstrap_settings label settings =
+  write_bootstrap_settings settings (fun root path ->
+      let config = Config.from_settings_file ~workspace_root:root path in
+      Alcotest.(check int) (label ^ " Harness definitions parse") 5 (List.length config.Config.agent_harnesses);
+      Alcotest.(check int) (label ^ " Logical Agents parse") 3 (List.length config.Config.logical_agents);
+      Alcotest.(check bool) (label ^ " explicit Harness model") true config.Config.agent_harnesses_explicit;
+      Alcotest.(check bool) (label ^ " sandbox disabled") false config.Config.sandbox.enabled;
+      Alcotest.(check (list string)) (label ^ " disabled sandbox gaps") []
+        (Config.readiness_gaps config |> sandbox_requirements))
+
+let test_bootstrap_settings_parse_through_config () =
+  [
+    ("no Harness", build_bootstrap_settings ());
+    ( "claude",
+      build_bootstrap_settings ~executables:[ "claude" ]
+        ~auth:[ ("claude", Bootstrap_harness_detection.Authenticated) ] () );
+    ( "cursor",
+      build_bootstrap_settings ~executables:[ "cursor-agent" ]
+        ~status:[ ("cursor", Bootstrap_harness_detection.Status_succeeded) ] () );
+    ("pi", build_bootstrap_settings ~executables:[ "pi" ]
+             ~auth:[ ("pi", Bootstrap_harness_detection.Authenticated) ] ());
+    ("codex", build_bootstrap_settings ~executables:[ "codex" ] ());
+  ]
+  |> List.iter (fun (label, settings) -> assert_parsed_bootstrap_settings label settings)
 
 let test_runtime_contract_docs_use_current_harness_examples () =
   let read path = Util.read_file (repository_file path) in
@@ -18919,6 +19451,24 @@ let () =
           Alcotest.test_case "bootstrap is idempotent" `Quick test_bootstrap_idempotency_preserves_user_files;
           Alcotest.test_case "bootstrap writes new Runtime Contract defaults" `Quick
             test_bootstrap_default_runtime_contract_shape;
+          Alcotest.test_case "renders selected-Harness Bootstrap guidance" `Quick
+            test_bootstrap_guidance_renderer_selected_harness;
+          Alcotest.test_case "renders no-usable-Harness Bootstrap guidance" `Quick
+            test_bootstrap_guidance_renderer_no_usable_harness;
+          Alcotest.test_case "renders existing-settings Bootstrap guidance" `Quick
+            test_bootstrap_guidance_renderer_existing_settings;
+          Alcotest.test_case "keeps Bootstrap guidance secret-free" `Quick
+            test_bootstrap_guidance_renderer_omits_raw_probe_output;
+          Alcotest.test_case "reports selected-Harness guidance for created settings" `Quick
+            test_bootstrap_with_guidance_reports_selected_harness_for_created_settings;
+          Alcotest.test_case "reports no-usable-Harness guidance for created settings" `Quick
+            test_bootstrap_with_guidance_reports_no_usable_harness_for_created_settings;
+          Alcotest.test_case "reports existing settings preserved guidance" `Quick
+            test_bootstrap_with_guidance_reports_existing_settings_preserved;
+          Alcotest.test_case "runtime startup carries Bootstrap guidance" `Quick
+            test_runtime_startup_prepare_carries_bootstrap_guidance;
+          Alcotest.test_case "Terminal Console logs include Bootstrap guidance before startup" `Quick
+            test_terminal_console_initial_logs_include_guidance_before_startup_completed;
           Alcotest.test_case "requires git repository root" `Quick test_root_validation;
           Alcotest.test_case "loads settings and prompt" `Quick test_settings_and_prompt_loading;
           Alcotest.test_case "parses server host settings" `Quick test_server_host_settings;
@@ -18953,6 +19503,38 @@ let () =
             test_runtime_startup_prepare_preserves_settings_with_overrides;
           Alcotest.test_case "runtime startup validates root before workspace override" `Quick
             test_runtime_startup_validates_root_before_workspace_override;
+        ] );
+      ( "bootstrap-harness-detection",
+        [
+          Alcotest.test_case "selects Codex with executable-only confidence" `Quick
+            test_bootstrap_harness_detection_selects_codex_executable_only;
+          Alcotest.test_case "selects single strong Harnesses" `Quick
+            test_bootstrap_harness_detection_selects_single_strong_harnesses;
+          Alcotest.test_case "uses deterministic selected-Harness priority" `Quick
+            test_bootstrap_harness_detection_uses_deterministic_priority;
+          Alcotest.test_case "never selects cursor-force automatically" `Quick
+            test_bootstrap_harness_detection_never_selects_cursor_force;
+          Alcotest.test_case "reports no usable Harness guidance" `Quick
+            test_bootstrap_harness_detection_no_usable_guidance;
+          Alcotest.test_case "keeps detection results secret-free" `Quick
+            test_bootstrap_harness_detection_result_is_secret_free;
+        ] );
+      ( "bootstrap-settings",
+        [
+          Alcotest.test_case "includes supported Harness definitions" `Quick
+            test_bootstrap_settings_includes_supported_harness_definitions;
+          Alcotest.test_case "routes selected Harnesses to Logical Agents" `Quick
+            test_bootstrap_settings_routes_selected_harnesses_to_logical_agents;
+          Alcotest.test_case "preserves no-Harness fallback Logical Agent routes" `Quick
+            test_bootstrap_settings_preserves_no_harness_fallback_routes;
+          Alcotest.test_case "never assigns cursor-force automatically" `Quick
+            test_bootstrap_settings_never_assigns_cursor_force_automatically;
+          Alcotest.test_case "keeps Stage Agents routed by agent only" `Quick
+            test_bootstrap_settings_stage_agents_route_by_agent_only;
+          Alcotest.test_case "keeps generated settings secret-free" `Quick
+            test_bootstrap_settings_text_is_secret_free;
+          Alcotest.test_case "parses generated settings through Config" `Quick
+            test_bootstrap_settings_parse_through_config;
         ] );
       ( "docs",
         [

--- a/docs/adr/0021-agent-harness-runtime-settings.md
+++ b/docs/adr/0021-agent-harness-runtime-settings.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted, amended 2026-05-08 and 2026-05-17
+Accepted, amended 2026-05-08, 2026-05-17, and 2026-05-23
 
 ## Context
 
@@ -27,6 +27,10 @@ Legacy harness-shaped `agents.*` entries remain migration input, but they are no
 Stage Agent mappings select logical agents with `stageAgents.stages[].agent`. Stage-level `stageAgents.stages[].harness` is legacy input and is a blocking Readiness Gap. The remediation is to move Harness selection to `agents.<logical-agent>.harness`.
 
 Readiness validation uses enabled Stage Agent mappings resolved through logical agents as the dispatch boundary for Agent Harness launch requirements. Required Agent Harness fields and launch environment checks are validated for selected Agent Harnesses; unused Agent Harness definitions do not block dispatch solely because their launch path is unavailable.
+
+Bootstrap may seed missing Runtime Settings from a local, allowlisted Agent Harness detection pass when `.symphony/settings.json` does not exist. Generated first-run settings keep all supported Harness definitions for editability, route default Logical Agents to the selected Harness when one is detected, and keep `cursor-force` as an explicit editable Harness that is not auto-selected. If no supported usable Harness is detected, Bootstrap still creates the Runtime Contract with the default Logical Agent routes and reports install or authentication guidance.
+
+This adaptive missing-settings Bootstrap is an onboarding signal, not runtime truth. Existing `.symphony/settings.json` files are preserved byte-for-byte and are not reinterpreted, regenerated, or rewritten by repeated Bootstrap. Runtime readiness remains the dispatch authority for validating the selected Agent Harness before any Stage Agent launches.
 
 The Optional Docker Sandbox remains separate from Agent Harness selection. Runtime Settings may define a top-level `sandbox` block that defaults to disabled. When `sandbox.enabled` is `true`, `sandbox.type` must be `docker`, required sandbox fields and live Docker availability become dispatch-blocking readiness inputs, and Symphony launches the selected Agent Harness through an Agent Worktree-scoped Sandbox container instead of redefining the Harness kind.
 
@@ -80,4 +84,4 @@ Runtime Settings parsing, readiness validation, launch command rendering, timeou
 
 Sandbox parsing, readiness validation, and Runtime State metadata are additional Runtime Contract concerns, but Sandbox must not become an Agent Harness kind or a stage-level routing concept.
 
-The Runtime Contract changes, so Bootstrap must preserve existing user-edited Runtime Settings and create new defaults only when files are missing.
+The Runtime Contract changes, so Bootstrap must preserve existing user-edited Runtime Settings and create new defaults only when files are missing. Adaptive first-run defaults reduce onboarding edits on machines with a usable Harness, but they also make the readiness boundary important: selected-Harness guidance must not imply dispatch is ready until Runtime Settings readiness has passed.


### PR DESCRIPTION
## Summary
- Add deterministic Bootstrap Harness detection and structured generated settings guidance.
- Wire adaptive Bootstrap guidance into startup/Terminal Console reporting while preserving existing Runtime Home files.
- Add focused backend coverage and mark the init-harness-detection Compozy task bundle complete.

## Verification
- `rtk compozy tasks validate --name init-harness-detection` -> all tasks valid (6 scanned)
- `rtk git diff --check origin/main...HEAD` -> exit 0
- `rtk env pnpm_config_verify_deps_before_run=false DUNE_ROOT=. DUNE_BUILD_DIR=/private/tmp/compozy_init_harness_detection_verify pnpm with current run backend:build` -> exit 0
- `rtk env pnpm_config_verify_deps_before_run=false DUNE_ROOT=. DUNE_BUILD_DIR=/private/tmp/compozy_init_harness_detection_verify pnpm with current run test` -> TUI 36 tests and backend 507 tests passed
- `rtk env pnpm_config_verify_deps_before_run=false pnpm with current run docs:test` -> 11 JSON examples checked

No generated `apps/frontend/src/*.res.js` files are changed.